### PR TITLE
DSOS-2097: update dns search domains for OEM

### DIFF
--- a/ansible/group_vars/environment_name_corporate_staff_rostering_development.yml
+++ b/ansible/group_vars/environment_name_corporate_staff_rostering_development.yml
@@ -2,3 +2,6 @@
 ansible_aws_ssm_bucket_name: s3-bucket20230609090952135600000001
 image_builder_s3_bucket_name: csr-software20230609090942172100000002
 dns_zone_internal: corporate-staff-rostering.hmpps-development.modernisation-platform.internal
+dns_search_domains:
+  - hmpps-oem.hmpps-development.modernisation-platform.internal
+  - azure.noms.root

--- a/ansible/group_vars/environment_name_corporate_staff_rostering_preproduction.yml
+++ b/ansible/group_vars/environment_name_corporate_staff_rostering_preproduction.yml
@@ -2,3 +2,6 @@
 ansible_aws_ssm_bucket_name: s3-bucket20230609110811735400000001
 image_builder_s3_bucket_name: csr-software20230609090942172100000002
 dns_zone_internal: corporate-staff-rostering.hmpps-preproduction.modernisation-platform.internal
+dns_search_domains:
+  - hmpps-oem.hmpps-preproduction.modernisation-platform.internal
+  - azure.hmpp.root

--- a/ansible/group_vars/environment_name_corporate_staff_rostering_production.yml
+++ b/ansible/group_vars/environment_name_corporate_staff_rostering_production.yml
@@ -2,3 +2,6 @@
 ansible_aws_ssm_bucket_name: s3-bucket20230609110809465800000001
 image_builder_s3_bucket_name: csr-software20230609090942172100000002
 dns_zone_internal: corporate-staff-rostering.hmpps-production.modernisation-platform.internal
+dns_search_domains:
+  - hmpps-oem.hmpps-production.modernisation-platform.internal
+  - azure.hmpp.root

--- a/ansible/group_vars/environment_name_corporate_staff_rostering_test.yml
+++ b/ansible/group_vars/environment_name_corporate_staff_rostering_test.yml
@@ -2,6 +2,9 @@
 ansible_aws_ssm_bucket_name: s3-bucket20230609090941956900000001
 image_builder_s3_bucket_name: csr-software20230609090942172100000002
 dns_zone_internal: corporate-staff-rostering.hmpps-test.modernisation-platform.internal
+dns_search_domains:
+  - hmpps-oem.hmpps-test.modernisation-platform.internal
+  - azure.noms.root
 
 # OEM server
 OMS_SERVER: test-oem-a.hmpps-oem.hmpps-test.modernisation-platform.internal

--- a/ansible/group_vars/environment_name_hmpps_oem_development.yml
+++ b/ansible/group_vars/environment_name_hmpps_oem_development.yml
@@ -2,3 +2,9 @@
 ansible_aws_ssm_bucket_name: s3-bucket20230608141801676400000001
 image_builder_s3_bucket_name: hmpps-oem-software20230608132809146600000002
 dns_zone_internal: hmpps-oem.hmpps-development.modernisation-platform.internal
+dns_search_domains:
+  - nomis.hmpps-development.modernisation-platform.internal
+  - oasys.hmpps-development.modernisation-platform.internal
+  - nomis-combined-reporting.hmpps-development.modernisation-platform.internal
+  - corporate-staff-rostering.hmpps-development.modernisation-platform.internal
+  - azure.noms.root

--- a/ansible/group_vars/environment_name_hmpps_oem_preproduction.yml
+++ b/ansible/group_vars/environment_name_hmpps_oem_preproduction.yml
@@ -2,3 +2,9 @@
 ansible_aws_ssm_bucket_name: s3-bucket20230608143839074500000001
 image_builder_s3_bucket_name: hmpps-oem-software20230608132809146600000002
 dns_zone_internal: hmpps-oem.hmpps-preproduction.modernisation-platform.internal
+dns_search_domains:
+  - nomis.hmpps-preproduction.modernisation-platform.internal
+  - oasys.hmpps-preproduction.modernisation-platform.internal
+  - nomis-combined-reporting.hmpps-preproduction.modernisation-platform.internal
+  - corporate-staff-rostering.hmpps-preproduction.modernisation-platform.internal
+  - azure.hmpp.root

--- a/ansible/group_vars/environment_name_hmpps_oem_production.yml
+++ b/ansible/group_vars/environment_name_hmpps_oem_production.yml
@@ -2,3 +2,9 @@
 ansible_aws_ssm_bucket_name: s3-bucket20230608143835254200000001
 image_builder_s3_bucket_name: hmpps-oem-software20230608132809146600000002
 dns_zone_internal: hmpps-oem.hmpps-production.modernisation-platform.internal
