### PR TITLE
Nomis: DSOS-1820: weblogic init script improvements

### DIFF
--- a/ansible/roles/nomis-weblogic/tasks/configure-forms.yml
+++ b/ansible/roles/nomis-weblogic/tasks/configure-forms.yml
@@ -109,10 +109,11 @@
     - WLS_FORMS
     - WLS_REPORTS
 
+# don't enable, let weblogic-all start these in parallel
 - name: Enable weblogic-server and opmn services
   ansible.builtin.service:
     name: "{{ item }}"
-    enabled: yes
+    enabled: no
   loop:
     - WLS_FORMS
     - WLS_REPORTS

--- a/ansible/roles/nomis-weblogic/tasks/create-additional-form-servers.yml
+++ b/ansible/roles/nomis-weblogic/tasks/create-additional-form-servers.yml
@@ -100,7 +100,6 @@
       ansible.builtin.service:
         name: "{{ weblogic_managed_app }}"
         state: restarted
-        enabled: yes
       async: 600
       poll: 20
 

--- a/ansible/roles/nomis-weblogic/tasks/create-managed-app.yml
+++ b/ansible/roles/nomis-weblogic/tasks/create-managed-app.yml
@@ -77,7 +77,6 @@
       ansible.builtin.service:
         name: "{{ weblogic_managed_app }}"
         state: restarted
-        enabled: yes
       async: 600
       poll: 20
 

--- a/ansible/roles/nomis-weblogic/tasks/install-healthcheck.yml
+++ b/ansible/roles/nomis-weblogic/tasks/install-healthcheck.yml
@@ -15,6 +15,11 @@
 - name: Configure forms
   block:
     - name: Check weblogic status
+      ansible.builtin.shell: service weblogic-all repair
+      changed_when: false
+      check_mode: false
+
+    - name: Check weblogic status
       ansible.builtin.shell: service weblogic-all status
       changed_when: false
       check_mode: false

--- a/ansible/roles/nomis-weblogic/tasks/install-healthcheck.yml
+++ b/ansible/roles/nomis-weblogic/tasks/install-healthcheck.yml
@@ -12,15 +12,13 @@
   loop:
     - /etc/init.d/weblogic-healthcheck
 
-- name: Configure forms
+- name: Configure healthcheck
   block:
-    - name: Check weblogic status
+    - name: Repair unhealthy weblogic services
       ansible.builtin.shell: service weblogic-all repair
-      changed_when: false
-      check_mode: false
 
-    - name: Check weblogic status
-      ansible.builtin.shell: service weblogic-all status
+    - name: Check weblogic services are healthy
+      ansible.builtin.shell: service weblogic-all healthcheck
       changed_when: false
       check_mode: false
 

--- a/ansible/roles/nomis-weblogic/templates/10.3/etc/init.d/opmn
+++ b/ansible/roles/nomis-weblogic/templates/10.3/etc/init.d/opmn
@@ -21,7 +21,7 @@ start_process() {
 
 stop_process() {
   if [[ $(whoami) == "root" ]]; then
-    su - oracle -c "opmnctl stopall" | logger -p local3.info -t $prog
+    su - oracle -c "opmnctl shutdown" | logger -p local3.info -t $prog
   else
     echo -n "must be run as root"
     return 1

--- a/ansible/roles/nomis-weblogic/templates/10.3/etc/init.d/weblogic-all
+++ b/ansible/roles/nomis-weblogic/templates/10.3/etc/init.d/weblogic-all
@@ -27,7 +27,7 @@ start() {
   set +e
   i=0
   for managed_service in $managed_services; do
-    key=$(echo $managed_service | cut -d/ -f4)
+    key=$(echo "$managed_service" | cut -d/ -f4)
     echo -n $"Waiting for $key: PID=${pids[i]}"
     if ! wait ${pids[i]}; then
       echo_failure
@@ -86,6 +86,83 @@ restart() {
   start
 }
 
+
+get_unhealthy_services() {
+  unhealthy=()
+  if [[ -x /etc/init.d/weblogic-node-manager ]]; then
+    if ! /etc/init.d/weblogic-node-manager status | head -1 | grep OK > /dev/null; then
+      unhealthy+=(weblogic-node-manager)
+    fi
+  fi
+  if [[ -x /etc/init.d/opmn ]]; then
+    if [[ $(/etc/init.d/opmn status | grep -c Alive) != 3 ]]; then
+      unhealthy+=(opmn)
+    fi
+  fi
+  if [[ -x /etc/init.d/weblogic-server ]]; then
+    ok=1
+    weblogic_server_status=$(/etc/init.d/weblogic-server status)
+    if ! echo "$weblogic_server_status" | head -1 | grep OK > /dev/null; then
+      ok=0
+    fi
+    if ! echo "$weblogic_server_status" | grep -w AdminServer | grep RUNNING > /dev/null; then
+      ok=0
+    fi
+    if (( ! ok )); then
+      unhealthy+=(weblogic-server)
+    fi
+  fi
+  managed_services=$(find /etc/init.d/ -name 'WLS*' | cut -d/ -f4)
+  for managed_service in $managed_services; do
+    ok=1
+    if ! /etc/init.d/"$managed_service" status | head -1 | grep OK > /dev/null; then
+      ok=0
+    fi
+    if ! echo "$weblogic_server_status" | grep -w "$managed_service" | grep RUNNING > /dev/null; then
+      ok=0
+    fi
+    if (( ! ok )); then
+      unhealthy+=("$managed_service")
+    fi
+  done
+  echo "${unhealthy[@]}"
+}
+
+healthcheck() {
+  unhealthy_services=$(get_unhealthy_services)
+  if [[ -z $unhealthy_services ]]; then
+    echo -n $"Healthcheck of weblogic-all: "
+    echo_success
+    echo
+    return 0
+  else
+    for service in $unhealthy_services; do
+      echo -n $"Healthcheck of $service: "
+      echo_failure
+      echo
+    done
+    return 1
+  fi
+}
+
+repair() {
+  unhealthy_services=$(get_unhealthy_services)
+  if [[ -z $unhealthy_services ]]; then
+    echo "All services healthy, nothing to repair"
+    return 0
+  fi
+  for service in $unhealthy_services; do
+    /etc/init.d/"$service" restart
+  done
+  unhealthy_services=$(get_unhealthy_services)
+  if [[ -z $unhealthy_services ]]; then
+    echo "All services repairedr"
+    return 0
+  fi
+  echo "Failed to repair: $unhealthy_services"
+  return 1
+}
+
 case "$1" in
   start)
     start
@@ -99,8 +176,14 @@ case "$1" in
   status)
     status
     ;;
+  healthcheck)
+    healthcheck
+    ;;
+  repair)
+    repair
+    ;;
   *)
