### PR TITLE
Nomis: DSOS-1645: fix monitoring

### DIFF
--- a/ansible/README.md
+++ b/ansible/README.md
@@ -13,6 +13,56 @@ Use `user_data` to provide a cloud init or shell script which runs
 ansible. See nomis ansible template scripts in [modernisation-platform-environments](https://github.com/ministryofjustice/modernisation-platform-environments/tree/main/terraform/environments/nomis/templates/) for an example. This relies on
 tags to identify which roles to run.
 
+## Installing on Mac
+
+Ensure you have python3.6+ installed on your local mac.
+
+Install ansible. Brew or pip, e.g.
+
+```
+brew install ansible@6
+```
+
+or
+
+```
+python -m pip install ansible==6.0.0
+```
+
+From this repo's ansible/ directory, install all requirements:
+
+```
+python -m pip install -r requirements.txt
+ansible-galaxy role install -r requirements.yml
+ansible-galaxy collection install -r requirements.yml
+```
+
+Ensure your ~/.aws/config contains your environment details, example [config] (https://github.com/ministryofjustice/dso-useful-stuff/blob/main/aws-cli/.aws/config)
+
+Sign into [AWS SSO](https://moj.awsapps.com/start/) and select
+"Command line or programmatic access" on the account you want to run ansible
+against.
+Under Option 1: Set AWS environment variables, Click to copy these commands
+and paste into terminal.
+
+Check you can access the dynamic inventory
+
+```
+ansible-inventory  --graph
+```
+
+This should show a list of EC2s in the account grouped by various tags. Run `ansible-playbook` like this:
+
+```
+ansible-playbook site.yml --check
+```
+
+Or try below if you get `ERROR! A worker was found in a dead state`
+
+```
+no_proxy="*" ansible-playbook site.yml --check
+```
+
 ## Running ansible against an EC2 instance post build
 
 A generic [site.yml](/ansible/site.yml) is provided with dynamic inventories

--- a/ansible/group_vars/server_type_base_rhel610.yml
+++ b/ansible/group_vars/server_type_base_rhel610.yml
@@ -5,3 +5,4 @@ roles_list:
   - set-ec2-hostname
   - domain-search
   - amazon-cloudwatch-agent
+  - node-exporter

--- a/ansible/group_vars/server_type_base_rhel79.yml
+++ b/ansible/group_vars/server_type_base_rhel79.yml
@@ -5,3 +5,4 @@ roles_list:
   - set-ec2-hostname
   - domain-search
   - amazon-cloudwatch-agent
+  - node-exporter

--- a/ansible/group_vars/server_type_ndh_app.yml
+++ b/ansible/group_vars/server_type_ndh_app.yml
@@ -4,3 +4,5 @@ roles_list:
   - get-ec2-facts
   - set-ec2-hostname
   - domain-search
+  - amazon-cloudwatch-agent
+  - node-exporter

--- a/ansible/group_vars/server_type_ndh_ems.yml
+++ b/ansible/group_vars/server_type_ndh_ems.yml
@@ -4,3 +4,5 @@ roles_list:
   - get-ec2-facts
   - set-ec2-hostname
   - domain-search
+  - amazon-cloudwatch-agent
+  - node-exporter

--- a/ansible/group_vars/server_type_nomis_db.yml
+++ b/ansible/group_vars/server_type_nomis_db.yml
@@ -9,3 +9,4 @@ roles_list:
   - oracle-secure-web
   - db-restore
   - amazon-cloudwatch-agent
+  - node-exporter

--- a/ansible/group_vars/server_type_nomis_db.yml
+++ b/ansible/group_vars/server_type_nomis_db.yml
@@ -5,8 +5,8 @@ roles_list:
   - get-ec2-facts
   - set-ec2-hostname
   - domain-search
+  - amazon-cloudwatch-agent
+  - node-exporter
   - oracle-db-monitoring
   - oracle-secure-web
   - db-restore
-  - amazon-cloudwatch-agent
-  - node-exporter

--- a/ansible/group_vars/server_type_nomis_web.yml
+++ b/ansible/group_vars/server_type_nomis_web.yml
@@ -6,5 +6,6 @@ roles_list:
   - domain-search
   - disable-ipv6
   - disable-firewall
-  - nomis-weblogic
   - amazon-cloudwatch-agent
+  - node-exporter
+  - nomis-weblogic

--- a/ansible/roles/node-exporter/README.md
+++ b/ansible/roles/node-exporter/README.md
@@ -1,0 +1,5 @@
+This role installs and configures node exporter agent for Prometheus on Red Hat machines.
+
+The intention of this role is to be used during the image building process.
+
+For more information regarding Prometheus node exporter please see: https://github.com/prometheus/node_exporter

--- a/ansible/roles/node-exporter/defaults/main.yml
+++ b/ansible/roles/node-exporter/defaults/main.yml
@@ -1,0 +1,1 @@
+node_exporter_version: 1.3.1

--- a/ansible/roles/node-exporter/files/node_exporter
+++ b/ansible/roles/node-exporter/files/node_exporter
@@ -1,0 +1,91 @@
+#!/bin/sh
+
+# chkconfig: 2345 60 20
+# description: Prometheus Node Exporter
+
+NAME=node_exporter
+SCRIPT="/usr/bin/${NAME}"
+PIDFILE="/var/run/${NAME}.pid"
+LOGFILE="/var/log/${NAME}.log"
+ENVFILE="/etc/default/${NAME}"
+
+
+start() {
+
+  if [ -f "${PIDFILE}" ] && kill -0 $(cat "${PIDFILE}") &> /dev/null; then
+    echo "${NAME} already running with PID $(cat ${PIDFILE})" >&2
+    return 1
+  fi
+  echo "Starting ${NAME}" >&2
+  . "${ENVFILE}"
+  CMD="${SCRIPT} ${EXPORTER_ARGS}"
+  local tmp_pid="/tmp/${NAME}.pid"
+  su - "${USER}" -c "${CMD} &> ${LOGFILE} & echo \$! > ${tmp_pid}"
+  mv "${tmp_pid}" "${PIDFILE}"
+  echo "${NAME} started with PID $(cat ${PIDFILE})" >&2
+  sleep 1
+  if [ -f "${PIDFILE}" ] && kill -0 $(cat "${PIDFILE}") &> /dev/null; then
+    echo "${NAME} started successfully." >&2
+  else
+    echo "${NAME} was not started OK"
+    return 1
+  fi
+
+}
+
+stop() {
+
+  if [ ! -f "$PIDFILE" ] || ! kill -0 $(cat "$PIDFILE") &> /dev/null; then
+    echo "${NAME} not running" >&2
+    return 1
+  fi
+  echo "Stopping ${NAME}..." >&2
+  kill -15 $(cat "$PIDFILE")
+  rm -f "$PIDFILE"
+  echo "${NAME} stopped" >&2
+
+}
+
+status() {
+
+  if [ ! -f "$PIDFILE" ] || ! kill -0 $(cat "$PIDFILE") &> /dev/null; then
+    echo "${NAME} is not running" >&2
+    return 1
+  else
+    echo "${NAME} is running" >&2
+  fi
+
+}
+
+# uninstall() {
+
+#   echo -n "Are you really sure you want to uninstall ${NAME}? That cannot be undone. [y$
+#   local SURE
+#   read SURE
+#   if [ "$SURE" = "yes" ]; then
+#     stop
+#     rm -f "$PIDFILE"
+#     echo "Notice: log file is not be removed: '$LOGFILE'" >&2
+#     update-rc.d -f <NAME> remove
+#     rm -fv "$0"
+#   fi
+
+# }
+
+case "$1" in
+  start)
+    start
+    ;;
+  stop)
+    stop
+    ;;
+  restart)
+    stop
+    start
+    ;;
+  status)
+  status
+  ;;
+  *)
+    echo "Usage: $0 {start|stop|restart|status}"
+esac

