### PR TITLE
script to create connection metrics

### DIFF
--- a/ansible/roles/amazon-cloudwatch-agent/files/fixngo.conf
+++ b/ansible/roles/amazon-cloudwatch-agent/files/fixngo.conf
@@ -1,0 +1,4 @@
+LoadPlugin exec
+<Plugin exec>
+   Exec "ec2-user" "/opt/collectd/fixngo_connected_metrics.sh"
+</Plugin>

--- a/ansible/roles/amazon-cloudwatch-agent/tasks/collectd.yml
+++ b/ansible/roles/amazon-cloudwatch-agent/tasks/collectd.yml
@@ -127,6 +127,28 @@
 
   when: ansible_distribution_major_version == '6'
 
+- name: set up collectd config for harvesting metric which indicates connectivity to fixngo/azure
+  block:
+    - name: get fact for fixngo connection target
+      set_fact:
+        fixngo_connection_target: '{{ ec2.tags["fixngo-connection-target"] }}'
+
+    - name: add fixngo conf for collectd to get connection state as a metric
+      ansible.builtin.copy:
+        src: fixngo.conf
+        dest: "/etc/collectd.d/fixngo.conf"
+        owner: root
+        mode: 0755
+
+    - name: Add fixngo connected check script
+      ansible.builtin.template:
+        src: fixngo_connected_metrics.sh.j2
+        dest: /opt/collectd/fixngo_connected_metrics.sh
+        mode: 0755
+      notify: restart collectd
+    
+  when: ec2.tags['fixngo-connection-target'] is defined
+
 - name: Start collectd service
   ansible.builtin.service:
     name: collectd

--- a/ansible/roles/amazon-cloudwatch-agent/tasks/collectd.yml
+++ b/ansible/roles/amazon-cloudwatch-agent/tasks/collectd.yml
@@ -146,7 +146,7 @@
         dest: /opt/collectd/fixngo_connected_metrics.sh
         mode: 0755
       notify: restart collectd
-    
+
   when: ec2.tags['fixngo-connection-target'] is defined
 
 - name: Start collectd service

--- a/ansible/roles/amazon-cloudwatch-agent/templates/fixngo_connected_metrics.sh.j2
+++ b/ansible/roles/amazon-cloudwatch-agent/templates/fixngo_connected_metrics.sh.j2
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+# Templated in from ansible
+HOSTNAME="${HOSTNAME:-localhost}"
+INTERVAL="{{ collectd_script_interval }}"
+timeout=1
+port=4903 
+target="{{ fixngo_connection_target }}"
+
+fixngo_connection_status() {
+    connection=$(ncat -vzw "$timeout" "$target" "$port" 2>&1)
+    if [[ "${connection}" == *"Connected"* ]]
+    then
+        return 0
+    else
+        return 1
+    fi
+}
+
+while sleep "$INTERVAL"
+do
+    fixngo_connection_status
+    connection=$?
+    echo "PUTVAL $HOSTNAME/exec-fixngo_connected/bool-fixngo_connected interval=$INTERVAL N:$connection"
+done


### PR DESCRIPTION
this uses collectd and is basically a carbon copy of the node/script-exported connection check

will be installed on any instance with a ["fixngo-connection-target"] ec2 tag with an ip address (target value) and (ideally) is linked to an alarm running on a distinct instance in (for example) nomis-production

there will be an related PR in mod-plat-environments to allow the alarm for this to metric be created for a single EC2 instance