-    echo "Usage: $0 {start|stop|restart|status}"
+    echo "Usage: $0 {start|stop|restart|status|healthcheck|repair}"
     exit 3
 esac
 

--- a/ansible/roles/nomis-weblogic/templates/10.3/etc/init.d/weblogic-managed-server
+++ b/ansible/roles/nomis-weblogic/templates/10.3/etc/init.d/weblogic-managed-server
@@ -69,13 +69,28 @@ stop() {
   echo "init.d killing $prog $PIDS" | logger -p local3.info -t "$prog"
   kill $PIDS
   sleep 2
-  if get_process_pids > /dev/null; then
-    echo_failure
+  if ! get_process_pids > /dev/null; then
+    echo_success
     echo
-    return 1
+    return 0
   fi
-  echo_success
+  sleep 5
+  if ! PIDS=$(get_process_pids); then
+    echo_success
+    echo
+    return 0
+  fi
+  echo "init.d killing with -9 $prog $PIDS" | logger -p local3.info -t "$prog"
+  kill -9 $PIDS
+  sleep 2
+  if ! get_process_pids > /dev/null; then
+    echo_success
+    echo
+    return 0
+  fi
+  echo_failure
   echo
+  return 1
 }
 
 status() {

--- a/ansible/roles/nomis-weblogic/templates/10.3/etc/init.d/weblogic-node-manager
+++ b/ansible/roles/nomis-weblogic/templates/10.3/etc/init.d/weblogic-node-manager
@@ -69,13 +69,28 @@ stop() {
   echo "init.d killing $prog $PIDS" | logger -p local3.info -t "$prog"
   kill $PIDS
   sleep 2
-  if get_process_pids > /dev/null; then
-    echo_failure
+  if ! get_process_pids > /dev/null; then
+    echo_success
     echo
-    return 1
+    return 0
   fi
-  echo_success
+  sleep 5
+  if ! PIDS=$(get_process_pids); then
+    echo_success
+    echo
+    return 0
+  fi
+  echo "init.d killing with -9 $prog $PIDS" | logger -p local3.info -t "$prog"
+  kill -9 $PIDS
+  sleep 2
+  if ! get_process_pids > /dev/null; then
+    echo_success
+    echo
+    return 0
+  fi
+  echo_failure
   echo
+  return 1
 }
 
 status() {

--- a/ansible/roles/nomis-weblogic/templates/10.3/etc/init.d/weblogic-server
+++ b/ansible/roles/nomis-weblogic/templates/10.3/etc/init.d/weblogic-server
@@ -69,13 +69,28 @@ stop() {
   echo "init.d killing $prog $PIDS" | logger -p local3.info -t "$prog"
   kill $PIDS
   sleep 2
-  if get_process_pids > /dev/null; then
-    echo_failure
+  if ! get_process_pids > /dev/null; then
+    echo_success
     echo
-    return 1
+    return 0
   fi
-  echo_success
+  sleep 5
+  if ! PIDS=$(get_process_pids); then
+    echo_success
+    echo
+    return 0
+  fi
+  echo "init.d killing with -9 $prog $PIDS" | logger -p local3.info -t "$prog"
+  kill -9 $PIDS
+  sleep 2
+  if ! get_process_pids > /dev/null; then
+    echo_success
+    echo
+    return 0
+  fi
+  echo_failure
   echo
+  return 1
 }
 
 status() {


### PR DESCRIPTION
Changes
- if traditional kill doesn't work, do a subsequent kill -9 on a service stop.  Fixes services in ADMIN mode
- add a repair/healthcheck option to the service script for spotting any unhealthy services and restarting them
- optimise server reboot by using weblogic-all to start services in parallel
- opmn restart includes shutdown of opmn service