--- a/ansible/roles/node-exporter/files/node_exporter.service
+++ b/ansible/roles/node-exporter/files/node_exporter.service
@@ -1,0 +1,18 @@
+[Unit]
+
+Description=Prometheus exporter for machine metrics
+Documentation=https://github.com/prometheus/node_exporter
+After=network.target
+
+
+[Service]
+
+EnvironmentFile=-/etc/default/node_exporter
+User=prometheus
+ExecStart=/usr/bin/node_exporter $NODE_EXPORTER_OPTS
+Restart=on-failure
+
+
+[Install]
+
+WantedBy=multi-user.target

--- a/ansible/roles/node-exporter/handlers/main.yml
+++ b/ansible/roles/node-exporter/handlers/main.yml
@@ -1,0 +1,5 @@
+- name: reload node_exporter
+  ansible.builtin.service:
+    name: node_exporter
+    enabled: yes
+    state: restarted

--- a/ansible/roles/node-exporter/tasks/main.yml
+++ b/ansible/roles/node-exporter/tasks/main.yml
@@ -1,0 +1,5 @@
+- import_tasks: node-exporter.yml
+  tags:
+    - amibuild
+    - ec2provision
+    - ec2patch

--- a/ansible/roles/node-exporter/tasks/node-exporter.yml
+++ b/ansible/roles/node-exporter/tasks/node-exporter.yml
@@ -1,0 +1,121 @@
+- name: create the prometheus group
+  ansible.builtin.group:
+    name: prometheus
+    state: present
+    system: yes
+
+- name: create the prometheus user
+  ansible.builtin.user:
+    name: prometheus
+    groups: prometheus
+    append: yes
+    shell: /usr/sbin/nologin
+    state: present
+    system: yes
+    create_home: no
+
+# force this to run in check_mode otherwise other steps will fail
+# set changed_when to false as this change is not impacting
+- name: get node_exporter archive
+  check_mode: no
+  changed_when: false
+  ansible.builtin.unarchive:
+    src: "https://github.com/prometheus/node_exporter/releases/download/v{{ node_exporter_version }}/node_exporter-{{ node_exporter_version }}.linux-amd64.tar.gz"
+    dest: /tmp/
+    remote_src: yes
+    list_files: yes
+  register: archive_contents
+
+- name: copy the binary into /usr/bin
+  ansible.builtin.copy:
+    src: "/tmp/{{ archive_contents.files[0] }}node_exporter"
+    dest: /usr/bin/
+    owner: root
+    group: root
+    remote_src: yes
+    mode: 0755
+
+# execute in check mode and set to changed_when false as this
+# set changed_when to false as this change is not impacting
+- name: clean up files
+  check_mode: no
+  changed_when: false
+  ansible.builtin.file:
+    path: "/tmp/{{ item }}"
+    state: absent
+  with_items:
+    - "{{ archive_contents.files[0].split('/')[0] }}.tar.gz"
+    - "{{ archive_contents.files[0].split('/')[0] }}"
+
+- name: create textfile_monitoring dir
+  ansible.builtin.file:
+    path: /opt/textfile_monitoring
+    state: directory
+    owner: prometheus
+    group: prometheus
+    mode: 0775
+
+# Configuration steps for RHEL6
+- name: RHEL6
+  block:
+  - name: create file for node_exporter Config
+    ansible.builtin.file:
+      path: /etc/default/node_exporter
+      state: touch
+      owner: root
+      group: root
+      mode: 0644
+
+  - name: user fix rhel6
+    ansible.builtin.lineinfile:
+      path: /etc/default/node_exporter
+      regexp: "^USER=.*$"
+      line: "USER=root"
+      owner: root
+      group: root
+      mode: 0644
+      state: present
+
+  - name: add initd service file
+    ansible.builtin.copy:
+      src: node_exporter
+      dest: /etc/init.d/node_exporter
+      owner: root
+      group: root
+      mode: 0755
+    notify: reload node_exporter
+
+  # block
+  when: ansible_distribution_major_version == '6'
+
+- name: RHEL78
+  block:
+
+  - name: node_exporter systemd metrics enabled rhel7 or rhel8 (misload absent)
+    ansible.builtin.lineinfile:
+      path: /etc/default/node_exporter
+      regexp: "^NODE_EXPORTER_OPTS.*$"
+      line: 'NODE_EXPORTER_OPTS=--collector.systemd --collector.systemd.unit-whitelist ".+\.service" --collector.textfile.directory=/opt/textfile_monitoring'
+      owner: root
+      group: root
+      mode: 0644
+      state: present
+      create: yes
+    notify: reload node_exporter
+
+  - name: add systemd service file
+    ansible.builtin.copy:
+      src: node_exporter.service
+      dest: /etc/systemd/system/node_exporter.service
+      owner: root
+      group: root
+      mode: 0644
+      
+  # block
+  when: ansible_distribution_major_version != '6'
+
+- name: start and enable service
+  ansible.builtin.service:
+    name: node_exporter
+    state: started
+    enabled: yes

