### PR TITLE
Nomis: DSOS-2088: fix issue with OEM build

### DIFF
--- a/ansible/roles/ncr-tomcat/tasks/get_facts.yml
+++ b/ansible/roles/ncr-tomcat/tasks/get_facts.yml
@@ -2,7 +2,6 @@
 - name: Set SSM parameters path fact from ec2 ssm-parameters-prefix and Name tag
   set_fact:
     ssm_parameters_path: '/{{ ssm_parameters_prefix }}/{{ ec2.tags["Name"] }}'
-  when: ssm_parameters_path is not defined
 
 - name: Set SSM parameters tomcat path facts
   set_fact:
@@ -13,4 +12,3 @@
   set_fact:
     tomcat_cms_password: "{{ lookup('aws_ssm', ssm_parameters_path_tomcat_cms_password, region=ansible_ec2_placement_region) }}"
     tomcat_product_key: "{{ lookup('aws_ssm', ssm_parameters_path_tomcat_product_key, region=ansible_ec2_placement_region) }}"
-  when: tomcat_cms_password is not defined

--- a/ansible/roles/nomis-release-deployment/tasks/get_facts.yml
+++ b/ansible/roles/nomis-release-deployment/tasks/get_facts.yml
@@ -27,7 +27,7 @@
 - name: Set SSM parameters path fact from ec2 ssm-parameters-prefix and Name tag
   set_fact:
     ssm_parameters_path: '/{{ ssm_parameters_prefix }}/{{ ec2.tags["oracle-db-name"] }}'
-  when: ssm_parameters_path is not defined and app_server_file.stat.exists
+  when: app_server_file.stat.exists
 
 - name: Set SSM parameters path fact from ec2 ssm-parameters-prefix and Name tag
   set_fact:

--- a/ansible/roles/nomis-weblogic/tasks/get-facts.yml
+++ b/ansible/roles/nomis-weblogic/tasks/get-facts.yml
@@ -2,7 +2,6 @@
 - name: Set SSM parameters path fact from ec2 ssm-parameters-prefix and Name tag
   set_fact:
     ssm_parameters_path: '/{{ ssm_parameters_prefix }}/{{ ec2.tags["Name"] }}'
-  when: ssm_parameters_path is not defined
 
 - name: Set SSM parameters weblogic path facts
   set_fact:
@@ -25,7 +24,6 @@
     weblogic_db_tagsar_password: "{{ lookup('aws_ssm', ssm_parameters_path_weblogic_db_tagsar_password, region=ansible_ec2_placement_region) }}"
     weblogic_rms_hosts: "{{ lookup('aws_ssm', ssm_parameters_path_weblogic_rms_hosts, region=ansible_ec2_placement_region) }}"
     weblogic_rms_key: "{{ lookup('aws_ssm', ssm_parameters_path_weblogic_rms_key, region=ansible_ec2_placement_region) }}"
-  when: weblogic_admin_username is not defined
 
 - name: Set db hostname from ec2 oracle-db-hostname tag
   set_fact:
@@ -35,7 +33,6 @@
 - name: Set db name from ec2 oracle-db-name tag
   set_fact:
     weblogic_db_name: "{{ ec2.tags['oracle-db-name'] }}"
-  when: weblogic_db_name is not defined
 
 - debug:
     msg: "Configuring Oracle DB {{ weblogic_db_name }} on {{ weblogic_db_hostname_a }},{{ weblogic_db_hostname_b }} with username {{ weblogic_db_username }}"

--- a/ansible/roles/nomis-xtag-weblogic/tasks/get-facts.yml
+++ b/ansible/roles/nomis-xtag-weblogic/tasks/get-facts.yml
@@ -2,7 +2,6 @@
 - name: Set SSM parameters path fact from ec2 ssm-parameters-prefix and Name tag
   set_fact:
     ssm_parameters_path: '/{{ ssm_parameters_prefix }}/{{ ec2.tags["Name"] }}'
-  when: ssm_parameters_path is not defined
 
 - name: Set SSM parameters weblogic path facts
   set_fact:
@@ -17,7 +16,6 @@
     weblogic_admin_password: "{{ lookup('aws_ssm', ssm_parameters_path_weblogic_admin_password, region=ansible_ec2_placement_region) }}"
     weblogic_db_username: "{{ lookup('aws_ssm', ssm_parameters_path_weblogic_db_username, region=ansible_ec2_placement_region) }}"
     weblogic_db_password: "{{ lookup('aws_ssm', ssm_parameters_path_weblogic_db_password, region=ansible_ec2_placement_region) }}"
