### PR TITLE
Nomis/dsos 1775/fix oracle batch check script

### DIFF
--- a/ansible/roles/amazon-cloudwatch-agent/README.md
+++ b/ansible/roles/amazon-cloudwatch-agent/README.md
@@ -58,13 +58,30 @@ Metrics collected by the Cloudwatch agent will appear in the 'metrics' panel as 
 
 Cloudwatch metrics are easily filtered by instance_id so you can see all the metrics for a particular instance.
 
-### collectd_exec-db_connected: Oracle_Sids connection check
+### collectd_exec_value instance: db_connected
 
-If this returns a value of 1 then the database is not connected. If it returns a value of 0 then the database is connected.
+If this returns a value of 1 then the database is not connected. If it returns a value of 0 then the database is connected. There is an alarm set up for this metrics.
 
-### collectd_exec-batch_error: Oracle Batch Error check
+### collectd_exec_value instance: nomis_long_running_batch
 
-If this returns a value of 1 there there is either a long running batch job or a batch job has failed.
+If this returns a value of 1 there is a long running batch job. There IS an alarm set up for this.
+
+#### collectd_exec_value instance: nomis_long_running_batch_value_missing
+
+If this returns a value of 1 then the value for the long running batch job is missing. There isn't an alarm set up for this metric
+### collectd_exec_value instance: nomis_batch_failure_status
+
+If this returns a value of 1 there is a batch job which has failed. There IS an alarm set up for this metric.
+
+#### collectd_exec_value instance: nomis_batch_failure_status_value_missing
+
+If this returns a value of 1 then the value for the batch job failure status is missing. There isn't an alarm set up for this metric.
+
+### collectd_exec_value instance: oracle_batch_monitoring_file_missing
+
+If this returns a value of 1 then the monitoring file is not there. There isn't an alarm set up for this metric.
+
+
 
 ## Finding Logs in Cloudwatch
 

--- a/ansible/roles/amazon-cloudwatch-agent/templates/oracle_health_metrics.sh.j2
+++ b/ansible/roles/amazon-cloudwatch-agent/templates/oracle_health_metrics.sh.j2
@@ -59,8 +59,7 @@ batch_status() {
         val="$(cat $ORACLE_BATCH_ERROR_FILE | grep "$LINE" | cut -f2 -d' ')"
         return "$val"
     else
-        # if the line is not there then this is still a successful check
-        echo "Batch status: $LINE not found in $ORACLE_BATCH_ERROR_FILE" 1>&2
+        # if the line is not there then return a different value to be posted to a different metric
         return 2
     fi
 }

--- a/ansible/roles/amazon-cloudwatch-agent/templates/oracle_health_metrics.sh.j2
+++ b/ansible/roles/amazon-cloudwatch-agent/templates/oracle_health_metrics.sh.j2
@@ -105,7 +105,7 @@ do
         status=$?
 
         service_name=${service//-/_}
-        echo "PUTVAL $HOSTNAME/exec-${service}_name/bool interval=$INTERVAL N:$status"
+        echo "PUTVAL $HOSTNAME/exec-${service_name}/bool interval=$INTERVAL N:$status"
     done
 
 done

--- a/ansible/roles/amazon-cloudwatch-agent/templates/oracle_health_metrics.sh.j2
+++ b/ansible/roles/amazon-cloudwatch-agent/templates/oracle_health_metrics.sh.j2
@@ -57,15 +57,10 @@ batch_status() {
     if [[ "$(cat $ORACLE_BATCH_ERROR_FILE | grep $LINE)" ]]
     then
         val="$(cat $ORACLE_BATCH_ERROR_FILE | grep "$LINE" | cut -f2 -d' ')"
-        if [[ $val == 0 ]] || [[ $val == 1 ]]
-        then
-            return "$val"
-        else
-            echo "batch error value for $LINE is not a valid number" 1>&2
-            return 2
-        fi
+        return "$val"
     else
-        echo "no batch status entry for $LINE" 1>&2
+        # if the line is not there then this is still a successful check
+        echo "Batch status: $LINE not found in $ORACLE_BATCH_ERROR_FILE" 1>&2
         return 2
     fi
 }
@@ -89,14 +84,20 @@ do
 
     if [[ -s "${ORACLE_BATCH_ERROR_FILE}" ]]
     then
+        echo "PUTVAL $HOSTNAME/exec-oracle_batch_monitoring_file_missing/bool interval=$INTERVAL N:0"
         for text in $ORACLE_BATCH_STATUSES
         do
             batch_status "$text" "$ORACLE_BATCH_ERROR_FILE"
             status=$?
-            echo "PUTVAL $HOSTNAME/exec-batch_error/gauge-$text interval=$INTERVAL N:$status"
+            if [[ $status == 0 ]] || [[ $status == 1 ]]
+            then
+                echo "PUTVAL $HOSTNAME/exec-$text/bool interval=$INTERVAL N:$status"
+            else
+                echo "PUTVAL $HOSTNAME/exec-${text}_value_missing/bool interval=$INTERVAL N:1"
+            fi
         done
     else
-        echo "PUTVAL $HOSTNAME/exec-file_error/gauge interval=$INTERVAL N:2"
+        echo "PUTVAL $HOSTNAME/exec-oracle_batch_monitoring_file_missing/bool interval=$INTERVAL N:1"
     fi
 
     for service in ${ORACLE_SERVICE_LIST}
@@ -105,7 +106,7 @@ do
         status=$?
 
         service_name=${service//-/_}
-        echo "PUTVAL $HOSTNAME/exec-$service_name/bool-$service_name interval=$INTERVAL N:$status"
+        echo "PUTVAL $HOSTNAME/exec-${service}_name/bool interval=$INTERVAL N:$status"
     done
 
 done


### PR DESCRIPTION
splits the various statuses out into their own metrics and fixes a bug where if either of the status check values were missing the result from the connection check would always be 1