### PR TITLE
Nomis/dsos 1898/improve fixngo connected metric

### DIFF
--- a/ansible/roles/fixngo-connected-metric/README.md
+++ b/ansible/roles/fixngo-connected-metric/README.md
@@ -1,3 +1,3 @@
-Takes the value of `fixngo-connection-target` from hosts in an environment and pings them using netcat to return a 'connected' metric. 
+Takes the value of `fixngo-connection-targets` from hosts in an environment and pings them using netcat to return a 'connected' metric. If ALL connections fail then the metric will return 1 (disconnected), if any of the connections return a 'Connected' result then the metric will return 0 (connected). This is to allow for targets that are (sometimes) a bit flacky and to avoid false alarms.
 
-In the modernisation-platform-environments repo you can add this tag (e.g. fixngo-connection-target = "<ip address>") and an associated alarm config to set up an alarm which will trigger if connection from that EC2 instance to the target IP address is lost.
+In the modernisation-platform-environments repo you can add this tag (e.g. fixngo-connection-targets = "<ip address> <port> <ip address> <port>") and an associated alarm config to set up an alarm which will trigger if connection from that EC2 instance to the target IP address is lost.

--- a/ansible/roles/fixngo-connected-metric/tasks/fixngo-connected-metric.yml
+++ b/ansible/roles/fixngo-connected-metric/tasks/fixngo-connected-metric.yml
@@ -1,7 +1,25 @@
 ---
-- name: get fact for fixngo connection target
+- name: create folder for exec script to collect metrics
+  ansible.builtin.file:
+    path: "/opt/collectd"
+    state: directory
+    owner: root
+    group: root
+    mode: 0755
+
+# format must be "x.x.x.x port x.x.x.x port x.x.x.x port ..."
+- name: get fact for fixngo connection targets
   set_fact:
-    fixngo_connection_target: '{{ ec2.tags["fixngo-connection-target"] }}'
+    fixngo_connection_targets: "{{ ec2.tags['fixngo-connection-targets'] }}"
+
+- name: list of lists
+  set_fact:
+    fixngo_connection_targets_list: "{{ fixngo_connection_targets.split(' ') | slice(2) | map('list') | list }}"
+
+- name: create dictionary of lists
+  set_fact:
+    fixngo_connection_targets_dict: "{{ fixngo_connection_targets_dict | default([]) + [{'ip': item.0, 'port': item.1 }] }}"
+  loop: "{{ fixngo_connection_targets_list }}"
 
 - name: add fixngo conf for collectd to get connection state as a metric
   ansible.builtin.copy:

--- a/ansible/roles/fixngo-connected-metric/tasks/fixngo-connected-metric.yml
+++ b/ansible/roles/fixngo-connected-metric/tasks/fixngo-connected-metric.yml
@@ -12,13 +12,23 @@
   set_fact:
     fixngo_connection_targets: "{{ ec2.tags['fixngo-connection-targets'] }}"
 
-- name: list of lists
+- name: check if fixngo connection targets contains more than two items
   set_fact:
+    multiple_pairs: "{{ fixngo_connection_targets.split(' ') | length > 2 }}"
+
+- name: convert string to list of pairs (multiple targets)
+  set_fact: 
     fixngo_connection_targets_list: "{{ fixngo_connection_targets.split(' ') | slice(2) | map('list') | list }}"
+  when: multiple_pairs
+
+- name: convert string to list of pairs (single target)
+  set_fact: 
+    fixngo_connection_targets_list: "[{{ fixngo_connection_targets.split(' ') }}]"
+  when: not multiple_pairs 
 
 - name: create dictionary of lists
   set_fact:
-    fixngo_connection_targets_dict: "{{ fixngo_connection_targets_dict | default([]) + [{'ip': item.0, 'port': item.1 }] }}"
+    fixngo_connection_targets_dict: "{{ fixngo_connection_targets_dict | default([]) + [{'ip': item[0], 'port': item[1] }] }}"
   loop: "{{ fixngo_connection_targets_list }}"
 
 - name: add fixngo conf for collectd to get connection state as a metric

--- a/ansible/roles/fixngo-connected-metric/tasks/main.yml
+++ b/ansible/roles/fixngo-connected-metric/tasks/main.yml
@@ -3,4 +3,4 @@
   tags:
     - ec2provision
     - ec2patch
-  when: ec2.tags['fixngo-connection-target'] is defined and ansible_facts['distribution'] == "RedHat"
+  when: ec2.tags['fixngo-connection-targets'] is defined and ansible_facts['distribution'] == "RedHat"

--- a/ansible/roles/fixngo-connected-metric/templates/fixngo_connected_metrics.sh.j2
+++ b/ansible/roles/fixngo-connected-metric/templates/fixngo_connected_metrics.sh.j2
@@ -2,24 +2,46 @@
 
 # Templated in from ansible
 HOSTNAME="${HOSTNAME:-localhost}"
-INTERVAL="{{ collectd_script_interval }}"
+INTERVAL={{ collectd_script_interval }}
 timeout=1
-port=4903 
-target="{{ fixngo_connection_target }}"
+targets={{ fixngo_connection_targets_dict }} # just to be able to see the values being used
 
-fixngo_connection_status() {
-    connection=$(ncat -vzw "$timeout" "$target" "$port" 2>&1)
-    if [[ "${connection}" == *"Connected"* ]]
-    then
-        return 0
-    else
-        return 1
-    fi
-}
+{% for target in fixngo_connection_targets_dict -%}
+    
+    function{{ loop.index }}() {
+        connection=$(ncat -vzw "$timeout" {{ target.ip }} {{ target.port }} 2>&1)
+        if [[ "${connection}" == *"Connected"* ]]
+        then
+            return 0
+        else
+            return 1 # Connection failed
+        fi
+    }
+
+{% endfor %}
 
 while sleep "$INTERVAL"
 do
-    fixngo_connection_status
-    connection=$?
-    echo "PUTVAL $HOSTNAME/exec-fixngo_connected/bool-fixngo_connected interval=$INTERVAL N:$connection"
+
+    {% for target in fixngo_connection_targets_dict %}
+        function{{ loop.index }}
+        connection{{ loop.index }}=$?
+    {% endfor %}
+
+    all_connection_checks_failed=true
+
+    {% for target in fixngo_connection_targets_dict %}
+        if [[ $connection{{ loop.index }} -ne 1 ]]
+        then
+            all_connection_checks_failed=false
+            break
+        fi
+    {% endfor %}
+
+    if [[ $all_connection_checks_failed == true ]]
+    then
+        echo "PUTVAL $HOSTNAME/exec-fixngo_connected/bool-fixngo_connected interval=$INTERVAL N:1"
+    else
+        echo "PUTVAL $HOSTNAME/exec-fixngo_connected/bool-fixngo_connected interval=$INTERVAL N:0"
+    fi
 done


### PR DESCRIPTION
Sets one (or more) fixngo-connection-targets via ip port pairs in modernisation-platform-environments tags 

This role creates a metric which returns 1 if ALL connection targets can't connect or 0 (success) if any of them can

Apart from changing the tag value in mod-platform-environments and deploying this on the target no other changes are needed