### PR TITLE
fix selinux policy setting

### DIFF
--- a/ansible/roles/collectd/tasks/collectd_selinux_policy.yml
+++ b/ansible/roles/collectd/tasks/collectd_selinux_policy.yml
@@ -20,13 +20,13 @@
       become: true
       changed_when: false # don't want to fail if no selinux AVC rules are found for collectd
 
-    - name: check if selinux policy file exists (Rhel 6)
+    - name: check if selinux policy file exists
       become: true
       ansible.builtin.stat:
         path: /opt/collectd/collectd_selinux_policy.te
       register: te_file
 
-    - name: convert and compile .te policy (RHEL 6) to .pp policy
+    - name: convert and compile .te policy to .pp policy
       ansible.builtin.shell: |
         checkmodule -M -m -o /opt/collectd/collectd_selinux_policy.mod /opt/collectd/collectd_selinux_policy.te
         semodule_package -o /opt/collectd/collectd_selinux_policy.pp -m /opt/collectd/collectd_selinux_policy.mod

--- a/ansible/roles/collectd/tasks/collectd_selinux_policy.yml
+++ b/ansible/roles/collectd/tasks/collectd_selinux_policy.yml
@@ -15,46 +15,34 @@
       ansible.builtin.shell: |
         result=$(grep 'AVC.*collectd\|collectd.*AVC' /var/log/audit/audit.log)
         if [[ $result ]]; then
-          echo "$result" | audit2allow -a -M collectd_selinux_policy
+          echo "$result" | audit2allow -m collectd_selinux_policy > /opt/collectd/collectd_selinux_policy.te
         fi
-      args:
-        chdir: ~ # policy file needs to be created/written in an "allowed" directory
       become: true
       changed_when: false # don't want to fail if no selinux AVC rules are found for collectd
 
     - name: check if selinux policy file exists (Rhel 6)
+      become: true
       ansible.builtin.stat:
-        path: ./collectd_selinux_policy.te
+        path: /opt/collectd/collectd_selinux_policy.te
       register: te_file
 
     - name: convert and compile .te policy (RHEL 6) to .pp policy
       ansible.builtin.shell: |
-        checkmodule -M -m -o collectd_selinux_policy.mod collectd_selinux_policy.te
-        semodule_package -o collectd_selinux_policy.pp -m collectd_selinux_policy.mod
+        checkmodule -M -m -o /opt/collectd/collectd_selinux_policy.mod /opt/collectd/collectd_selinux_policy.te
+        semodule_package -o /opt/collectd/collectd_selinux_policy.pp -m /opt/collectd/collectd_selinux_policy.mod
       become: true
-      args:
-        chdir: ~
       when: te_file.stat.exists
 
     - name: Check if .pp file exists (RHEL 7+)
       stat:
-        path: ./collectd_selinux_policy.pp
+        path: /opt/collectd/collectd_selinux_policy.pp
       register: pp_file
 
     - name: Load .pp policy (RHEL 6 or 7+)
       ansible.builtin.shell: |
-        semodule -i collectd_selinux_policy.pp
+        semodule -i /opt/collectd/collectd_selinux_policy.pp
       become: true
-      args:
-        chdir: ~
       when: pp_file.stat.exists
-
-    # seems this step is also needed to allow collectd to run without selinux errors
-    - name: set selinux policy for collectd_t to permissive
-      ansible.builtin.command: semanage permissive -a collectd_t
-      become: true
-      changed_when: false
-      ignore_errors: true
 
     - name: restart collectd after policy on Rhel 6
       ansible.builtin.command: service collectd restart


### PR DESCRIPTION
- outputs selinux policy to a .te file (which is human readable)
- when this has been run on nomis-weblogic (rhel 6 instances) on Monday a.m. we can change this role to reference a file 
   - this will remove the 'gather exceptions' step entirely from the code and save us 3 minutes + of waiting about