### PR TITLE
Nomis: DSOS-1613: ami ansible tweaks

### DIFF
--- a/ansible/group_vars/ami_base_rhel_6_10.yml
+++ b/ansible/group_vars/ami_base_rhel_6_10.yml
@@ -1,0 +1,25 @@
+---
+ansible_python_interpreter: /usr/local/bin/python3.6
+ami_packages:
+  - openssl
+  - wget
+  - curl
+  - ca-certificates
+  - nc
+  - tcpdump
+  - unzip
+  - xz
+  - zlib
+  - bzip2
+  - screen
+ami_roles_list: 
+  - packages
+  - time
+  - message-of-the-day
+  - amazon-ssm-agent
+  - amazon-cloudwatch-agent
+  - amazon-cli
+
+# the below vars are defined in multiple groups.  Keep the values the same to avoid unexpected behaviour
+roles_list: "{{ (ami_roles_list | default([])) + (server_type_roles_list | default([])) }}"
+packages_yum_install: "{{ (ami_packages | default([])) + (server_type_packages | default([])) }}"

--- a/ansible/group_vars/ami_base_rhel_6_10.yml
+++ b/ansible/group_vars/ami_base_rhel_6_10.yml
@@ -12,7 +12,7 @@ ami_packages:
   - zlib
   - bzip2
   - screen
-ami_roles_list: 
+ami_roles_list:
   - packages
   - time
   - message-of-the-day

--- a/ansible/group_vars/ami_base_rhel_7_9.yml
+++ b/ansible/group_vars/ami_base_rhel_7_9.yml
@@ -1,0 +1,25 @@
+---
+ansible_python_interpreter: /usr/local/bin/python3.9
+ami_packages:
+  - openssl
+  - wget
+  - curl
+  - ca-certificates
+  - nc
+  - tcpdump
+  - unzip
+  - xz
+  - zlib
+  - bzip2
+  - screen
+ami_roles_list:
+  - packages
+  - time
+  - message-of-the-day
+  - amazon-ssm-agent
+  - amazon-cloudwatch-agent
+  - amazon-cli
+
+# the below vars are defined in multiple groups.  Keep the values the same to avoid unexpected behaviour
+roles_list: "{{ (ami_roles_list | default([])) + (server_type_roles_list | default([])) }}"
+packages_yum_install: "{{ (ami_packages | default([])) + (server_type_packages | default([])) }}"

--- a/ansible/hosts/autoscaling_group_aws_ec2.yml
+++ b/ansible/hosts/autoscaling_group_aws_ec2.yml
@@ -25,6 +25,8 @@ groups:
 keyed_groups:
   - key: tags['environment-name']
     prefix: environment-name
+  - key: tags['ami']
+    prefix: ami
   - key: tags['server-type']
     prefix: server-type
 

--- a/ansible/hosts/instance_aws_ec2.yml
+++ b/ansible/hosts/instance_aws_ec2.yml
@@ -21,6 +21,8 @@ groups:
 keyed_groups:
   - key: tags['environment-name']
     prefix: environment-name
+  - key: tags['ami']
+    prefix: ami
   - key: tags['server-type']
     prefix: server-type
 

--- a/ansible/roles/ansible-requirements/tasks/main.yml
+++ b/ansible/roles/ansible-requirements/tasks/main.yml
@@ -2,4 +2,5 @@
 - import_tasks: pip.yml
   tags:
     - amibuild
+    - ec2provision
     - ec2patch

--- a/ansible/roles/packages/defaults/main.yml
+++ b/ansible/roles/packages/defaults/main.yml
@@ -2,4 +2,7 @@
 packages_yum_enablerepo: "" 
 packages_yum_install: []
 packages_yum_update_on_build: "*"  # update everything when building an AMI/EC2
-packages_yum_update_on_patch: []   # define what's safe to update when patching in group_vars
+
+# list of packages to update after an EC2 has been provisioned
+# override this in the corresponding group_vars
+packages_yum_update_on_patch: []

