### PR TITLE
DSOS-1932: add additional search domains for xtag

### DIFF
--- a/ansible/group_vars/environment_name_nomis_development.yml
+++ b/ansible/group_vars/environment_name_nomis_development.yml
@@ -3,3 +3,5 @@ ansible_aws_ssm_bucket_name: s3-bucket20220916125223367600000002
 db_backup_s3_bucket_name: nomis-db-backup-bucket20220916125226300100000009
 image_builder_s3_bucket_name: ec2-image-builder-nomis20220314103938567000000001
 dns_zone_internal: nomis.hmpps-development.modernisation-platform.internal
+dns_search_domains:
+  - azure.noms.root

--- a/ansible/group_vars/environment_name_nomis_preproduction.yml
+++ b/ansible/group_vars/environment_name_nomis_preproduction.yml
@@ -3,3 +3,5 @@ ansible_aws_ssm_bucket_name: s3-bucket20220929161938056300000001
 db_backup_s3_bucket_name: nomis-db-backup-bucket20220929161940860900000005
 image_builder_s3_bucket_name: ec2-image-builder-nomis20220314103938567000000001
 dns_zone_internal: nomis.hmpps-preproduction.modernisation-platform.internal
+dns_search_domains:
+  - azure.hmpp.root

--- a/ansible/group_vars/environment_name_nomis_production.yml
+++ b/ansible/group_vars/environment_name_nomis_production.yml
@@ -3,3 +3,5 @@ ansible_aws_ssm_bucket_name: s3-bucket20220427111226925000000002
 db_backup_s3_bucket_name: nomis-db-backup-bucket20220427111226918600000001
 image_builder_s3_bucket_name: ec2-image-builder-nomis20220314103938567000000001
 dns_zone_internal: nomis.hmpps-production.modernisation-platform.internal
+dns_search_domains:
+  - azure.hmpp.root

--- a/ansible/group_vars/environment_name_nomis_test.yml
+++ b/ansible/group_vars/environment_name_nomis_test.yml
@@ -3,6 +3,8 @@ ansible_aws_ssm_bucket_name: s3-bucket20210929163229537900000001 # for some reas
 db_backup_s3_bucket_name: nomis-db-backup-bucket20220131102905687200000001
 image_builder_s3_bucket_name: ec2-image-builder-nomis20220314103938567000000001
 dns_zone_internal: nomis.hmpps-test.modernisation-platform.internal
+dns_search_domains:
+  - azure.noms.root
 
 db_configs:
   CNOMT1:
@@ -73,79 +75,6 @@ db_configs:
     host_name: t1-nomis-db-1-b.test.nomis.service.justice.gov.uk
     port: 1521
     tns_name: T1TRDS1
-    s3_bucket: nomis-db-backup-bucket20220131102905687200000001
-    asm_disk_groups: DATA
-    service:
-      - { name: TRDAT_TAF, role: PRIMARY }
-
-  CNOMT2:
-    db_name: CNOMT2
-    db_unique_name: CNOMT2
-    instance_name: CNOMT2
-    host_name: T2PDL0012.azure.noms.root
-    port: 1521
-    tns_name: CNOMT2
-    storage_account_name: strtcmonsazcopyorabkup
-    asm_disk_groups: DATA,FLASH
-    service:
-      - { name: OR_TAF, role: PRIMARY }
-      - { name: NOMIS_TAF, role: PRIMARY }
-      - { name: OLDNOMIS_TAF, role: PRIMARY }
-      - { name: NOMIS_APIRO, role: PRIMARY }
-  T2CNOMS1:
-    db_name: CNOMT2
-    db_unique_name: T2CNOMS1
-    instance_name: T2CNOMS1
-    host_name: t2-nomis-db-1-b.test.nomis.service.justice.gov.uk
-    port: 1521
-    tns_name: T2CNOMS1
-    s3_bucket: nomis-db-backup-bucket20220131102905687200000001
-    asm_disk_groups: DATA,FLASH
-    service:
-      - { name: OR_TAF, role: PRIMARY }
-      - { name: NOMIS_TAF, role: PRIMARY }
-      - { name: OLDNOMIS_TAF, role: PRIMARY }
-      - { name: NOMIS_APIRO, role: PRIMARY }
-  NDHT2:
-    db_name: NDHT2
-    db_unique_name: NDHT2
-    instance_name: NDHT2
-    host_name: T2PDL0012.azure.noms.root
-    port: 1521
-    tns_name: NDHT2
-    storage_account_name: strtcmonsazcopyorabkup
-    asm_disk_groups: DATA
-    service:
-      - { name: NDH_TAF, role: PRIMARY }
-  T2NDHS1:
-    db_name: NDHT2
-    db_unique_name: T2NDHS1
-    instance_name: T2NDHS1
-    host_name: t2-nomis-db-1-b.test.nomis.service.justice.gov.uk
-    port: 1521
-    tns_name: T2NDHS1
-    s3_bucket: nomis-db-backup-bucket20220131102905687200000001
-    asm_disk_groups: DATA
-    service:
-      - { name: NDH_TAF, role: PRIMARY }
-  TRDATT2:
-    db_name: TRDATT2
-    db_unique_name: TRDATT2
-    instance_name: TRDATT2
-    host_name: T2PDL0012.azure.noms.root
-    port: 1521
-    tns_name: TRDATT2
-    storage_account_name: strtcmonsazcopyorabkup
-    asm_disk_groups: DATA
-    service:
-      - { name: TRDAT_TAF, role: PRIMARY }
-  T2TRDS1:
-    db_name: TRDATT2
-    db_unique_name: T2TRDS1
-    instance_name: T2TRDS1
-    host_name: t2-nomis-db-1-b.test.nomis.service.justice.gov.uk
-    port: 1521
-    tns_name: T2TRDS1
     s3_bucket: nomis-db-backup-bucket20220131102905687200000001
     asm_disk_groups: DATA
     service:

--- a/ansible/roles/domain-search/defaults/main.yml
+++ b/ansible/roles/domain-search/defaults/main.yml
@@ -1,2 +1,5 @@
 ---
 # dns_zone_internal: set in environment specific group_vars
+
+# optionally add additional search domains
+dns_search_domains: []

--- a/ansible/roles/domain-search/templates/dhclient-eth0.conf.j2
+++ b/ansible/roles/domain-search/templates/dhclient-eth0.conf.j2
@@ -1,2 +1,5 @@
 append domain-search "{{ ansible_ec2_placement_region }}.compute.internal";
 append domain-search "{{ dns_zone_internal }}";
+{% for dns_search_domain in dns_search_domains -%}
+append domain-search "{{ dns_search_domain }}";
+{% endfor %}


### PR DESCRIPTION
Allow FixNGo hosts to be referenced without FQDN.  Required for XTAG to NDH connectivity.
Plus removed some duplicate DB entries that caused warnings.