-  when: weblogic_admin_username is not defined
 
 - name: Set db hostname from ec2 oracle-db-hostname tag
   set_fact:
@@ -27,12 +25,10 @@
 - name: Set db name from ec2 oracle-db-name tag
   set_fact:
     weblogic_db_name: "{{ ec2.tags['oracle-db-name'] }}"
-  when: weblogic_db_name is not defined
 
 - name: Set ndh ems name from ec2 ndh-ems-hostname tag
   set_fact:
     ndh_ems_server: "{{ ec2.tags['ndh-ems-hostname'] }}"
-  when: ndh_ems_server is not defined
 
 - debug:
     msg: "Configuring Oracle DB {{ weblogic_db_name }} on {{ weblogic_db_hostname_a }},{{ weblogic_db_hostname_b }} with username {{ weblogic_db_username }}"

--- a/ansible/roles/oasys-ords/tasks/install.yml
+++ b/ansible/roles/oasys-ords/tasks/install.yml
@@ -2,7 +2,6 @@
 - name: Set SSM parameters path fact from ec2 ssm-parameters-prefix and Name tag
   set_fact:
     ssm_parameters_path: '/{{ ssm_parameters_prefix }}/{{ ec2.tags["oasys-environment"] }}'
-  when: ssm_parameters_path is not defined
 
 - name: Set SSM parameters database path facts
   set_fact:

--- a/ansible/roles/oracle-11g/tasks/get-facts.yml
+++ b/ansible/roles/oracle-11g/tasks/get-facts.yml
@@ -2,7 +2,6 @@
 - name: Set SSM parameters path fact from ec2 ssm-parameters-prefix and Name tag
   set_fact:
     ssm_parameters_path: '/{{ ssm_parameters_prefix }}/{{ ec2.tags["Name"] }}'
-  when: ssm_parameters_path is not defined
 
 - name: Set SSM parameters weblogic path facts
   set_fact:

--- a/ansible/roles/oracle-active-db-duplication/tasks/get_facts.yml
+++ b/ansible/roles/oracle-active-db-duplication/tasks/get_facts.yml
@@ -17,7 +17,6 @@
 - name: Set SSM parameters path fact from ec2 ssm-parameters-prefix and Name tag
   set_fact:
     ssm_parameters_path: '/{{ ssm_parameters_prefix }}/{{ ec2.tags["Name"] }}'
-  when: ssm_parameters_path is not defined
 
 - name: Set SSM parameters database path facts
   set_fact:

--- a/ansible/roles/oracle-db-standby-setup/tasks/get_facts.yml
+++ b/ansible/roles/oracle-db-standby-setup/tasks/get_facts.yml
@@ -30,7 +30,6 @@
 - name: Set SSM parameters path fact from ec2 ssm-parameters-prefix and Name tag
   set_fact:
     ssm_parameters_path: '/{{ ssm_parameters_prefix }}/{{ ec2.tags["Name"] }}'
-  when: ssm_parameters_path is not defined
 
 - name: Set SSM parameters database path facts
   set_fact:

--- a/ansible/roles/oracle-oem-agent-setup/tasks/get_facts.yml
+++ b/ansible/roles/oracle-oem-agent-setup/tasks/get_facts.yml
@@ -3,7 +3,6 @@
   set_fact:
     ssm_parameters_path: "/{{ ssm_parameters_prefix }}"
     db_ssm_parameters_path: '/database/{{ ec2.tags["Name"] }}'
-  when: ssm_parameters_path is not defined
 
 - name: Set SSM parameters database path facts
   set_fact:

--- a/ansible/roles/oracle-oms-setup/tasks/create_emrepo_database.yml
+++ b/ansible/roles/oracle-oms-setup/tasks/create_emrepo_database.yml
@@ -19,12 +19,15 @@
         - create_oem_repository_db.sh
         - db_set_parameter.sh
 
