### PR TITLE
Nomis/fix cloudwatch agent check

### DIFF
--- a/ansible/roles/amazon-cloudwatch-agent/tasks/configure.yml
+++ b/ansible/roles/amazon-cloudwatch-agent/tasks/configure.yml
@@ -69,3 +69,4 @@
   loop: "{{ template_files.results|json_query('[*].item') if template_files.results is defined else [] }}"
   loop_control:
     label: item
+  register: template_config_files

--- a/ansible/roles/amazon-cloudwatch-agent/tasks/create_helper_script.yml
+++ b/ansible/roles/amazon-cloudwatch-agent/tasks/create_helper_script.yml
@@ -1,9 +1,4 @@
 ---
-- name: set fact so jinja templating doesn't fail looping through an empty object
-  ansible.builtin.set_fact:
-    items_to_template: "{{ template_config_files.results }}"
-  when: template_config_files.results|length > 0
-
 # Creates a start_cwagent_helper.sh script to start the cloudwatch agent manually
 - name: Create start_cwagent_helper.sh script
   ansible.builtin.template:

--- a/ansible/roles/amazon-cloudwatch-agent/tasks/create_helper_script.yml
+++ b/ansible/roles/amazon-cloudwatch-agent/tasks/create_helper_script.yml
@@ -1,4 +1,9 @@
 ---
+- name: set fact so jinja templating doesn't fail looping through an empty object
+  ansible.builtin.set_fact:
+    items_to_template: "{{ template_config_files.results }}"
+  when: template_config_files.results|length > 0
+
 # Creates a start_cwagent_helper.sh script to start the cloudwatch agent manually
 - name: Create start_cwagent_helper.sh script
   ansible.builtin.template:

--- a/ansible/roles/amazon-cloudwatch-agent/tasks/install.yml
+++ b/ansible/roles/amazon-cloudwatch-agent/tasks/install.yml
@@ -14,7 +14,8 @@
   ignore_errors: true
   register: agent_installed
 
+# Will still fail on Rhel610 images due to: ansible-core requires a minimum of Python2 version 2.7 or Python3 version 3.5. Current version: 2.6.6
 - name: Install amazon-cloudwatch-agent
   ansible.builtin.yum:
     name: "{{ amazon_cloudwatch_agent_package }}"
-  when: agent_installed == 1
+  when: agent_installed.rc == 1 and ansible_distribution_major_version != "6"

--- a/ansible/roles/amazon-cloudwatch-agent/tasks/install.yml
+++ b/ansible/roles/amazon-cloudwatch-agent/tasks/install.yml
@@ -14,8 +14,8 @@
   ignore_errors: true
   register: agent_installed
 
-# Will still fail on Rhel610 images due to: ansible-core requires a minimum of Python2 version 2.7 or Python3 version 3.5. Current version: 2.6.6
 - name: Install amazon-cloudwatch-agent
   ansible.builtin.yum:
     name: "{{ amazon_cloudwatch_agent_package }}"
-  when: agent_installed.rc == 1 and ansible_distribution_major_version != "6"
+    state: present
+  when: agent_installed.rc == 1

--- a/ansible/roles/amazon-cloudwatch-agent/templates/restart_cwagent_helper.sh.j2
+++ b/ansible/roles/amazon-cloudwatch-agent/templates/restart_cwagent_helper.sh.j2
@@ -14,7 +14,7 @@
 /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a append-config -m ec2 -s -c file:"{{ amazon_cloudwatch_agent_config_path }}/{{ amazon_cloudwatch_agent_collectd_config_file }}"
 {% endif %}
 
-{% for item in template_files.results|json_query('[*].item') if template_files.results is defined %}
+{% for item in template_config_files.results|json_query('[*].item') if template_config_files is defined %}
 /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a append-config -m ec2 -s -c file:"{{ amazon_cloudwatch_agent_config_path }}/{{ item }}.json"
 {% endfor %}    
 


### PR DESCRIPTION
- checks properly whether cloudwatch agent is already installed
- fixes an issue with the helper script if extra cloudwatch configs are not defined (empty list)