--- a/ansible/roles/packages/defaults/main.yml
+++ b/ansible/roles/packages/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+packages_yum_enablerepo: "" 
+packages_yum_install: []
+packages_yum_update_on_build: "*"  # update everything when building an AMI/EC2
+packages_yum_update_on_patch: []   # define what's safe to update when patching in group_vars

--- a/ansible/roles/packages/defaults/main.yml
+++ b/ansible/roles/packages/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
-packages_yum_enablerepo: "" 
+packages_yum_enablerepo: ""
 packages_yum_install: []
-packages_yum_update_on_build: "*"  # update everything when building an AMI/EC2
+packages_yum_update_on_build: "*" # update everything when building an AMI/EC2
 
 # list of packages to update after an EC2 has been provisioned
 # override this in the corresponding group_vars

--- a/ansible/roles/packages/tasks/main.yml
+++ b/ansible/roles/packages/tasks/main.yml
@@ -1,0 +1,23 @@
+---
+- block:
+  - import_tasks: yum-install.yml
+    tags:
+      - amibuild
+      - ec2provision
+      - ec2patch
+
+  - import_tasks: yum-update.yml
+    vars:
+      packages_yum_update: "{{ packages_yum_update_on_build }}"
+    tags:
+      - amibuild
+      - ec2provision
+
+  - import_tasks: yum-update.yml
+    vars:
+      packages_yum_update: "{{ packages_yum_update_on_patch }}"
+    tags:
+      - ec2patch
+  
+  # block
+  when: ansible_distribution == 'RedHat'

--- a/ansible/roles/packages/tasks/main.yml
+++ b/ansible/roles/packages/tasks/main.yml
@@ -1,23 +1,23 @@
 ---
 - block:
-  - import_tasks: yum-install.yml
-    tags:
-      - amibuild
-      - ec2provision
-      - ec2patch
+    - import_tasks: yum-install.yml
+      tags:
+        - amibuild
+        - ec2provision
+        - ec2patch
 
-  - import_tasks: yum-update.yml
-    vars:
-      packages_yum_update: "{{ packages_yum_update_on_build }}"
-    tags:
-      - amibuild
-      - ec2provision
+    - import_tasks: yum-update.yml
+      vars:
+        packages_yum_update: "{{ packages_yum_update_on_build }}"
+      tags:
+        - amibuild
+        - ec2provision
 
-  - import_tasks: yum-update.yml
-    vars:
-      packages_yum_update: "{{ packages_yum_update_on_patch }}"
-    tags:
-      - ec2patch
-  
+    - import_tasks: yum-update.yml
+      vars:
+        packages_yum_update: "{{ packages_yum_update_on_patch }}"
+      tags:
+        - ec2patch
+
   # block
   when: ansible_distribution == 'RedHat'

--- a/ansible/roles/packages/tasks/yum-install.yml
+++ b/ansible/roles/packages/tasks/yum-install.yml
@@ -1,0 +1,7 @@
+---
+- name: Install packages
+  ansible.builtin.yum:
+    name: "{{ packages_yum_install }}"
+    state: present
+    enablerepo: "{{ packages_yum_enablerepo }}"
+  when: packages_yum_install | length > 0

--- a/ansible/roles/packages/tasks/yum-update.yml
+++ b/ansible/roles/packages/tasks/yum-update.yml
@@ -1,0 +1,7 @@
+---
+- name: Update packages
+  ansible.builtin.yum:
+    name: "{{ packages_yum_update }}"
+    state: latest
+    enablerepo: "{{ packages_yum_enablerepo }}"
+  when: packages_yum_update | length > 0


### PR DESCRIPTION
Added more support for AMI images so we can use the one repo for all ansible configuration.

Added packages role so we can fine tune what packages to update when an EC2 is running.  This is intended for instances that can't easily be rebuilt such as oracle databases. 
