### PR TITLE
Nomis: DSOS-1893: re-enable warm pools

### DIFF
--- a/ansible/group_vars/aws_ec2.yml
+++ b/ansible/group_vars/aws_ec2.yml
@@ -1,5 +1,5 @@
 ansible_connection: community.aws.aws_ssm
-ansible_aws_ssm_timeout: 300 # long enough so long operations that don't support async, e.g. unarchive
-ansible_aws_ssm_reconnection_retries: 1 # just retry once
+ansible_aws_ssm_timeout: 300 # long enough for operations that don't support async, e.g. unarchive
+ansible_aws_ssm_reconnection_retries: 0 # Retrying doesn't work well with shell commands that timeout, better to fail immediately.
 ansible_aws_ssm_region: eu-west-2
 instance_id: "{{ hostvars[inventory_hostname].instance_id }}" # for scenarios where {{ ansible_host }} is set to the ip address rather than instance_id

--- a/ansible/group_vars/server_type_base_rhel610.yml
+++ b/ansible/group_vars/server_type_base_rhel610.yml
@@ -2,9 +2,10 @@
 ansible_python_interpreter: /usr/local/bin/python3.6
 
 server_type_roles_list:
-  - get-ec2-facts
+  - autoscale-group-hooks
   - set-ec2-hostname
   - domain-search
   - amazon-cloudwatch-agent
+  - autoscale-group-hooks-state
 
 roles_list: "{{ (ami_roles_list | default([]) | difference(server_type_roles_list | default([]))) + (server_type_roles_list | default([])) }}"

--- a/ansible/group_vars/server_type_base_rhel79.yml
+++ b/ansible/group_vars/server_type_base_rhel79.yml
@@ -2,8 +2,10 @@
 ansible_python_interpreter: /usr/local/bin/python3.9
 
 server_type_roles_list:
+  - autoscale-group-hooks
   - set-ec2-hostname
   - domain-search
   - amazon-cloudwatch-agent
+  - autoscale-group-hooks-state
 
 roles_list: "{{ (ami_roles_list | default([]) | difference(server_type_roles_list | default([]))) + (server_type_roles_list | default([])) }}"

--- a/ansible/group_vars/server_type_base_rhel79.yml
+++ b/ansible/group_vars/server_type_base_rhel79.yml
@@ -2,10 +2,8 @@
 ansible_python_interpreter: /usr/local/bin/python3.9
 
 server_type_roles_list:
-  - autoscale-group-hooks
   - set-ec2-hostname
   - domain-search
   - amazon-cloudwatch-agent
-  - autoscale-group-hooks-state
 
 roles_list: "{{ (ami_roles_list | default([]) | difference(server_type_roles_list | default([]))) + (server_type_roles_list | default([])) }}"

--- a/ansible/group_vars/server_type_base_rhel79.yml
+++ b/ansible/group_vars/server_type_base_rhel79.yml
@@ -1,9 +1,11 @@
 ---
 ansible_python_interpreter: /usr/local/bin/python3.9
+
 server_type_roles_list:
-  - get-ec2-facts
+  - autoscale-group-hooks
   - set-ec2-hostname
   - domain-search
   - amazon-cloudwatch-agent
+  - autoscale-group-hooks-state
 
 roles_list: "{{ (ami_roles_list | default([]) | difference(server_type_roles_list | default([]))) + (server_type_roles_list | default([])) }}"

--- a/ansible/group_vars/server_type_base_rhel85.yml
+++ b/ansible/group_vars/server_type_base_rhel85.yml
@@ -1,9 +1,12 @@
 ---
 ansible_python_interpreter: python3.9
+
 server_type_roles_list:
+  - autoscale-group-hooks
   - get-ec2-facts
   - set-ec2-hostname
   - domain-search
   - amazon-cloudwatch-agent
+  - autoscale-group-hooks-state
 
 roles_list: "{{ (ami_roles_list | default([]) | difference(server_type_roles_list | default([]))) + (server_type_roles_list | default([])) }}"

