### PR TITLE
nomis: DSOS-1960: temporarily comment out monitoring roles

### DIFF
--- a/ansible/group_vars/server_type_nomis_db.yml
+++ b/ansible/group_vars/server_type_nomis_db.yml
@@ -9,10 +9,10 @@ server_type_roles_list:
   - oracle-11g
   - oracle-secure-web
   - oracle-db-backup
-  - collectd
-  - amazon-cloudwatch-agent
-  - oracle-db-restore
-  - oracle-db-monitoring
+#  - collectd                 # temporarily disabling as generating errors, address in DSOS-1974
+#  - amazon-cloudwatch-agent
+#  - oracle-db-restore
+#  - oracle-db-monitoring
 
 # the below vars are defined in multiple groups.  Keep the values the same to avoid unexpected behaviour
 roles_list: "{{ (ami_roles_list | default([]) | difference(server_type_roles_list | default([]))) + (server_type_roles_list | default([])) }}"


### PR DESCRIPTION
collectd is filling /var/log/messages with errors, and oracle-db-monitoring fails since script exporter is not installed.  These issues will be addressed in later ticket but commenting out for now so the new ansible installs cleanly.