+    - debug:
+        msg: "create_oem_repository_db.sh {{ emrepo_db_name.emrepo_db_name }} {{ db_sys_password }} {{ db_system_password }}"
+
     - name: Create OEM repository database
       become_user: oracle
       ansible.builtin.shell: |
         set -eo pipefail
         main() {
-          echo "# create_oem_repository_db.sh "
+          echo "# create_oem_repository_db.sh {{ emrepo_db_name.emrepo_db_name }} {{ db_sys_password }} {{ db_system_password }}"
           {{ stage }}/create_oem_repository_db.sh {{ emrepo_db_name.emrepo_db_name }} {{ db_sys_password }} {{ db_system_password }}
         }
         main 2>&1 | logger -p local3.info -t ansible-oracle-db

--- a/ansible/roles/oracle-oms-setup/tasks/create_emrepo_database.yml
+++ b/ansible/roles/oracle-oms-setup/tasks/create_emrepo_database.yml
@@ -6,9 +6,6 @@
   check_mode: yes
   register: emrepo_db_exists_check
     
-- debug:
-    msg: "E create_oem_repository_db.sh {{ emrepo_db_name.emrepo_db_name }} {{ db_sys_password }} {{ db_system_password }}"
-
 - name: Create OEM repository database
   block:
     - name: Copy OEM repository creation scripts
@@ -22,15 +19,12 @@
         - create_oem_repository_db.sh
         - db_set_parameter.sh
 
-    - debug:
-        msg: "F create_oem_repository_db.sh {{ emrepo_db_name.emrepo_db_name }} {{ db_sys_password }} {{ db_system_password }}"
-
     - name: Create OEM repository database
       become_user: oracle
       ansible.builtin.shell: |
         set -eo pipefail
         main() {
-          echo "# create_oem_repository_db.sh {{ emrepo_db_name.emrepo_db_name }} {{ db_sys_password }} {{ db_system_password }}"
+          echo "# create_oem_repository_db.sh {{ emrepo_db_name.emrepo_db_name }}"
           {{ stage }}/create_oem_repository_db.sh {{ emrepo_db_name.emrepo_db_name }} {{ db_sys_password }} {{ db_system_password }}
         }
         main 2>&1 | logger -p local3.info -t ansible-oracle-db

--- a/ansible/roles/oracle-oms-setup/tasks/create_emrepo_database.yml
+++ b/ansible/roles/oracle-oms-setup/tasks/create_emrepo_database.yml
@@ -5,7 +5,7 @@
     line: "{{ emrepo_db_name.emrepo_db_name }}"
   check_mode: yes
   register: emrepo_db_exists_check
-    
+
 - name: Create OEM repository database
   block:
     - name: Copy OEM repository creation scripts
@@ -49,8 +49,8 @@
       become_user: oracle
       ansible.builtin.shell: |
         export PATH=$PATH:/usr/local/bin
-        . oraenv <<< {{ emrepo_db_name.emrepo_db_name }} 
-        srvctl stop database -d {{ emrepo_db_name.emrepo_db_name }} 
+        . oraenv <<< {{ emrepo_db_name.emrepo_db_name }}
+        srvctl stop database -d {{ emrepo_db_name.emrepo_db_name }}
         srvctl start database -d {{ emrepo_db_name.emrepo_db_name }}
 
   # block

--- a/ansible/roles/oracle-oms-setup/tasks/create_emrepo_database.yml
+++ b/ansible/roles/oracle-oms-setup/tasks/create_emrepo_database.yml
@@ -5,6 +5,9 @@
     line: "{{ emrepo_db_name.emrepo_db_name }}"
   check_mode: yes
   register: emrepo_db_exists_check
+    
+- debug:
+    msg: "E create_oem_repository_db.sh {{ emrepo_db_name.emrepo_db_name }} {{ db_sys_password }} {{ db_system_password }}"
 
 - name: Create OEM repository database
   block:
@@ -20,7 +23,7 @@
         - db_set_parameter.sh
 
     - debug:
-        msg: "create_oem_repository_db.sh {{ emrepo_db_name.emrepo_db_name }} {{ db_sys_password }} {{ db_system_password }}"
+        msg: "F create_oem_repository_db.sh {{ emrepo_db_name.emrepo_db_name }} {{ db_sys_password }} {{ db_system_password }}"
 
     - name: Create OEM repository database
       become_user: oracle

--- a/ansible/roles/oracle-oms-setup/tasks/get_facts.yml
+++ b/ansible/roles/oracle-oms-setup/tasks/get_facts.yml
@@ -51,3 +51,6 @@
   fail:
     msg: Ensure all required parameters are set
   when: not db_all_variables_set|default(false)
