### PR TITLE
DSOS-1620: use separate password for tagsarjdbs

### DIFF
--- a/ansible/roles/nomis-weblogic/tasks/get-facts.yml
+++ b/ansible/roles/nomis-weblogic/tasks/get-facts.yml
@@ -10,7 +10,8 @@
     ssm_parameters_path_weblogic_admin_password: "{{ ssm_parameters_path }}/admin_password"
     ssm_parameters_path_weblogic_db_username: "{{ ssm_parameters_path }}/db_username"
     ssm_parameters_path_weblogic_db_password: "{{ ssm_parameters_path }}/db_password"
-  when: ssm_parameters_path_weblogic_admin_username is not defined
+    ssm_parameters_path_weblogic_db_tagsar_username: "{{ ssm_parameters_path }}/db_tagsar_username"
+    ssm_parameters_path_weblogic_db_tagsar_password: "{{ ssm_parameters_path }}/db_tagsar_password"
 
 - name: Get SSM parameters
   set_fact:
@@ -18,6 +19,8 @@
     weblogic_admin_password: "{{ lookup('aws_ssm', ssm_parameters_path_weblogic_admin_password, region=ansible_ec2_placement_region) }}"
     weblogic_db_username: "{{ lookup('aws_ssm', ssm_parameters_path_weblogic_db_username, region=ansible_ec2_placement_region) }}"
     weblogic_db_password: "{{ lookup('aws_ssm', ssm_parameters_path_weblogic_db_password, region=ansible_ec2_placement_region) }}"
+    weblogic_db_tagsar_username: "{{ lookup('aws_ssm', ssm_parameters_path_weblogic_db_tagsar_username, region=ansible_ec2_placement_region) }}"
+    weblogic_db_tagsar_password: "{{ lookup('aws_ssm', ssm_parameters_path_weblogic_db_tagsar_password, region=ansible_ec2_placement_region) }}"
   when: weblogic_admin_username is not defined
 
 - name: Set db hostname from ec2 oracle-db-hostname tag

--- a/ansible/roles/nomis-weblogic/templates/10.3/home/oracle/admin/scripts/create_managed_app.py
+++ b/ansible/roles/nomis-weblogic/templates/10.3/home/oracle/admin/scripts/create_managed_app.py
@@ -143,10 +143,12 @@ if msName:
 # Create Data Source(s)
 if dsName:
     # Create List of Data Source(s)
+    dsUsernames = dsUsername.split(",")
+    dsPasswords = dsPassword.split(",")
     dsName = dsName.split(",")
     dsJNDIName = dsJNDIName.split(",")
-    datasources = zip(dsName, dsJNDIName)
-    for dsName, dsJNDIName in datasources:
+    datasources = zip(dsName, dsJNDIName, dsUsernames, dsPasswords)
+    for dsName, dsJNDIName, dsUsername, dsPassword in datasources:
         edit()
         startEdit()
         cd('/')

--- a/ansible/roles/nomis-weblogic/templates/10.3/u01/software/weblogic/WLS_TAGSAR.properties
+++ b/ansible/roles/nomis-weblogic/templates/10.3/u01/software/weblogic/WLS_TAGSAR.properties
@@ -14,8 +14,8 @@ ms.port=9004
 ms.cluster=cluster_tagsar
 
 # Database Config (Used for Data Sources)
-ds.username={{ weblogic_db_username }}
-ds.password={{ weblogic_db_password }}
+ds.username={{ weblogic_db_username }},{{ weblogic_db_tagsar_username }}
+ds.password={{ weblogic_db_password }},{{ weblogic_db_tagsar_password }}
 ds.url=jdbc:oracle:thin:@{{ weblogic_db_hostname }}:{{ weblogic_db_port }}:{{ weblogic_db_name }}
 ds.driver=oracle.jdbc.xa.client.OracleXADataSource
 


### PR DESCRIPTION
Updated deployment python script to allow separate password for tagsar jdbs datasource (issue identified by Sandhya).  I guess this must have been manually fixed previously.  Tested in nomis-test, seems OK.