--- a/ansible/group_vars/server_type_nomis_web.yml
+++ b/ansible/group_vars/server_type_nomis_web.yml
@@ -11,5 +11,6 @@ server_type_roles_list:
   - nomis-weblogic
   - collectd
   - amazon-cloudwatch-agent
+  - autoscale-group-hooks-state
 
 roles_list: "{{ (ami_roles_list | default([]) | difference(server_type_roles_list | default([]))) + (server_type_roles_list | default([])) }}"

--- a/ansible/roles/amazon-cloudwatch-agent/tasks/install.yml
+++ b/ansible/roles/amazon-cloudwatch-agent/tasks/install.yml
@@ -18,4 +18,5 @@
   ansible.builtin.yum:
     name: "{{ amazon_cloudwatch_agent_package }}"
     state: present
+    disable_gpg_check: true
   when: agent_installed.rc == 1

--- a/ansible/roles/autoscale-group-hooks-state/README.md
+++ b/ansible/roles/autoscale-group-hooks-state/README.md
@@ -1,0 +1,20 @@
+Also see autoscale-group-hooks
+
+Use this role to set the state of a hook to READY.  Include this as the final
+role in your ansible role list.  If there is an error somewhere along the
+way, the ansible will fail and the role won't get run.  In your EC2 user data,
+run ansible as a first step, and then include a second step to call the AWS
+hook.
+
+This way, the AWS hook will get called regardless of whether the ansible
+succeeds or not.  And it will only be set to READY if the ansible completes
+successfully.
+
+```
+roles_list:
+ - autoscale-group-hooks
+ - some-role
+ - some-other-role
+ - final-role
+ - autoscale-group-hooks-state
+```

--- a/ansible/roles/autoscale-group-hooks-state/defaults/main.yml
+++ b/ansible/roles/autoscale-group-hooks-state/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
 autoscaling_hooks:
-  - lifecycle_hook_name: ready
+  - lifecycle_hook_name: ready-hook
     state: CONTINUE

--- a/ansible/roles/autoscale-group-hooks-state/defaults/main.yml
+++ b/ansible/roles/autoscale-group-hooks-state/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+autoscaling_hooks:
+  - lifecycle_hook_name: ready
+    state: CONTINUE

--- a/ansible/roles/autoscale-group-hooks-state/meta/main.yml
+++ b/ansible/roles/autoscale-group-hooks-state/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - role: get-ec2-facts

--- a/ansible/roles/autoscale-group-hooks-state/tasks/main.yml
+++ b/ansible/roles/autoscale-group-hooks-state/tasks/main.yml
@@ -1,0 +1,6 @@
+---
+- import_tasks: set-hook-state.yml
+  tags:
+    - ec2provision
+    - ec2patch
+  when: ansible_ec2_autoscaling_target_lifecycle_state is defined

--- a/ansible/roles/autoscale-group-hooks-state/tasks/set-hook-state.yml
+++ b/ansible/roles/autoscale-group-hooks-state/tasks/set-hook-state.yml
@@ -1,0 +1,9 @@
+---
+- name: Set autoscaling hook
+  ansible.builtin.template:
+    src: .autoscaling-lifecycle-hook.j2
+    dest: "/root/.autoscaling-lifecycle-{{ autoscaling_hook.lifecycle_hook_name }}"
+    mode: "0644"
+  loop: "{{ autoscaling_hooks }}"
+  loop_control:
+    loop_var: autoscaling_hook

--- a/ansible/roles/autoscale-group-hooks-state/templates/.autoscaling-lifecycle-hook.j2
+++ b/ansible/roles/autoscale-group-hooks-state/templates/.autoscaling-lifecycle-hook.j2
@@ -1,0 +1,2 @@
+# managed by modernisation-platform-configuration-management/ansible/roles/nomis-weblogic
+{{ autoscaling_hook.state }}

