### PR TITLE
Nomis/dsos 1646/oracle db status

### DIFF
--- a/ansible/roles/amazon-cloudwatch-agent/README.md
+++ b/ansible/roles/amazon-cloudwatch-agent/README.md
@@ -8,6 +8,7 @@ These connection metrics will then be picked up by Cloudwatch if the `"collectd"
 
 NOTE: At the moment this has NOT been tested on a Windows host. It may need to be tested as part of a deployment to a Windows host due to challenges with the module if run locally at an existing EC2 target. ONLY RUNS ON RedHat INSTANCES CURRENTLY
 
+# Cloudwatch Agent
 ## Debugging on Linux
 
 ssm onto the machine/instance and run the following command to find out the running status of the agent:
@@ -26,12 +27,34 @@ cat /opt/aws/amazon-cloudwatch-agent/logs/configuration-validation.log
 
 https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/troubleshooting-CloudWatch-Agent.html
 
+# Collectd
 ## Debugging Collectd
 
 Probably the easiest thing to do is un-comment the 'logfile' plugin sections in collectd.conf.j2 and reload collectd via `sudo systemctl restart collectd.service`
 
+Then you can `cat /var/log/collectd.log` to see what's going on. Also `sudo cat /var/log/messages | grep collectd` to see if there are any errors. This is especially useful for plugins not loading or configuration issues generally.
+
+You can also install tcpdump on the instance `sudo yum install tcpdump` and run `sudo tcpdump -vv -A -i lo -n udp port 25826 | grep oracle-health` to see the metrics which should be picked up by the Cloudwatch agent locally.
+
+Further collectd Troubleshooting [here](https://collectd.org/wiki/index.php/Troubleshooting)
+
 ## Collectd gotchas and how things work
 
-IMPORTANT: .conf files must have an empty line at the end to load, otherwise collectd won't start...
+IMPORTANT: *.conf files must have an empty line at the end to load, otherwise collectd won't start...
 
-Collectd relies on plugins, the most important one related to Cloudwatch is the 'network' plugin which posts the metrics data to a UDP endpoint. Cloudwatch picks metrics up from there and sends them on to cloudwatch.
+Collectd relies on plugins, the most important one related to Cloudwatch is the 'network' plugin which posts the metrics data to a UDP endpoint. Cloudwatch picks metrics up from there and sends them on to cloudwatch. 
+
+Intro to Collectd networking [here](https://collectd.org/wiki/index.php/Networking_introduction)
+
+## Finding metrics in Cloudwatch
+
+Metrics collected by the Cloudwatch agent will appear in the 'metrics' panel as <cloudwatch_agent_config/metrics/metrics_collected/collectd/name_prefix>_<collectd_plugin_name>_value e.g. collectd_cpu_value, collectd_exec_value.
+
+Cloudwatch metrics are easily filtered by instance_id so you can see all the metrics for a particular instance.
+
+### collectd_exec_value: Oracle_Sids connection check
+
+If this returns a value of 1 then the database is not connected. If it returns a value of 0 then the database is connected.
+
+## Finding Logs in Cloudwatch
+<!-- coming soon!!>

--- a/ansible/roles/amazon-cloudwatch-agent/files/types.db.custom
+++ b/ansible/roles/amazon-cloudwatch-agent/files/types.db.custom
@@ -1,0 +1,1 @@
+bool    value:GAUGE:0:1

--- a/ansible/roles/amazon-cloudwatch-agent/tasks/redhat.yml
+++ b/ansible/roles/amazon-cloudwatch-agent/tasks/redhat.yml
@@ -34,6 +34,13 @@
       set_fact:
         oracle_monitoring_list: '{{ ec2.tags["oracle-sids"].split() | default([]) | join(" ") }}'
 
+    - name: add custom types file for oracle_health.sh
+      ansible.builtin.copy:
+        src: types.db.custom
+        dest: /usr/share/collectd/types.db.custom
+        owner: root
+        mode: 0644
+
     - name: Configure collectd # TODO: make this reload the service if/when it changes
       ansible.builtin.template:
         src: collectd.conf.j2
@@ -60,19 +67,11 @@
       ansible.builtin.shell: |
         chmod +x /opt/collectd/oracle_health.sh
 
-    # - name: run script
-    #   become: true
-    #   become_user: oracle
-    #   ansible.builtin.shell: |
-    #     bash -x ./oracle_health.sh
-    #   args:
-    #     chdir: /opt/collectd
-
-    # - name: Start collectd service
-    #   ansible.builtin.service:
-    #     name: collectd
-    #     state: started
-    #     enabled: yes
+    - name: Start collectd service
+      ansible.builtin.service:
+        name: collectd
+        state: started
+        enabled: yes
 
   when: ec2.tags['oracle-sids'] is defined
 

--- a/ansible/roles/amazon-cloudwatch-agent/templates/agent_config_linux.json.j2
+++ b/ansible/roles/amazon-cloudwatch-agent/templates/agent_config_linux.json.j2
@@ -61,7 +61,7 @@
             	"name_prefix":"collectd_",
             	"metrics_aggregation_interval": 60,
 				"collectd_security_level": "none",
-				"collectd_typesdb": ["/usr/share/collectd/types.db"]
+				"collectd_typesdb": ["/usr/share/collectd/types.db","/usr/share/collectd/types.db.custom"]
          	}
 			{% endif %}
 		}

--- a/ansible/roles/amazon-cloudwatch-agent/templates/collectd.conf.j2
+++ b/ansible/roles/amazon-cloudwatch-agent/templates/collectd.conf.j2
@@ -13,32 +13,27 @@
 Hostname    "localhost"
 FQDNLookup   true
 BaseDir     "/var/lib/collectd"
-# PIDFile     "/var/run/collectd.pid"
 PluginDir   "/usr/lib64/collectd"
-TypesDB     "/usr/share/collectd/types.db"
+TypesDB     "/usr/share/collectd/types.db" "/usr/share/collectd/types.db.custom"
 
 ##############################################################################
 # Plugins                                                                    #
 ##############################################################################
 
-# LoadPlugin logfile 
-LoadPlugin network
-# LoadPlugin exec
+# LoadPlugin logfile
 # LoadPlugin cpu
+LoadPlugin network
+LoadPlugin exec
 
-<Plugin logfile>
-   LogLevel debug
-   File "/var/log/collectd.log"
-   Timestamp true
-   PrintSeverity false
-</Plugin>
-
-#<Plugin exec>
-#   Exec "oracle" "/opt/collectd/oracle_health.sh"
+# Enable this and the LoadPlugin logfile line to get debug output for changes
+#<Plugin logfile>
+#   LogLevel "info"
+#   File "/var/log/collectd.log"
+#   Timestamp true
+#   PrintSeverity false
 #</Plugin>
 
-# Exec "oracle" "/opt/collectd/oracle_health.sh" "{{ oracle_monitoring_list }}" "arg1"
-
+# Enable this to help debugging as this will appear in CloudWatch as collectd_cpu_value
 #<Plugin cpu>
 #  ReportByCpu true
 #  ReportByState true
@@ -52,6 +47,10 @@ LoadPlugin network
     <Server "127.0.0.1" "25826">
         SecurityLevel None
     </Server>
+</Plugin>
+
+<Plugin exec>
+   Exec "oracle" "/opt/collectd/oracle_health.sh"
 </Plugin>
 
 #############################################################################

--- a/ansible/roles/amazon-cloudwatch-agent/templates/collectd_conf_reference.conf
+++ b/ansible/roles/amazon-cloudwatch-agent/templates/collectd_conf_reference.conf
@@ -1,5 +1,5 @@
 #
-# Config file for collectd(1).
+# Config file for collectd(1). This is here for reference only.
 # Please read collectd.conf(5) for a list of options.
 # http://collectd.org/
 #

--- a/ansible/roles/amazon-cloudwatch-agent/templates/oracle_health.sh.j2
+++ b/ansible/roles/amazon-cloudwatch-agent/templates/oracle_health.sh.j2
@@ -14,42 +14,16 @@ HOSTNAME="${HOSTNAME}"
 INTERVAL="{{ collectd_script_interval }}"
 LIST="{{ oracle_monitoring_list }}"
 
-# This is a function to determine if the database is clustered or not
-clustered() {
-    local CRSCTL
-    CRSCTL="$(dbhome +ASM)/bin/crsctl"
-
-    if [[ -x "${CRSCTL}" ]]
-    then
-        return 0
-    else
-        return 1
-    fi
-}
-
-# returns 0 if RAC (clustering) disabled, 1 if enabled
-clustered_v2() {
-    cd "$(dbhome "$SID")rdbms/lib" || { echo "Could not cd to $(dbhome "$SID")rdbms/lib" ; exit 1; }
-    ar -t libknlopt.a | grep -c kcsm.o 
-    returnval=$?
-    echo "clustered y/n return val: $returnval"
-    return $returnval
-}
-
-clustered_v3() {
-    PID="$(pgrep -fal ora_pmon | grep "$SID" | awk '{print$1}')"
-    DIR="$(dirname "$(pwdx "$PID" | awk '{print$2}')")"
-    cd "$DIR/rdbms/lib" || { echo "Could not cd to $DIR/rdbms/lib" ; exit 1; }
-    ar -t libknlopt.a | grep -c kcsm.o 
-    returnval=$?
-    echo "clustered y/n return val: $returnval"
-    return $returnval
-}
-
-# if the database is clustered, is it connected?
-clustered_db_connected() {
+db_connected() {
     # DB resources names are usually 'ora.${DB}.db' but some have a suffix after ${DB}
     DB="$(crsctl status resource | grep -m1 -i ora\.${SID}.*\.db | cut -f2 -d=)"
+
+    # Check added to alert on not having a database resource BEFORE trying to get it's status
+    if [[ -z "$DB" ]]
+    then
+        echo "Failed to find a database resource for ${SID}" 1>&2
+        return 1
+    fi
 
     # Worth noting here that crsctl exits with code 0 even if you try and find details of a database that doesn't exist
     STATUS="$(crsctl status resource ${DB} -v | grep STATE_DETAILS | cut -f2 -d= | cut -f1 -d,)"
@@ -65,102 +39,21 @@ clustered_db_connected() {
             return 0
             ;;
         *)
-            echo "clustered_db_connected: ${STATUS}"
+            echo "Failed to find a valid state for ${DB}" 1>&2
             return 1
             ;;
     esac
 }
 
-for SID in ${LIST}
+while sleep "$INTERVAL"
 do
-    if ! clustered_v3
-        then
-            ORACLE_SID="+ASM"
-            ORAENV_ASK="NO"
-            . oraenv > /dev/null
-            clustered_db_connected
-        else
-            ORACLE_SID="${SID}"
-            ORAENV_ASK="NO"
-            . oraenv > /dev/null
-            "${ORACLE_HOME}"/bin/sqlplus / as sysdba <<-EOF > /dev/null
-            set heading off
-            WHENEVER SQLERROR EXIT SQL.SQLCODE
-            select sysdate from dual;
-EOF
-            val=$?
-            echo "clustered value: $val"
-            return $val
-    fi
+    for SID in ${LIST}
+    do            
+        ORACLE_SID="+ASM"
+        ORAENV_ASK="NO"
+        . oraenv > /dev/null
+        db_connected
+        returnval=$?
+        echo "PUTVAL \"$HOSTNAME-$SID/exec-oracle-health/bool\" interval=$INTERVAL N:$returnval"
+    done
 done
-# if the database is not clustered, is it connected?
-#db_connected() {
-    #             
-
-#             ${ORACLE_HOME}/bin/sqlplus / as sysdba <<-EOF > /dev/null
-#             set heading off
-#             WHENEVER SQLERROR EXIT SQL.SQLCODE
-#             select sysdate from dual;
-# EOF
-
-#             exit "$?"
-#}
-
-
-
-
-# while sleep "$INTERVAL"
-# do
-
-#     CRSCTL="$(dbhome +ASM)/bin/crsctl"
-
-#     for SID in {{ oracle_monitoring_list }}
-#     do
-
-#         if [[ -x "${CRSCTL}" ]]
-#         then
-#             # Clustered Oracle
-#             ORACLE_SID="+ASM"
-#             ORAENV_ASK="NO"
-#             . oraenv > /dev/null
-
-#             # DB resources names are usually 'ora.${DB}.db' but some have a suffix after ${DB}
-#             DB="$(crsctl status resource | grep -m1 -i ora\.${SID}.*\.db | cut -f2 -d=)"
-
-#             # Worth noting here that crsctl exits with code 0 even if you try and find details of a database that doesn't exist
-#             STATUS="$(crsctl status resource ${DB} -v | grep STATE_DETAILS | cut -f2 -d= | cut -f1 -d,)"
-
-#             case ${STATUS} in
-#                 "Open")
-#                     VALUE=0
-#                     ;;
-#                 "Open,Readonly")
-#                     VALUE=0
-#                     ;;
-#                 "Mounted (Closed)")
-#                     VALUE=0
-#                     ;;
-#                 *)
-#                     VALUE=1
-#                     ;;
-#             esac
-#         else
-#             # Not clustered so we use the sysdate query
-#             ORACLE_SID="${SID}"
-#             ORAENV_ASK="NO"
-#             . oraenv > /dev/null
-
-#             ${ORACLE_HOME}/bin/sqlplus / as sysdba <<-EOF > /dev/null
-#             set heading off
-#             WHENEVER SQLERROR EXIT SQL.SQLCODE
-#             select sysdate from dual;
-# EOF
-
-#             exit "$?"
-#         fi
-
-#     echo "PUTVAL \"$HOSTNAME/exec-oracle-health/db-${SID}\" interval=$INTERVAL N:$VALUE"
-#     done
-
-# done
-

--- a/ansible/roles/oracle-db-monitoring/templates/oracle-health.sh.j2
+++ b/ansible/roles/oracle-db-monitoring/templates/oracle-health.sh.j2
@@ -6,24 +6,24 @@ then
 fi
 
 # We need to make sure this is in the path
-export PATH=$${PATH}:/usr/local/bin
+export PATH=${PATH}:/usr/local/bin
 
 CRSCTL="$(dbhome +ASM)/bin/crsctl"
 
-if [[ -x "$${CRSCTL}" ]]
+if [[ -x "${CRSCTL}" ]]
 then
   # Clustered Oracle
   ORACLE_SID="+ASM"
   ORAENV_ASK="NO"
   . oraenv > /dev/null
 
-  # DB resources names are usually 'ora.$${DB}.db' but some have a suffix after $${DB}
+  # DB resources names are usually 'ora.${DB}.db' but some have a suffix after ${DB}
   DB="$(crsctl status resource | grep -m1 -i ora\.${oracle_sid}.*\.db | cut -f2 -d=)"
 
   # Worth noting here that crsctl exits with code 0 even if you try and find details of a database that doesn't exist
-  STATUS="$(crsctl status resource $${DB} -v | grep STATE_DETAILS | cut -f2 -d= | cut -f1 -d,)"
+  STATUS="$(crsctl status resource ${DB} -v | grep STATE_DETAILS | cut -f2 -d= | cut -f1 -d,)"
 
-  case $${STATUS} in
+  case ${STATUS} in
     "Open")
       exit 0
       ;;
@@ -34,7 +34,7 @@ then
       exit 0
       ;;
     *)
-      echo "Failed to find a valid state for $${DB}" 1>&2
+      echo "Failed to find a valid state for ${DB}" 1>&2
       exit 1
       ;;
   esac
@@ -44,11 +44,11 @@ else
   ORAENV_ASK="NO"
   . oraenv > /dev/null
 
-  $${ORACLE_HOME}/bin/sqlplus / as sysdba <<-EOF > /dev/null
+  ${ORACLE_HOME}/bin/sqlplus / as sysdba <<-EOF > /dev/null
   set heading off
   WHENEVER SQLERROR EXIT SQL.SQLCODE
   select sysdate from dual;
 EOF
 
-  exit "$${?}"
+  exit "${?}"
 fi

--- a/ansible/roles/oracle-db-monitoring/templates/oracle-health.sh.j2
+++ b/ansible/roles/oracle-db-monitoring/templates/oracle-health.sh.j2
@@ -6,24 +6,24 @@ then
 fi
 
 # We need to make sure this is in the path
-export PATH=${PATH}:/usr/local/bin
+export PATH=$${PATH}:/usr/local/bin
 
 CRSCTL="$(dbhome +ASM)/bin/crsctl"
 
-if [[ -x "${CRSCTL}" ]]
+if [[ -x "$${CRSCTL}" ]]
 then
   # Clustered Oracle
   ORACLE_SID="+ASM"
   ORAENV_ASK="NO"
   . oraenv > /dev/null
 
-  # DB resources names are usually 'ora.${DB}.db' but some have a suffix after ${DB}
+  # DB resources names are usually 'ora.$${DB}.db' but some have a suffix after $${DB}
   DB="$(crsctl status resource | grep -m1 -i ora\.${oracle_sid}.*\.db | cut -f2 -d=)"
 
   # Worth noting here that crsctl exits with code 0 even if you try and find details of a database that doesn't exist
-  STATUS="$(crsctl status resource ${DB} -v | grep STATE_DETAILS | cut -f2 -d= | cut -f1 -d,)"
+  STATUS="$(crsctl status resource $${DB} -v | grep STATE_DETAILS | cut -f2 -d= | cut -f1 -d,)"
 
-  case ${STATUS} in
+  case $${STATUS} in
     "Open")
       exit 0
       ;;
@@ -34,7 +34,7 @@ then
       exit 0
       ;;
     *)
-      echo "Failed to find a valid state for ${DB}" 1>&2
+      echo "Failed to find a valid state for $${DB}" 1>&2
       exit 1
       ;;
   esac
@@ -44,11 +44,11 @@ else
   ORAENV_ASK="NO"
   . oraenv > /dev/null
 
-  ${ORACLE_HOME}/bin/sqlplus / as sysdba <<-EOF > /dev/null
+  $${ORACLE_HOME}/bin/sqlplus / as sysdba <<-EOF > /dev/null
   set heading off
   WHENEVER SQLERROR EXIT SQL.SQLCODE
   select sysdate from dual;
 EOF
 
-  exit "${?}"
+  exit "$${?}"
 fi


### PR DESCRIPTION
Collectd exec plugin now runs a script to check whether databases related to oracle_sids are in a proper state and then makes these values available to Cloudwatch agent locally to send to Cloudwatch.

Collectd outputs the collectd_exec_value metric as 0 (connected) or 1 (disconnected) on a per-instance_id/per oracle_sid basis. See the README for more in-depth explanation and some guidelines for debugging.