### PR TITLE
fix weblogic deployment role

### DIFF
--- a/ansible/roles/nomis-release-deployment/tasks/main.yml
+++ b/ansible/roles/nomis-release-deployment/tasks/main.yml
@@ -32,35 +32,12 @@
 
 # - name: Stop streams (Import oracle-streams role, WIP)
 
-- name: APP - Copy script to deploy release on application server
-  ansible.builtin.template:
-    src: "tag_release_deployment.sh.j2"
-    dest: "{{ stage }}/tag_release_deployment.sh"
-    mode: 0700
-    owner: "{{ oracle_install_user }}"
-    group: "{{ oracle_install_group }}"
-  when: app_server_file.stat.exists
-  tags:
-    - ec2provision
-    - deploy_release
-
-- name: APP - Copy script to compile single form
-  ansible.builtin.template:
-    src: "compform.sh.j2"
-    dest: "/u01/tag/utils/scripts/compform.sh"
-    mode: 0700
-    owner: "{{ oracle_install_user }}"
-    group: "{{ oracle_install_group }}"
-  when: app_server_file.stat.exists
-  tags:
-    - ec2provision
-    - deploy_release
-
 - name: Deploy nomis releases
   ansible.builtin.include_tasks:
     file: nomis_deploy_release.yml
     apply:
       tags:
+        - ec2provision
         - deploy_release
   loop_control:
     loop_var: nomis_release

--- a/ansible/roles/nomis-release-deployment/tasks/nomis_deploy_release.yml
+++ b/ansible/roles/nomis-release-deployment/tasks/nomis_deploy_release.yml
@@ -28,6 +28,24 @@
   changed_when: false
   register: db_release_status
 
+- name: APP - Copy script to deploy release on application server
+  ansible.builtin.template:
+    src: "tag_release_deployment.sh.j2"
+    dest: "{{ stage }}/tag_release_deployment.sh"
+    mode: 0700
+    owner: "{{ oracle_install_user }}"
+    group: "{{ oracle_install_group }}"
+  when: app_server_file.stat.exists
+
+- name: APP - Copy script to compile single form
+  ansible.builtin.template:
+    src: "compform.sh.j2"
+    dest: "/u01/tag/utils/scripts/compform.sh"
+    mode: 0700
+    owner: "{{ oracle_install_user }}"
+    group: "{{ oracle_install_group }}"
+  when: app_server_file.stat.exists
+
 - name: Deploy release {{ nomis_release.name }} on database server
   block:
     - name: Download {{ nomis_release.name }} release on db server


### PR DESCRIPTION
Fixes to nomis weblogic deployment role
- add missing tag
- copy scripts after the step which creates the directory