+dns_search_domains:
+  - nomis.hmpps-production.modernisation-platform.internal
+  - oasys.hmpps-production.modernisation-platform.internal
+  - nomis-combined-reporting.hmpps-production.modernisation-platform.internal
+  - corporate-staff-rostering.hmpps-production.modernisation-platform.internal
+  - azure.hmpp.root

--- a/ansible/group_vars/environment_name_hmpps_oem_test.yml
+++ b/ansible/group_vars/environment_name_hmpps_oem_test.yml
@@ -3,6 +3,12 @@ ansible_aws_ssm_bucket_name: s3-bucket20230608132808605000000001
 image_builder_s3_bucket_name: hmpps-oem-software20230608132809146600000002
 db_backup_s3_bucket_name: devtest-hmpps-oem-db-backup-bucket-20230801085755707000000001
 dns_zone_internal: hmpps-oem.hmpps-test.modernisation-platform.internal
+dns_search_domains:
+  - nomis.hmpps-test.modernisation-platform.internal
+  - oasys.hmpps-test.modernisation-platform.internal
+  - nomis-combined-reporting.hmpps-test.modernisation-platform.internal
+  - corporate-staff-rostering.hmpps-test.modernisation-platform.internal
+  - azure.noms.root
 emrepo: EMREP
 rcvcat: RCVCAT
 

--- a/ansible/group_vars/environment_name_nomis_combined_reporting_development.yml
+++ b/ansible/group_vars/environment_name_nomis_combined_reporting_development.yml
@@ -2,3 +2,6 @@
 ansible_aws_ssm_bucket_name: s3-bucket20230228122737682700000001
 image_builder_s3_bucket_name: nomis-combined-reporting-software20230330140932343400000001
 dns_zone_internal: nomis-combined-reporting.hmpps-development.modernisation-platform.internal
+dns_search_domains:
+  - hmpps-oem.hmpps-development.modernisation-platform.internal
+  - azure.noms.root

--- a/ansible/group_vars/environment_name_nomis_combined_reporting_preproduction.yml
+++ b/ansible/group_vars/environment_name_nomis_combined_reporting_preproduction.yml
@@ -2,3 +2,6 @@
 ansible_aws_ssm_bucket_name: s3-bucket20230301111337484000000001
 image_builder_s3_bucket_name: nomis-combined-reporting-software20230330140932343400000001
 dns_zone_internal: nomis-combined-reporting.hmpps-preproduction.modernisation-platform.internal
+dns_search_domains:
+  - hmpps-oem.hmpps-preproduction.modernisation-platform.internal
+  - azure.hmpp.root

--- a/ansible/group_vars/environment_name_nomis_combined_reporting_production.yml
+++ b/ansible/group_vars/environment_name_nomis_combined_reporting_production.yml
@@ -2,3 +2,6 @@
 ansible_aws_ssm_bucket_name: s3-bucket20230301110833610700000001
 image_builder_s3_bucket_name: nomis-combined-reporting-software20230330140932343400000001
 dns_zone_internal: nomis-combined-reporting.hmpps-production.modernisation-platform.internal
+dns_search_domains:
+  - hmpps-oem.hmpps-production.modernisation-platform.internal
+  - azure.hmpp.root

--- a/ansible/group_vars/environment_name_nomis_combined_reporting_test.yml
+++ b/ansible/group_vars/environment_name_nomis_combined_reporting_test.yml
@@ -3,6 +3,9 @@ ansible_aws_ssm_bucket_name: s3-bucket20230301110846292900000001
 db_backup_s3_bucket_name: ncr-db-backup-bucket20230815134351976500000003
 image_builder_s3_bucket_name: nomis-combined-reporting-software20230330140932343400000001
 dns_zone_internal: nomis-combined-reporting.hmpps-test.modernisation-platform.internal
+dns_search_domains:
+  - hmpps-oem.hmpps-test.modernisation-platform.internal
+  - azure.noms.root
 
 database_home: /u01/app/oracle/product/19c/db_1
 oracle_path: /usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/home/oracle/.local/bin:/home/oracle/bin

--- a/ansible/group_vars/environment_name_nomis_development.yml
+++ b/ansible/group_vars/environment_name_nomis_development.yml
@@ -4,4 +4,5 @@ db_backup_s3_bucket_name: nomis-db-backup-bucket20220916125226300100000009
 image_builder_s3_bucket_name: ec2-image-builder-nomis20220314103938567000000001
 dns_zone_internal: nomis.hmpps-development.modernisation-platform.internal
 dns_search_domains:
+  - hmpps-oem.hmpps-development.modernisation-platform.internal
   - azure.noms.root

