### PR TITLE
remove node-exporter from the roles list for deploying new EC2 instances

### DIFF
--- a/ansible/README.md
+++ b/ansible/README.md
@@ -99,7 +99,8 @@ Define the list of roles to run on each type of server under an server-type spec
 ```
 ---
 roles_list:
-  - node-exporter
+  - collectd
+  - amazon-cloudwatch-agent
 ```
 
 Run ansible
@@ -112,7 +113,7 @@ ansible-playbook site.yml --check
 ansible-playbook site.yml --limit bastion
 
 # Limit to a particular role
-ansible-playbook site.yml -e "role=node-exporter"
+ansible-playbook site.yml -e "role=amazon-cloudwatch-agent"
 
 # Run locally (the comma after localhost is important)
 ansible-playbook site.yml --connection=local -i localhost, -e "target=localhost" -e "@group_vars/server_type_nomis_db.yml" --check

--- a/ansible/group_vars/server_type_base_rhel610.yml
+++ b/ansible/group_vars/server_type_base_rhel610.yml
@@ -5,6 +5,5 @@ server_type_roles_list:
   - set-ec2-hostname
   - domain-search
   - amazon-cloudwatch-agent
-  - node-exporter
 
 roles_list: "{{ (ami_roles_list | default([]) | difference(server_type_roles_list | default([]))) + (server_type_roles_list | default([])) }}"

--- a/ansible/group_vars/server_type_base_rhel79.yml
+++ b/ansible/group_vars/server_type_base_rhel79.yml
@@ -5,6 +5,5 @@ server_type_roles_list:
   - set-ec2-hostname
   - domain-search
   - amazon-cloudwatch-agent
-  - node-exporter
 
 roles_list: "{{ (ami_roles_list | default([]) | difference(server_type_roles_list | default([]))) + (server_type_roles_list | default([])) }}"

--- a/ansible/group_vars/server_type_base_rhel85.yml
+++ b/ansible/group_vars/server_type_base_rhel85.yml
@@ -5,6 +5,5 @@ server_type_roles_list:
   - set-ec2-hostname
   - domain-search
   - amazon-cloudwatch-agent
-  - node-exporter
 
 roles_list: "{{ (ami_roles_list | default([]) | difference(server_type_roles_list | default([]))) + (server_type_roles_list | default([])) }}"

--- a/ansible/group_vars/server_type_ndh_app.yml
+++ b/ansible/group_vars/server_type_ndh_app.yml
@@ -5,7 +5,6 @@ server_type_roles_list:
   - set-ec2-hostname
   - domain-search
   - amazon-cloudwatch-agent
-  - node-exporter
   - ndh-app
 
 roles_list: "{{ (ami_roles_list | default([]) | difference(server_type_roles_list | default([]))) + (server_type_roles_list | default([])) }}"

--- a/ansible/group_vars/server_type_ndh_ems.yml
+++ b/ansible/group_vars/server_type_ndh_ems.yml
@@ -5,7 +5,6 @@ server_type_roles_list:
   - set-ec2-hostname
   - domain-search
   - amazon-cloudwatch-agent
-  - node-exporter
   - ndh-ems
 
 roles_list: "{{ (ami_roles_list | default([]) | difference(server_type_roles_list | default([]))) + (server_type_roles_list | default([])) }}"

--- a/ansible/group_vars/server_type_nomis_db.yml
+++ b/ansible/group_vars/server_type_nomis_db.yml
@@ -12,7 +12,6 @@ server_type_roles_list:
   - collectd
   - amazon-cloudwatch-agent
   - oracle-db-restore
-  - node-exporter
   - script-exporter
   - oracle-db-monitoring
 

--- a/ansible/group_vars/server_type_nomis_web.yml
+++ b/ansible/group_vars/server_type_nomis_web.yml
@@ -6,7 +6,6 @@ server_type_roles_list:
   - autoscale-group-hooks
   - set-ec2-hostname
   - domain-search
-  - node-exporter
   - nomis-weblogic
   - collectd
   - amazon-cloudwatch-agent

--- a/ansible/group_vars/server_type_oasys_db.yml
+++ b/ansible/group_vars/server_type_oasys_db.yml
@@ -9,7 +9,6 @@ roles_list:
   - disable-firewall
   - time
   - packages
-  - node-exporter
   - message-of-the-day
   - amazon-ssm-agent
   #- amazon-cloudwatch-agent # currently nomis specific

--- a/ansible/group_vars/server_type_oasys_web.yml
+++ b/ansible/group_vars/server_type_oasys_web.yml
@@ -8,6 +8,5 @@ roles_list:
   - disable-ipv6
   - disable-firewall
   - amazon-cloudwatch-agent
-  - node-exporter
   - oasys-ords
   - autoscale-trigger-hook

--- a/ansible/group_vars/server_type_oasys_web_training.yml
+++ b/ansible/group_vars/server_type_oasys_web_training.yml
@@ -8,6 +8,5 @@ roles_list:
   - disable-ipv6
   - disable-firewall
   # - amazon-cloudwatch-agent
-  - node-exporter
   - oasys-ords
   - autoscale-trigger-hook

--- a/ansible/roles/node-exporter/README.md
+++ b/ansible/roles/node-exporter/README.md
@@ -3,3 +3,5 @@ This role installs and configures node exporter agent for Prometheus on Red Hat 
 The intention of this role is to be used during the image building process.
 
 For more information regarding Prometheus node exporter please see: https://github.com/prometheus/node_exporter
+
+In most (if not all) cases it has been superseded by the amazon-cloudwatch-agent role


### PR DESCRIPTION
removes all instances of deploying node-exporter from group-vars

the role still exists in case someone else insists on using it (e.g. another team) 