### PR TITLE
nomis: DSOS-1652: update get-ec2-facts to get full instance information

### DIFF
--- a/ansible/roles/get-ec2-facts/README.md
+++ b/ansible/roles/get-ec2-facts/README.md
@@ -1,16 +1,30 @@
 Use this module to retrieve information about the EC2 host.
-You can then use the EC2 metadata and tag facts within other
-roles.
 
-See [ec2_metadata_facts_module.html](https://docs.ansible.com/ansible/latest/collections/amazon/aws/ec2_metadata_facts_module.html)
-for available metadata variables.
+The EC2 will require either ec2:DescribeInstances or ec2:DescribeTags
+permissions. If the former, full ec2 instance info is available
+under the ec2 fact. If just the tags, only tag information is
+available under the ec2 fact.
 
-Tags are registered to `ec2` host variable. Example usage
-to debug the "application" tag value.
+For available metadata variables, see:
+
+- [ec2_metadata_facts_module](https://docs.ansible.com/ansible/latest/collections/amazon/aws/ec2_metadata_facts_module.html)
+
+For metadata made available under `ec2` fact, see:
+
+- [ec2_instance_info_module](https://docs.ansible.com/ansible/latest/collections/amazon/aws/ec2_instance_info_module.html)
+- [ec2_tag_info_module](https://docs.ansible.com/ansible/latest/collections/amazon/aws/ec2_tag_info_module.html)
+
+Examples:
 
 ```
+# this works if server has DescribeInstances or just DescribeTags permissions
 - debug:
     var: ec2.tags.application
+
+
+# this only works if server has DescribeInstances permissions
+- debug:
+    var: ec2.block_device_mappings
 ```
 
 Where tags have names that are hyphenated you need to reference them as follows:

--- a/ansible/roles/get-ec2-facts/tasks/get-ec2-facts.yml
+++ b/ansible/roles/get-ec2-facts/tasks/get-ec2-facts.yml
@@ -1,8 +1,32 @@
 - name: Get EC2 Metadata Facts
   amazon.aws.ec2_metadata_facts:
 
+# Requires ec2:DescribeInstances
+- name: Retrieve EC2 Instance Info
+  failed_when: false
+  amazon.aws.ec2_instance_info:
+    region: "{{ ansible_ec2_placement_region }}"
+    instance_ids: "{{ ansible_ec2_instance_id }}"
+  register: ec2_instance_info
+
+- name: Check EC2 Instance Info retrieve OK
+  set_fact:
+    has_ec2_instance_info: "{{ ec2_instance_info['instances'] is defined and ec2_instance_info.instances|length == 1 }}"
+
+# Requires ec2:DescribeTags
 - name: Retrieve EC2 Tags
   amazon.aws.ec2_tag_info:
     region: "{{ ansible_ec2_placement_region }}"
     resource: "{{ ansible_ec2_instance_id }}"
-  register: ec2
+  register: ec2_tag_info
+  when: not has_ec2_instance_info
+
+- name: Setting full ec2 instance info
+  set_fact:
+    ec2: "{{ ec2_instance_info.instances[0] }}"
+  when: has_ec2_instance_info
+
+- name: Setting ec2 tag info only since ec2:DescribeInstances not allowed
+  set_fact:
+    ec2: "{{ ec2_tag_info }}"
+  when: not has_ec2_instance_info


### PR DESCRIPTION
Update role so it will get more instance information if permissions allow.  This is backward compatible with the current solution which just retrieves tags.