### PR TITLE
Nomis/dsos 2034/xtag health

### DIFF
--- a/ansible/group_vars/server_type_nomis_xtag.yml
+++ b/ansible/group_vars/server_type_nomis_xtag.yml
@@ -1,12 +1,15 @@
 ---
 ansible_python_interpreter: /usr/local/bin/python3.9
 image_builder_s3_bucket_name: ec2-image-builder-nomis20220314103938567000000001
+collectd_metric_configs:
+  - nomis-xtag
 
 server_type_roles_list:
   - autoscale-group-hooks
   - set-ec2-hostname
   - domain-search
   - nomis-xtag-weblogic
+  - collectd
   - amazon-cloudwatch-agent
   - autoscale-group-hooks-state
 

--- a/ansible/roles/collectd/README.md
+++ b/ansible/roles/collectd/README.md
@@ -26,6 +26,8 @@ There is an additional task specifically to create a selinux policy for collectd
 
 Having loging for collectd is NOT enabled. Most of the useful information goes to /var/log/messages anyway or with selinux to /var/log/audit/audit.log where you can see what's being blocked in relation to collectd
 
+setting semanage to permissively allow collectd to run scripts is also required. This is done by the task `collectd_configure : set selinux to permissive for collectd`
+
 ## Debugging Collectd
 
 Probably the easiest thing to do is un-comment the 'logfile' plugin sections in collectd.conf.j2 and reload collectd via `sudo systemctl restart collectd.service`

--- a/ansible/roles/collectd/files/nomis_xtag.conf
+++ b/ansible/roles/collectd/files/nomis_xtag.conf
@@ -1,0 +1,4 @@
+LoadPlugin exec
+<Plugin exec>
+   Exec "oracle" "/opt/collectd/nomis_xtag.sh"
+</Plugin>

--- a/ansible/roles/collectd/tasks/collectd_selinux_policy.yml
+++ b/ansible/roles/collectd/tasks/collectd_selinux_policy.yml
@@ -11,7 +11,7 @@
         minutes: 3 # may need to be extended if this doesn't allow enough time for all issues to be captured
 
     # also checks if there's a policy to enforce, if not then no subsequent tasks will run
-    - name: capture selinux AVC rules from audit log around collectd
+    - name: capture selinux AVC rules from audit log around collectd 
       ansible.builtin.shell: |
         result=$(grep 'AVC.*collectd\|collectd.*AVC' /var/log/audit/audit.log)
         if [[ $result ]]; then

--- a/ansible/roles/collectd/tasks/collectd_selinux_policy.yml
+++ b/ansible/roles/collectd/tasks/collectd_selinux_policy.yml
@@ -49,5 +49,24 @@
         chdir: ~
       when: pp_file.stat.exists
 
-  # block
+    # seems this step is also needed to allow collectd to run without selinux errors
+    - name: set selinux policy for collectd_t to permissive
+      ansible.builtin.command: semanage permissive -a collectd_t
+      become: true
+      changed_when: false
+      ignore_errors: true
+
+    - name: restart collectd after policy on Rhel 6
+      ansible.builtin.command: service collectd restart
+      become: true
+      when: ansible_distribution_major_version == '6'
+
+    - name: restart collectd after policy on Rhel 7+
+      ansible.builtin.service:
+        name: collectd
+        state: restarted
+        enabled: yes
+      become: true
+      when: ansible_distribution_major_version >= '7'
+
   when: selinux_status.stdout == 'Enforcing'

--- a/ansible/roles/collectd/tasks/collectd_selinux_policy.yml
+++ b/ansible/roles/collectd/tasks/collectd_selinux_policy.yml
@@ -11,7 +11,7 @@
         minutes: 3 # may need to be extended if this doesn't allow enough time for all issues to be captured
 
     # also checks if there's a policy to enforce, if not then no subsequent tasks will run
-    - name: capture selinux AVC rules from audit log around collectd 
+    - name: capture selinux AVC rules from audit log around collectd
       ansible.builtin.shell: |
         result=$(grep 'AVC.*collectd\|collectd.*AVC' /var/log/audit/audit.log)
         if [[ $result ]]; then

--- a/ansible/roles/collectd/templates/nomis_xtag.sh.j2
+++ b/ansible/roles/collectd/templates/nomis_xtag.sh.j2
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+# Templated in from ansible
+HOSTNAME="${HOSTNAME:-localhost}"
+INTERVAL="{{ collectd_script_interval }}"
+SERVICE_LIST="{{ service_list_xtag }}"
+
+service_status() {
+    local SERVICE="$1"
+    systemctl is-active --quiet "$SERVICE"
+}
+
+while sleep "$INTERVAL"
+do
+    for service in ${SERVICE_LIST}
+    do
+        service_status "$service" 
+        status=$?
+
+        service_name=${service//-/_}
+        echo "PUTVAL $HOSTNAME/exec-$service_name/bool-$service_name interval=$INTERVAL N:$status"
+    done
+done

--- a/ansible/roles/collectd/templates/nomis_xtag.sh.j2
+++ b/ansible/roles/collectd/templates/nomis_xtag.sh.j2
@@ -17,7 +17,7 @@ do
         service_status "$service" 
         status=$?
 
-        service_name=${service//-/_}
-        echo "PUTVAL $HOSTNAME/exec-$service_name/bool-$service_name interval=$INTERVAL N:$status"
+        service_name=${service//_}
+        echo "PUTVAL $HOSTNAME/$service_name/bool-$service_name interval=$INTERVAL N:$status"
     done
 done

--- a/ansible/roles/collectd/vars/main.yml
+++ b/ansible/roles/collectd/vars/main.yml
@@ -9,3 +9,4 @@ service_list_oracle: "oracle-ohasd oracleasm"
 # service lists vars
 service_list_linux: "chronyd sshd"
 service_list_weblogic: "weblogic-healthcheck"
+service_list_xtag: "wls_nodemanager wls_adminserver wls_managedserver"


### PR DESCRIPTION
- rework selinux exceptions stage to cope with (possibly) empty config files
- invoke semanage to permissive for collectd_t
- handle differences between selinux exception configs between Rhel 6 & 7
- add restarts for collectd to cope with changes/enabling selinux exception
- changes to collectd metric names e.g. collectd_wlsmanagedserver_value
  - makes alarms a lot easier to manage in associated modernisation-platform-environments terraform code 