--- a/ansible/roles/autoscale-group-hooks/templates/autoscaling-lifecycle-hook.sh.j2
+++ b/ansible/roles/autoscale-group-hooks/templates/autoscaling-lifecycle-hook.sh.j2
@@ -1,9 +1,12 @@
 #!/bin/bash
 # Managed by modernisation-platform-configuration-management/ansible/roles/autoscale-group-hooks
 PATH=$PATH:/usr/local/bin
-lifecycle_action_result=ABANDON
-if [[ -e "/root/.autoscaling-lifecycle-{{ lifecycle_hook_name }}" ]]; then  
-  lifecycle_action_result=$(grep -v ^# "/root/.autoscaling-lifecycle-{{ lifecycle_hook_name }}" | head -1)
-fi
-echo "running: aws autoscaling complete-lifecycle-action --lifecycle-action-result $lifecycle_action_result ..." | logger -p local3.info -t "autoscaling-lifecycle"
-aws autoscaling complete-lifecycle-action --lifecycle-action-result "$lifecycle_action_result" --instance-id "{{ ansible_ec2_instance_id }}" --lifecycle-hook-name "{{ ec2.tags['Name'] }}-{{ lifecycle_hook_name }}" --auto-scaling-group-name "{{ ec2.tags['Name'] }}" --region "{{ ansible_ec2_placement_region }}"
+main() {
+  lifecycle_action_result=ABANDON
+  if [[ -e "/root/.autoscaling-lifecycle-{{ lifecycle_hook_name }}" ]]; then
+    lifecycle_action_result=$(grep -v ^# "/root/.autoscaling-lifecycle-{{ lifecycle_hook_name }}" | head -1)
+  fi
+  echo "running: aws autoscaling complete-lifecycle-action --lifecycle-action-result $lifecycle_action_result ..."
+  aws autoscaling complete-lifecycle-action --lifecycle-action-result "$lifecycle_action_result" --instance-id "{{ ansible_ec2_instance_id }}" --lifecycle-hook-name "{{ ec2.tags['Name'] }}-{{ lifecycle_hook_name }}" --auto-scaling-group-name "{{ ec2.tags['Name'] }}" --region "{{ ansible_ec2_placement_region }}"
+}
+main 2>&1 | logger -p local3.info -t "autoscaling-lifecycle"

--- a/ansible/roles/nomis-weblogic/tasks/complete-autoscaling-hook.yml
+++ b/ansible/roles/nomis-weblogic/tasks/complete-autoscaling-hook.yml
@@ -1,8 +1,0 @@
----
-- name: Set autoscaling hook
-  ansible.builtin.template:
-    src: "10.3{{ item }}"
-    dest: "{{ item }}"
-    mode: "0644"
-  loop:
-    - /root/.autoscaling-lifecycle-ready-hook

--- a/ansible/roles/nomis-weblogic/tasks/main.yml
+++ b/ansible/roles/nomis-weblogic/tasks/main.yml
@@ -1,12 +1,6 @@
 ---
 - name: Rhel6
   block:
-    # temporarily putting this at the start so we can more easily diagnose failures
-    - import_tasks: complete-autoscaling-hook.yml
-      tags:
-        - ec2provision
-        - weblogic_complete_autoscaling_hook
-
     - import_tasks: get-facts.yml
       tags:
         - ec2provision

--- a/ansible/roles/nomis-weblogic/templates/10.3/root/.autoscaling-lifecycle-ready-hook
+++ b/ansible/roles/nomis-weblogic/templates/10.3/root/.autoscaling-lifecycle-ready-hook
@@ -1,2 +1,0 @@
-# managed by modernisation-platform-configuration-management/ansible/roles/nomis-weblogic
-CONTINUE


### PR DESCRIPTION
Primarily tweaking the autoscale lifecycle hook logic.  Added a new autoscale-group-hooks-state role to set the server state lifecycle state to CONTINUE.  The idea being it will only run if all previous roles are successful.  Removed corresponding code from weblogic.

Also fixed error with cloudwatch agent install and added the autoscale roles to base images so it can be tested there.