--- a/ansible/group_vars/environment_name_nomis_preproduction.yml
+++ b/ansible/group_vars/environment_name_nomis_preproduction.yml
@@ -4,4 +4,5 @@ db_backup_s3_bucket_name: nomis-db-backup-bucket20220929161940860900000005
 image_builder_s3_bucket_name: ec2-image-builder-nomis20220314103938567000000001
 dns_zone_internal: nomis.hmpps-preproduction.modernisation-platform.internal
 dns_search_domains:
+  - hmpps-oem.hmpps-preproduction.modernisation-platform.internal
   - azure.hmpp.root

--- a/ansible/group_vars/environment_name_nomis_production.yml
+++ b/ansible/group_vars/environment_name_nomis_production.yml
@@ -4,4 +4,5 @@ db_backup_s3_bucket_name: nomis-db-backup-bucket20220427111226918600000001
 image_builder_s3_bucket_name: ec2-image-builder-nomis20220314103938567000000001
 dns_zone_internal: nomis.hmpps-production.modernisation-platform.internal
 dns_search_domains:
+  - hmpps-oem.hmpps-production.modernisation-platform.internal
   - azure.hmpp.root

--- a/ansible/group_vars/environment_name_nomis_test.yml
+++ b/ansible/group_vars/environment_name_nomis_test.yml
@@ -4,6 +4,7 @@ db_backup_s3_bucket_name: nomis-db-backup-bucket20220131102905687200000001
 image_builder_s3_bucket_name: ec2-image-builder-nomis20220314103938567000000001
 dns_zone_internal: nomis.hmpps-test.modernisation-platform.internal
 dns_search_domains:
+  - hmpps-oem.hmpps-test.modernisation-platform.internal
   - azure.noms.root
 
 # OEM server

--- a/ansible/group_vars/environment_name_oasys_development.yml
+++ b/ansible/group_vars/environment_name_oasys_development.yml
@@ -2,4 +2,7 @@
 ansible_aws_ssm_bucket_name: oasys-development20230403093252068800000001
 image_builder_s3_bucket_name: devtest-oasys-20230411143832198800000001
 dns_zone_internal: oasys.hmpps-development.modernisation-platform.internal
+dns_search_domains:
+  - hmpps-oem.hmpps-development.modernisation-platform.internal
+  - azure.noms.root
 s3_bucket: devtest-oasys-20230411143832198800000001

--- a/ansible/group_vars/environment_name_oasys_preproduction.yml
+++ b/ansible/group_vars/environment_name_oasys_preproduction.yml
@@ -2,6 +2,9 @@
 ansible_aws_ssm_bucket_name: oasys-preproduction20230403093924275400000001
 image_builder_s3_bucket_name: prodpreprod-oasys-20230412084245180100000001
 dns_zone_internal: oasys.hmpps-preproduction.modernisation-platform.internal
+dns_search_domains:
+  - hmpps-oem.hmpps-preproduction.modernisation-platform.internal
+  - azure.hmpp.root
 s3_bucket: prodpreprod-oasys-20230412084245180100000001
 
 ords_trusted_origins:

--- a/ansible/group_vars/environment_name_oasys_production.yml
+++ b/ansible/group_vars/environment_name_oasys_production.yml
@@ -2,6 +2,9 @@
 ansible_aws_ssm_bucket_name: oasys-production20230403093924372800000001
 image_builder_s3_bucket_name: prodpreprod-oasys-20230412084245180100000001
 dns_zone_internal: oasys.hmpps-production.modernisation-platform.internal
+dns_search_domains:
+  - hmpps-oem.hmpps-production.modernisation-platform.internal
+  - azure.hmpp.root
 s3_bucket: prodpreprod-oasys-20230412084245180100000001
 
 ords_trusted_origins:

--- a/ansible/group_vars/environment_name_oasys_test.yml
+++ b/ansible/group_vars/environment_name_oasys_test.yml
@@ -2,6 +2,9 @@
 ansible_aws_ssm_bucket_name: oasys-test20230403093247696000000001
 image_builder_s3_bucket_name: devtest-oasys-20230411143832198800000001
 dns_zone_internal: oasys.hmpps-test.modernisation-platform.internal
+dns_search_domains:
+  - hmpps-oem.hmpps-test.modernisation-platform.internal
+  - azure.noms.root
 s3_bucket: devtest-oasys-20230411143832198800000001
 db_backup_s3_bucket_name: devtest-oasys-db-backup-bucket-20230721145548176300000001
 


### PR DESCRIPTION
OEM needs to be able to resolve database names using hostname only without FQDN.  Databases need to be able to resolve the OEM server using its hostname without FQDN.  Easiest way is to add the OEM domain to the database search domains.  And for OEM, we need to include all application domains.  Also added the relevant FixNGo domains.