--- a/ansible/roles/node-exporter/tasks/node-exporter.yml
+++ b/ansible/roles/node-exporter/tasks/node-exporter.yml
@@ -58,59 +58,58 @@
 # Configuration steps for RHEL6
 - name: RHEL6
   block:
-  - name: create file for node_exporter Config
-    ansible.builtin.file:
-      path: /etc/default/node_exporter
-      state: touch
-      owner: root
-      group: root
-      mode: 0644
+    - name: create file for node_exporter Config
+      ansible.builtin.file:
+        path: /etc/default/node_exporter
+        state: touch
+        owner: root
+        group: root
+        mode: 0644
 
-  - name: user fix rhel6
-    ansible.builtin.lineinfile:
-      path: /etc/default/node_exporter
-      regexp: "^USER=.*$"
-      line: "USER=root"
-      owner: root
-      group: root
-      mode: 0644
-      state: present
+    - name: user fix rhel6
+      ansible.builtin.lineinfile:
+        path: /etc/default/node_exporter
+        regexp: "^USER=.*$"
+        line: "USER=root"
+        owner: root
+        group: root
+        mode: 0644
+        state: present
 
-  - name: add initd service file
-    ansible.builtin.copy:
-      src: node_exporter
-      dest: /etc/init.d/node_exporter
-      owner: root
-      group: root
-      mode: 0755
-    notify: reload node_exporter
+    - name: add initd service file
+      ansible.builtin.copy:
+        src: node_exporter
+        dest: /etc/init.d/node_exporter
+        owner: root
+        group: root
+        mode: 0755
+      notify: reload node_exporter
 
   # block
   when: ansible_distribution_major_version == '6'
 
 - name: RHEL78
   block:
+    - name: node_exporter systemd metrics enabled rhel7 or rhel8 (misload absent)
+      ansible.builtin.lineinfile:
+        path: /etc/default/node_exporter
+        regexp: "^NODE_EXPORTER_OPTS.*$"
+        line: 'NODE_EXPORTER_OPTS=--collector.systemd --collector.systemd.unit-whitelist ".+\.service" --collector.textfile.directory=/opt/textfile_monitoring'
+        owner: root
+        group: root
+        mode: 0644
+        state: present
+        create: yes
+      notify: reload node_exporter
 
-  - name: node_exporter systemd metrics enabled rhel7 or rhel8 (misload absent)
-    ansible.builtin.lineinfile:
-      path: /etc/default/node_exporter
-      regexp: "^NODE_EXPORTER_OPTS.*$"
-      line: 'NODE_EXPORTER_OPTS=--collector.systemd --collector.systemd.unit-whitelist ".+\.service" --collector.textfile.directory=/opt/textfile_monitoring'
-      owner: root
-      group: root
-      mode: 0644
-      state: present
-      create: yes
-    notify: reload node_exporter
+    - name: add systemd service file
+      ansible.builtin.copy:
+        src: node_exporter.service
+        dest: /etc/systemd/system/node_exporter.service
+        owner: root
+        group: root
+        mode: 0644
 
-  - name: add systemd service file
-    ansible.builtin.copy:
-      src: node_exporter.service
-      dest: /etc/systemd/system/node_exporter.service
-      owner: root
-      group: root
-      mode: 0644
-      
   # block
   when: ansible_distribution_major_version != '6'
 

--- a/ansible/roles/oracle-db-monitoring/templates/oracle-health.sh.j2
+++ b/ansible/roles/oracle-db-monitoring/templates/oracle-health.sh.j2
@@ -6,24 +6,24 @@ then
 fi
 
 # We need to make sure this is in the path
-export PATH=$${PATH}:/usr/local/bin
+export PATH=${PATH}:/usr/local/bin
 
 CRSCTL="$(dbhome +ASM)/bin/crsctl"
 
-if [[ -x "$${CRSCTL}" ]]
+if [[ -x "${CRSCTL}" ]]
 then
   # Clustered Oracle
   ORACLE_SID="+ASM"
   ORAENV_ASK="NO"
   . oraenv > /dev/null
 
-  # DB resources names are usually 'ora.$${DB}.db' but some have a suffix after $${DB}
-  DB="$(crsctl status resource | grep -m1 -i ora\.${oracle_sid}.*\.db | cut -f2 -d=)"
+  # DB resources names are usually 'ora.${DB}.db' but some have a suffix after ${DB}
+  DB="$(crsctl status resource | grep -m1 -i ora\.{{ oracle_sid }}.*\.db | cut -f2 -d=)"
 
   # Worth noting here that crsctl exits with code 0 even if you try and find details of a database that doesn't exist
-  STATUS="$(crsctl status resource $${DB} -v | grep STATE_DETAILS | cut -f2 -d= | cut -f1 -d,)"
+  STATUS="$(crsctl status resource ${DB} -v | grep STATE_DETAILS | cut -f2 -d= | cut -f1 -d,)"
 
-  case $${STATUS} in
+  case ${STATUS} in
     "Open")
       exit 0
       ;;
@@ -34,21 +34,11 @@ then
       exit 0
       ;;
     *)
-      echo "Failed to find a valid state for $${DB}" 1>&2
+      echo "Failed to find a valid state for {{ oracle_sid }}" 1>&2
       exit 1
       ;;
   esac
 else
-  # Not clustered so we use the sysdate query
-  ORACLE_SID="${oracle_sid}"
-  ORAENV_ASK="NO"
-  . oraenv > /dev/null
-
-  $${ORACLE_HOME}/bin/sqlplus / as sysdba <<-EOF > /dev/null
-  set heading off
-  WHENEVER SQLERROR EXIT SQL.SQLCODE
-  select sysdate from dual;
-EOF
-
-  exit "$${?}"
+  echo "Clustered oracle not installed"
+  exit 1
 fi


### PR DESCRIPTION
Some changes to fix prometheus monitoring:
- added section to README on how to run on a mac
- added node-exporter role to all the group vars (temporarily while we are still using prometheus)
- added node-exporter role (copied from ami repo but with fix for textfile monitoring)
- fixed the oracle-health script
Deployed across all oracle DBs already.  Seems to be working OK now.