+
+- debug:
+    msg: "A create_oem_repository_db.sh {{ emrepo_db_name.emrepo_db_name }} {{ db_sys_password }} {{ db_system_password }}"

--- a/ansible/roles/oracle-oms-setup/tasks/get_facts.yml
+++ b/ansible/roles/oracle-oms-setup/tasks/get_facts.yml
@@ -25,9 +25,6 @@
     ssm_parameters_path_oem_nodemanager_password: "{{ ssm_parameters_path }}/OEM/nodemanagerpassword"
     ssm_parameters_path_oem_agent_registration_password: "{{ ssm_parameters_path }}/OEM/agentregpassword"
 
-- debug:
-    var: ssm_parameters_path_db_sys_password
-
 - name: Get SSM parameters
   set_fact:
     db_sys_password: "{{ lookup('aws_ssm', ssm_parameters_path_db_sys_password, region=ansible_ec2_placement_region) }}"
@@ -36,11 +33,6 @@
     weblogic_admin_password: "{{ lookup('aws_ssm', ssm_parameters_path_oem_weblogic_password, region=ansible_ec2_placement_region) }}"
     nodemanager_password: "{{ lookup('aws_ssm', ssm_parameters_path_oem_nodemanager_password, region=ansible_ec2_placement_region) }}"
     oem_agent_password: "{{ lookup('aws_ssm', ssm_parameters_path_oem_agent_registration_password, region=ansible_ec2_placement_region) }}"
-
-- debug:
-    var: db_sys_password
-- debug:
-    var: db_system_password
 
 - name: Check parameters
   set_fact:
@@ -54,18 +46,7 @@
     - nodemanager_password|length > 0
     - oem_agent_password|length > 0
 
-- debug:
-    var: db_sys_password
-- debug:
-    var: db_system_password
-
 - name: Fail if missing parameters
   fail:
     msg: Ensure all required parameters are set
   when: not db_all_variables_set|default(false)
-
-- debug:
-    msg: "A create_oem_repository_db.sh {{ emrepo_db_name.emrepo_db_name }} {{ db_sys_password }} {{ db_system_password }}"
-
-- debug:
-    msg: "AA {{ db_sys_password }}"

--- a/ansible/roles/oracle-oms-setup/tasks/get_facts.yml
+++ b/ansible/roles/oracle-oms-setup/tasks/get_facts.yml
@@ -35,6 +35,11 @@
     nodemanager_password: "{{ lookup('aws_ssm', ssm_parameters_path_oem_nodemanager_password, region=ansible_ec2_placement_region) }}"
     oem_agent_password: "{{ lookup('aws_ssm', ssm_parameters_path_oem_agent_registration_password, region=ansible_ec2_placement_region) }}"
 
+- debug:
+    var: db_sys_password
+- debug:
+    var: db_system_password
+
 - name: Check parameters
   set_fact:
     db_all_variables_set: true
@@ -47,6 +52,11 @@
     - nodemanager_password|length > 0
     - oem_agent_password|length > 0
 
+- debug:
+    var: db_sys_password
+- debug:
+    var: db_system_password
+
 - name: Fail if missing parameters
   fail:
     msg: Ensure all required parameters are set
@@ -54,3 +64,6 @@
 
 - debug:
     msg: "A create_oem_repository_db.sh {{ emrepo_db_name.emrepo_db_name }} {{ db_sys_password }} {{ db_system_password }}"
+
+- debug:
+    msg: "AA {{ db_sys_password }}"

--- a/ansible/roles/oracle-oms-setup/tasks/get_facts.yml
+++ b/ansible/roles/oracle-oms-setup/tasks/get_facts.yml
@@ -15,7 +15,6 @@
 - name: Set SSM parameters path fact from ec2 ssm-parameters-prefix and Name tag
   set_fact:
     ssm_parameters_path: '/{{ ssm_parameters_prefix }}/{{ ec2.tags["Name"] }}'
-  when: ssm_parameters_path is not defined
 
 - name: Set SSM parameters database path facts
   set_fact:
@@ -25,6 +24,9 @@
     ssm_parameters_path_oem_weblogic_password: "{{ ssm_parameters_path }}/OEM/weblogicpassword"
     ssm_parameters_path_oem_nodemanager_password: "{{ ssm_parameters_path }}/OEM/nodemanagerpassword"
     ssm_parameters_path_oem_agent_registration_password: "{{ ssm_parameters_path }}/OEM/agentregpassword"
+
+- debug:
+    var: ssm_parameters_path_db_sys_password
 
 - name: Get SSM parameters
   set_fact:

--- a/ansible/roles/oracle-oms-setup/tasks/install_oem_prereq.yml
+++ b/ansible/roles/oracle-oms-setup/tasks/install_oem_prereq.yml
@@ -25,3 +25,6 @@
     - redhat-lsb-core
     - openssl
     - make
+
+- debug:
+    msg: "C create_oem_repository_db.sh {{ emrepo_db_name.emrepo_db_name }} {{ db_sys_password }} {{ db_system_password }}"

--- a/ansible/roles/oracle-oms-setup/tasks/install_oem_prereq.yml
+++ b/ansible/roles/oracle-oms-setup/tasks/install_oem_prereq.yml
@@ -25,6 +25,3 @@
     - redhat-lsb-core
     - openssl
     - make
-
-- debug:
-    msg: "C create_oem_repository_db.sh {{ emrepo_db_name.emrepo_db_name }} {{ db_sys_password }} {{ db_system_password }}"

--- a/ansible/roles/oracle-oms-setup/tasks/main.yml
+++ b/ansible/roles/oracle-oms-setup/tasks/main.yml
@@ -10,12 +10,22 @@
   tags:
     - always
 
+- debug:
+    msg: "B create_oem_repository_db.sh {{ emrepo_db_name.emrepo_db_name }} {{ db_sys_password }} {{ db_system_password }}"
+  tags:
+    - always
+
 - block:
     - import_tasks: install_oem_prereq.yml
       tags:
         - amibuild
         - ec2provision
         - oracle_oem_software_prereq
+
+    - debug:
+        msg: "D create_oem_repository_db.sh {{ emrepo_db_name.emrepo_db_name }} {{ db_sys_password }} {{ db_system_password }}"
+      tags:
+        - always
 
     - import_tasks: create_emrepo_database.yml
       tags:

--- a/ansible/roles/oracle-oms-setup/tasks/main.yml
+++ b/ansible/roles/oracle-oms-setup/tasks/main.yml
@@ -21,7 +21,7 @@
       tags:
         - amibuild
         - ec2provision
-        - oracle_oem_software_prereq
+        - oracle_oem_create_emrepo_database
 
     - import_tasks: download_oem_software.yml
       tags:

--- a/ansible/roles/oracle-oms-setup/tasks/main.yml
+++ b/ansible/roles/oracle-oms-setup/tasks/main.yml
@@ -10,22 +10,12 @@
   tags:
     - always
 
-- debug:
-    msg: "B create_oem_repository_db.sh {{ emrepo_db_name.emrepo_db_name }} {{ db_sys_password }} {{ db_system_password }}"
-  tags:
-    - always
-
 - block:
     - import_tasks: install_oem_prereq.yml
       tags:
         - amibuild
         - ec2provision
         - oracle_oem_software_prereq
-
-    - debug:
-        msg: "D create_oem_repository_db.sh {{ emrepo_db_name.emrepo_db_name }} {{ db_sys_password }} {{ db_system_password }}"
-      tags:
-        - always
 
     - import_tasks: create_emrepo_database.yml
       tags:

--- a/ansible/roles/oracle-recovery-catalog/tasks/get_facts.yml
+++ b/ansible/roles/oracle-recovery-catalog/tasks/get_facts.yml
@@ -15,7 +15,6 @@
 - name: Set SSM parameters path fact from ec2 ssm-parameters-prefix and Name tag
   set_fact:
     ssm_parameters_path: '/{{ ssm_parameters_prefix }}/{{ ec2.tags["Name"] }}'
-  when: ssm_parameters_path is not defined
 
 - name: Set SSM parameters database path facts
   set_fact:


### PR DESCRIPTION
Removing a when clause on setting SSM parameter path as this can cause a problem if a EC2 instance is using parameters across different SSM paths, e.g. both /database/oem-a/ and /oem/oem-a/
There's a separate ticket to sort out the SSM parameters as the current structure is getting difficult to manage, and wasn't really designed to support what Sandhya is implementing.
Also corrected typo on a tag.