### PR TITLE
DSOS-2123: setup oem secretmanager secrets

### DIFF
--- a/ansible/group_vars/environment_name_corporate_staff_rostering_development.yml
+++ b/ansible/group_vars/environment_name_corporate_staff_rostering_development.yml
@@ -1,4 +1,6 @@
 ---
+application: corporate-staff-rostering
+aws_environment: development
 ansible_aws_ssm_bucket_name: s3-bucket20230609090952135600000001
 image_builder_s3_bucket_name: csr-software20230609090942172100000002
 dns_zone_internal: corporate-staff-rostering.hmpps-development.modernisation-platform.internal

--- a/ansible/group_vars/environment_name_corporate_staff_rostering_preproduction.yml
+++ b/ansible/group_vars/environment_name_corporate_staff_rostering_preproduction.yml
@@ -1,4 +1,6 @@
 ---
+application: corporate-staff-rostering
+aws_environment: preproduction
 ansible_aws_ssm_bucket_name: s3-bucket20230609110811735400000001
 image_builder_s3_bucket_name: csr-software20230609090942172100000002
 dns_zone_internal: corporate-staff-rostering.hmpps-preproduction.modernisation-platform.internal

--- a/ansible/group_vars/environment_name_corporate_staff_rostering_production.yml
+++ b/ansible/group_vars/environment_name_corporate_staff_rostering_production.yml
@@ -1,4 +1,6 @@
 ---
+application: corporate-staff-rostering
+aws_environment: production
 ansible_aws_ssm_bucket_name: s3-bucket20230609110809465800000001
 image_builder_s3_bucket_name: csr-software20230609090942172100000002
 dns_zone_internal: corporate-staff-rostering.hmpps-production.modernisation-platform.internal

--- a/ansible/group_vars/environment_name_corporate_staff_rostering_test.yml
+++ b/ansible/group_vars/environment_name_corporate_staff_rostering_test.yml
@@ -1,4 +1,6 @@
 ---
+application: corporate-staff-rostering
+aws_environment: test
 ansible_aws_ssm_bucket_name: s3-bucket20230609090941956900000001
 image_builder_s3_bucket_name: csr-software20230609090942172100000002
 db_backup_s3_bucket_name: csr-db-backup-bucket20230822131811925900000001

--- a/ansible/group_vars/environment_name_hmpps_oem_development.yml
+++ b/ansible/group_vars/environment_name_hmpps_oem_development.yml
@@ -1,4 +1,6 @@
 ---
+application: hmpps-oem
+aws_environment: development
 ansible_aws_ssm_bucket_name: s3-bucket20230608141801676400000001
 image_builder_s3_bucket_name: hmpps-oem-software20230608132809146600000002
 dns_zone_internal: hmpps-oem.hmpps-development.modernisation-platform.internal

--- a/ansible/group_vars/environment_name_hmpps_oem_preproduction.yml
+++ b/ansible/group_vars/environment_name_hmpps_oem_preproduction.yml
@@ -1,4 +1,6 @@
 ---
+application: hmpps-oem
+aws_environment: preproduction
 ansible_aws_ssm_bucket_name: s3-bucket20230608143839074500000001
 image_builder_s3_bucket_name: hmpps-oem-software20230608132809146600000002
 dns_zone_internal: hmpps-oem.hmpps-preproduction.modernisation-platform.internal

--- a/ansible/group_vars/environment_name_hmpps_oem_production.yml
+++ b/ansible/group_vars/environment_name_hmpps_oem_production.yml
@@ -1,4 +1,6 @@
 ---
+application: hmpps-oem
+aws_environment: production
 ansible_aws_ssm_bucket_name: s3-bucket20230608143835254200000001
 image_builder_s3_bucket_name: hmpps-oem-software20230608132809146600000002
 dns_zone_internal: hmpps-oem.hmpps-production.modernisation-platform.internal

--- a/ansible/group_vars/environment_name_hmpps_oem_test.yml
+++ b/ansible/group_vars/environment_name_hmpps_oem_test.yml
@@ -1,4 +1,6 @@
 ---
+application: hmpps-oem
+aws_environment: test
 ansible_aws_ssm_bucket_name: s3-bucket20230608132808605000000001
 image_builder_s3_bucket_name: hmpps-oem-software20230608132809146600000002
 db_backup_s3_bucket_name: devtest-hmpps-oem-db-backup-bucket-20230801085755707000000001

--- a/ansible/group_vars/environment_name_nomis_combined_reporting_development.yml
+++ b/ansible/group_vars/environment_name_nomis_combined_reporting_development.yml
@@ -1,4 +1,6 @@
 ---
+application: nomis-combined-reporting
+aws_environment: development
 ansible_aws_ssm_bucket_name: s3-bucket20230228122737682700000001
 image_builder_s3_bucket_name: nomis-combined-reporting-software20230330140932343400000001
 dns_zone_internal: nomis-combined-reporting.hmpps-development.modernisation-platform.internal

--- a/ansible/group_vars/environment_name_nomis_combined_reporting_preproduction.yml
+++ b/ansible/group_vars/environment_name_nomis_combined_reporting_preproduction.yml
@@ -1,4 +1,6 @@
 ---
+application: nomis-combined-reporting
+aws_environment: preproduction
 ansible_aws_ssm_bucket_name: s3-bucket20230301111337484000000001
 image_builder_s3_bucket_name: nomis-combined-reporting-software20230330140932343400000001
 dns_zone_internal: nomis-combined-reporting.hmpps-preproduction.modernisation-platform.internal

--- a/ansible/group_vars/environment_name_nomis_combined_reporting_production.yml
+++ b/ansible/group_vars/environment_name_nomis_combined_reporting_production.yml
@@ -1,4 +1,6 @@
 ---
+application: nomis-combined-reporting
+aws_environment: production
 ansible_aws_ssm_bucket_name: s3-bucket20230301110833610700000001
 image_builder_s3_bucket_name: nomis-combined-reporting-software20230330140932343400000001
 dns_zone_internal: nomis-combined-reporting.hmpps-production.modernisation-platform.internal

--- a/ansible/group_vars/environment_name_nomis_combined_reporting_test.yml
+++ b/ansible/group_vars/environment_name_nomis_combined_reporting_test.yml
@@ -1,4 +1,6 @@
 ---
+application: nomis-combined-reporting
+aws_environment: test
 ansible_aws_ssm_bucket_name: s3-bucket20230301110846292900000001
 db_backup_s3_bucket_name: ncr-db-backup-bucket20230815134351976500000003
 image_builder_s3_bucket_name: nomis-combined-reporting-software20230330140932343400000001

--- a/ansible/roles/get-modernisation-platform-facts/README.md
+++ b/ansible/roles/get-modernisation-platform-facts/README.md
@@ -1,0 +1,16 @@
+Role for retrieving common modernisation platform secrets and SSM parameters.
+
+Variables are set as follows:
+- `modernisation_platform_account_id` is the account ID for `modernisation_platform` account
+- `environment_management_secret` is the `environment_management` secret
+- `account_ids` is a map of account IDs where account name is the key.  Part of the `environment_management` secret.
+
+Use this if you need to reference resources from other accounts.  For example:
+
+```
+- set_fact:
+     mypassword_secret_id: "arn:aws:secretsmanager:eu-west-2:{{ account_ids['nomis-test'] }}:secret:mypassword"
+
+- set_fact:
+     mypassword_secret: "{{ lookup('amazon.aws.aws_secret', mypassword_secret_id, region='eu-west-2') }}"
+```

--- a/ansible/roles/get-modernisation-platform-facts/tasks/get-facts.yml
+++ b/ansible/roles/get-modernisation-platform-facts/tasks/get-facts.yml
@@ -1,0 +1,20 @@
+---
+# Ensure EC2 includes arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore or a policy with ssm:GetParameter 
+- name: Get modernisation_platform_account_id SSM parameter
+  set_fact:
+    modernisation_platform_account_id: "{{ lookup('aws_ssm', 'modernisation_platform_account_id', region='eu-west-2') }}"
+  failed_when: modernisation_platform_account_id|length < 12
+
+- name: Get environment_management SecretsManager Secret Id
+  set_fact:
+    environment_management_secret_id: "arn:aws:secretsmanager:eu-west-2:{{ modernisation_platform_account_id }}:secret:environment_management"
+
+# The secret is shared with all accounts, the EC2 should have access without any extra policies.
+- name: Get environment_maangement SecretsManager Secret
+  set_fact:
+    environment_management_secret: "{{ lookup('amazon.aws.aws_secret', environment_management_secret_id, region='eu-west-2') }}"
+  failed_when: environment_management_secret|length < 2
+  
+- name: Get account_ids JSON 
+  set_fact:
+    account_ids: "{{ environment_management_secret.account_ids }}"

--- a/ansible/roles/get-modernisation-platform-facts/tasks/get-facts.yml
+++ b/ansible/roles/get-modernisation-platform-facts/tasks/get-facts.yml
@@ -1,5 +1,5 @@
 ---
-# Ensure EC2 includes arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore or a policy with ssm:GetParameter 
+# Ensure EC2 includes arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore or a policy with ssm:GetParameter
 - name: Get modernisation_platform_account_id SSM parameter
   set_fact:
     modernisation_platform_account_id: "{{ lookup('aws_ssm', 'modernisation_platform_account_id', region='eu-west-2') }}"
@@ -14,7 +14,7 @@
   set_fact:
     environment_management_secret: "{{ lookup('amazon.aws.aws_secret', environment_management_secret_id, region='eu-west-2') }}"
   failed_when: environment_management_secret|length < 2
-  
-- name: Get account_ids JSON 
+
+- name: Get account_ids JSON
   set_fact:
     account_ids: "{{ environment_management_secret.account_ids }}"

--- a/ansible/roles/get-modernisation-platform-facts/tasks/main.yml
+++ b/ansible/roles/get-modernisation-platform-facts/tasks/main.yml
@@ -1,0 +1,4 @@
+---
+- import_tasks: get-facts.yml
+  tags:
+    - always

--- a/ansible/roles/oracle-oem-agent-setup/defaults/main.yml
+++ b/ansible/roles/oracle-oem-agent-setup/defaults/main.yml
@@ -1,7 +1,6 @@
 ---
 artefacts_s3_bucket_name: mod-platform-image-artefact-bucket20230203091453221500000001
 artefacts_s3_bucket_path: hmpps/oracle-oem-135
-ssm_parameters_prefix: oem
 oracle_inventory: /u01/app/oraInventory
 app_dir: /u01/app/oracle/product
 oem_agent_base: "{{ app_dir }}/oem-agent"
@@ -15,3 +14,14 @@ agent_ru_patch_number: 35437910
 agentpatcher_patch: p33355570_135000_Generic.zip
 agentpatcher_version: 13.9.5.5.0
 agent_home: "{{ oem_agent_base }}/agent_13.5.0.0.0"
+oem_secretsmanager_secrets:
+  - key: "oem_passwords"
+    account_name: "hmpps-oem-{{ environment }}"
+    secret: "/ec2/oracle/oem/passwords"
+    users:
+      - agentreg:
+  - key: "emrep_passwords"
+    account_name: "hmpps-oem-{{ environment }}"
+    secret: "/ec2/oracle/database/EMREP/passwords"
+    users:
+      - sysman:

--- a/ansible/roles/oracle-oem-agent-setup/defaults/main.yml
+++ b/ansible/roles/oracle-oem-agent-setup/defaults/main.yml
@@ -17,11 +17,11 @@ agent_home: "{{ oem_agent_base }}/agent_13.5.0.0.0"
 oem_secretsmanager_secrets:
   - key: "oem_passwords"
     account_name: "hmpps-oem-{{ aws_environment }}"
-    secret: "/ec2/oracle/oem/passwords"
+    secret: "/oracle/oem/passwords"
     users:
       - agentreg:
   - key: "emrep_passwords"
     account_name: "hmpps-oem-{{ aws_environment }}"
-    secret: "/ec2/oracle/database/EMREP/passwords"
+    secret: "/oracle/database/EMREP/passwords"
     users:
       - sysman:

--- a/ansible/roles/oracle-oem-agent-setup/defaults/main.yml
+++ b/ansible/roles/oracle-oem-agent-setup/defaults/main.yml
@@ -16,12 +16,12 @@ agentpatcher_version: 13.9.5.5.0
 agent_home: "{{ oem_agent_base }}/agent_13.5.0.0.0"
 oem_secretsmanager_secrets:
   - key: "oem_passwords"
-    account_name: "hmpps-oem-{{ environment }}"
+    account_name: "hmpps-oem-{{ aws_environment }}"
     secret: "/ec2/oracle/oem/passwords"
     users:
       - agentreg:
   - key: "emrep_passwords"
-    account_name: "hmpps-oem-{{ environment }}"
+    account_name: "hmpps-oem-{{ aws_environment }}"
     secret: "/ec2/oracle/database/EMREP/passwords"
     users:
       - sysman:

--- a/ansible/roles/oracle-oem-agent-setup/tasks/get_facts.yml
+++ b/ansible/roles/oracle-oem-agent-setup/tasks/get_facts.yml
@@ -1,19 +1,22 @@
 ---
+- name: Get OEM secrets
+  import_role:
+    name: secretsmanager-passwords
+  vars:
+    secretsmanager_passwords: "{{ oem_secretsmanager_secrets }}"
+
 - name: Set SSM parameters path fact from ec2 ssm-parameters-prefix and Name tag
   set_fact:
-    ssm_parameters_path: "/{{ ssm_parameters_prefix }}"
     db_ssm_parameters_path: '/database/{{ ec2.tags["Name"] }}'
 
 - name: Set SSM parameters database path facts
   set_fact:
-    ssm_parameters_path_oem_sysman_password: "{{ ssm_parameters_path }}/sysmanpassword"
-    ssm_parameters_path_oem_agent_registration_password: "{{ ssm_parameters_path }}/agentregpassword"
     ssm_parameter_path_asmsnmp_password: "{{ db_ssm_parameters_path }}/ASMSNMP"
 
 - name: Get SSM parameters
   set_fact:
-    oem_sysman_password: "{{ lookup('aws_ssm', ssm_parameters_path_oem_sysman_password, region=ansible_ec2_placement_region) }}"
-    oem_agent_password: "{{ lookup('aws_ssm', ssm_parameters_path_oem_agent_registration_password, region=ansible_ec2_placement_region) }}"
+    oem_sysman_password: "{{ secretsmanager_passwords_dict['emrep_passwords'].passwords['sysman'] }}"
+    oem_agent_password: "{{ secretsmanager_passwords_dict['oem_passwords'].passwords['agentreg'] }}"
     asmsnmp_password: "{{ lookup('aws_ssm', ssm_parameter_path_asmsnmp_password, region=ansible_ec2_placement_region) }}"
 
 - name: Get private ip address of the ec2 instance

--- a/ansible/roles/secretsmanager-passwords/README.md
+++ b/ansible/roles/secretsmanager-passwords/README.md
@@ -49,3 +49,12 @@ The role will automatically generate passwords and update the
 secret value.
 
 See OEM secrets for an example of how this is used in practice.
+
+3. Force re-generation of password
+
+You can force a re-generation of password by including the secret key and username
+in the `secretmanager_passwords_force_rotate` variable.  For example:
+
+```
+ansible-playbook site.yml -e role=oracle-oem-agent-setup -e secretmanager_passwords_force_rotate=emrep_passwords:sysman --limit test-oem-a
+```

--- a/ansible/roles/secretsmanager-passwords/README.md
+++ b/ansible/roles/secretsmanager-passwords/README.md
@@ -1,0 +1,51 @@
+# SecretsManager Passwords
+
+Use this role to retrieve and/or automatically generate passwords stored in SecretsManager Secrets.
+
+The secret itself is a JSON with following structure:
+
+```
+{
+  "username1": "password1",
+  "username2": "password2"
+}
+```
+
+## Recommended Usage
+
+1. Set placeholder value in terraform
+
+Create a "placeholder" SecretsManager Secret in terraform.
+Include the word "placeholder" in the value set by terraform.
+Set lifecycle to ignore value changes.
+
+2. Configure ansible to use this role
+
+Either use `import_role` in the relevant place, or include the
+role in the `role_list` for the server.  Define the `secretsmanager_passwords`
+variable accordingly (define `account_name` if the secret is from another
+account.)
+Ensure the secret has been shared with EC2 instances in this account.
+
+```
+- name: Get OEM secrets
+  import_role:
+    name: secretsmanager-passwords
+  vars:
+    secretsmanager_passwords:
+      - key: "oem_passwords"
+        account_name: "hmpps-oem-{{ environment }}"
+        secret: "/ec2/oracle/oem/passwords"
+        users:
+          - agentreg:
+      - key: "emrep_passwords"
+        account_name: "hmpps-oem-{{ environment }}"
+        secret: "/ec2/oracle/database/EMREP/passwords"
+        users:
+          - sysman:
+```
+
+The role will automatically generate passwords and update the
+secret value.
+
+See OEM secrets for an example of how this is used in practice.

--- a/ansible/roles/secretsmanager-passwords/defaults/main.yml
+++ b/ansible/roles/secretsmanager-passwords/defaults/main.yml
@@ -1,0 +1,15 @@
+---
+secretmanager_passwords:  
+# - key: "unique_key_for_ansible_dictionary1" e.g. my_password
+#   account_name: "my-aws-account-name1"      e.g. hmpps-oem-test
+#   secret: "my-secretsmanager-secret-name1"  e.g. /ec2/oracle/oem/passwords"
+#   users:  # list of users and optional passwords (don't commit)
+#     - myuser1: myfixedvalue
+#     - myuser2
+# - key: "unique_key_for_ansible_dictionary2"
+#   account_name: "my-aws-account-name2"
+#   secret: "my-secretsmanager-secret-name2"
+#   users:
+#     - myuser3
+
+

--- a/ansible/roles/secretsmanager-passwords/defaults/main.yml
+++ b/ansible/roles/secretsmanager-passwords/defaults/main.yml
@@ -12,4 +12,5 @@ secretmanager_passwords:
 #   users:
 #     - myuser3
 
-
+secretmanager_passwords_force_rotate: ""
+# include the secret key and username to force rotation, e.g. "unique_key_for_ansible_dictionary1:myuser1"

--- a/ansible/roles/secretsmanager-passwords/defaults/main.yml
+++ b/ansible/roles/secretsmanager-passwords/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-secretmanager_passwords:  
+secretmanager_passwords:
 # - key: "unique_key_for_ansible_dictionary1" e.g. my_password
 #   account_name: "my-aws-account-name1"      e.g. hmpps-oem-test
 #   secret: "my-secretsmanager-secret-name1"  e.g. /ec2/oracle/oem/passwords"

--- a/ansible/roles/secretsmanager-passwords/meta/main.yml
+++ b/ansible/roles/secretsmanager-passwords/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - role: get-modernisation-platform-facts

--- a/ansible/roles/secretsmanager-passwords/tasks/main.yml
+++ b/ansible/roles/secretsmanager-passwords/tasks/main.yml
@@ -100,9 +100,10 @@
     label: "{{ item.key }}"
   loop: "{{ secretsmanager_passwords }}"
 
-# NOTE: if this fails, it might be because a password is marked as requiring
-# update in a different account to where the secret is stored.  Update
-# it in the account where the secret is stored instead
+# NOTE: if this fails, check a password isn't being updated in an account
+# that is different to where the secret is stored. If this is intentional,
+# the relevant IAM policies for updating secrets across accounts need
+# to be configured
 - name: Retrieve resource policy for any secrets requiring update
   ansible.builtin.shell: |
     if [[ {{ secretsmanager_passwords_dict[item.key].upload }} == True ]]; then
@@ -124,12 +125,19 @@
              'policy': item.stdout
            }
          }, recursive=true) }}
+  loop_control:
+    label: "{{ item.item.key }}"
   loop: "{{ secret_resource_policy.results }}"
 
 - name: Check secrets which require updating
   set_fact:
     secretsmanager_passwords_to_update: "{{ secretsmanager_passwords_dict | dict2items | selectattr('value.upload', 'equalto', true) }}"
 
+# - debug:
+#    var: secretsmanager_passwords_to_update
+
+# When I tested, if resource_policy wasn't set, the policy was cleared
+# and would need to be reset in terraform.  So attempting to set here.
 - name: Upload updated secrets
   community.aws.secretsmanager_secret:
     region: "eu-west-2"

--- a/ansible/roles/secretsmanager-passwords/tasks/main.yml
+++ b/ansible/roles/secretsmanager-passwords/tasks/main.yml
@@ -1,0 +1,113 @@
+---
+- name: Fail if account ids lookup table not defined
+  fail:
+    msg: "Account_ids lookup not found, please check get-modernisation-platform-facts role ran successfully"
+  when: account_ids is not defined
+
+- name: Setup facts
+  set_fact:
+    secretsmanager_passwords_dict: "{{ secretsmanager_passwords_dict|default({}) }}"
+    secretsmanager_passwords_self: "{{ secretsmanager_passwords | rejectattr('account_name', 'defined') }}"
+    secretsmanager_passwords_other: "{{ secretsmanager_passwords | selectattr('account_name', 'defined') }}"
+
+- name: Form Secret Ids - Self
+  set_fact:
+    secretsmanager_passwords_dict: |
+      {{ secretsmanager_passwords_dict | combine({
+           item.key: {
+               'id': item.secret
+           }
+         }, recursive=true) }}
+  loop_control:
+    label: "{{ item.key }}"
+  loop: "{{ secretsmanager_passwords_self }}"
+
+- name: Form Secret Ids - Other accounts
+  set_fact:
+    secretsmanager_passwords_dict: |
+      {{ secretsmanager_passwords_dict | combine({
+           item.key: {
+               'id': 'arn:aws:secretsmanager:eu-west-2:' + account_ids[item.account_name] + ':secret:' + item.secret
+           }
+         }, recursive=true) }}
+  loop_control:
+    label: "{{ item.key }}"
+  loop: "{{ secretsmanager_passwords_other }}"
+
+- name: Get SecretManager Secrets
+  set_fact:
+    secretsmanager_passwords_dict: |
+      {{ secretsmanager_passwords_dict | combine({
+           item.key: {
+             'value': lookup('amazon.aws.aws_secret', secretsmanager_passwords_dict[item.key].id, region='eu-west-2')
+           }
+         }, recursive=true) }}
+  loop_control:
+    label: "{{ item.key }}"
+  loop: "{{ secretsmanager_passwords }}"
+
+- name: Prepare any placeholder secrets
+  set_fact:
+    secretsmanager_passwords_dict: |
+      {{ secretsmanager_passwords_dict | combine({
+           item.key: {
+             'passwords': {} if 'placeholder' in secretsmanager_passwords_dict[item.key].value else secretsmanager_passwords_dict[item.key].value
+           }
+         }, recursive=true) }}
+  loop_control:
+    label: "{{ item.key }}"
+  loop: "{{ secretsmanager_passwords }}"
+
+# The if statement:
+# - use the password defined in the secretsmanager_passwords variable if there is one
+# - else use existing password defined in the secretsmanager_secret
+# - else generate random password
+- name: Generate any missing passwords
+  set_fact:
+    secretsmanager_passwords_dict: |
+      {{ secretsmanager_passwords_dict | combine({
+           item[0].key: {
+             'passwords': {
+               item[1].keys()|first:
+                 item[1].values()|first if item[1].values()|first != None
+                 else secretsmanager_passwords_dict[item[0].key].passwords[item[1].keys()|first] if item[1].keys()|first in secretsmanager_passwords_dict[item[0].key]
+                 else lookup('ansible.builtin.password', '/dev/null chars=ascii_letters length=1')
+                 + lookup('ansible.builtin.password', '/dev/null chars=ascii_letters,digits length=15')
+             }
+           }
+         }, recursive=true) }}
+  loop_control:
+    label: "{{ item[0].key }}:{{ item[0].secret }}:{{ item[1].keys()|first }}"
+  with_subelements:
+    - "{{ secretsmanager_passwords }}"
+    - users
+
+- name: Check secrets which require updating
+  set_fact:
+    secretsmanager_passwords_dict: |
+      {{ secretsmanager_passwords_dict | combine({
+           item.key: {
+               'upload': secretsmanager_passwords_dict[item.key].passwords != secretsmanager_passwords_dict[item.key].value
+           }
+         }, recursive=true) }}
+  loop_control:
+    label: "{{ item.key }}"
+  loop: "{{ secretsmanager_passwords }}"
+
+- debug:
+    var: secretsmanager_passwords_dict|dict2items
+
+- name: Check secrets which require da
+  set_fact:
+    secretsmanager_passwords_to_update: "{{ secretsmanager_passwords_dict | dict2items | selectattr('value.upload', 'equalto', true) }}"
+
+- debug:
+    var: secretsmanager_passwords_to_update
+
+- name: Only create a new secret, but do not update if alredy exists by name
+  community.aws.secretsmanager_secret:
+    name: item.value.id
+    secret_json: item.value.passwords
+  loop_control:
+    label: "{{ item.key }}"
+  loop: "{{ secretsmanager_passwords_to_update }}"

--- a/ansible/roles/secretsmanager-passwords/tasks/main.yml
+++ b/ansible/roles/secretsmanager-passwords/tasks/main.yml
@@ -10,6 +10,7 @@
     secretsmanager_passwords_self: "{{ secretsmanager_passwords | rejectattr('account_name', 'defined') }}"
     secretsmanager_passwords_other: "{{ secretsmanager_passwords | selectattr('account_name', 'defined') }}"
 
+# If this fails, ensure secret has been created via terraform first
 - name: Form Secret Ids - Self
   set_fact:
     secretsmanager_passwords_dict: |
@@ -22,6 +23,8 @@
     label: "{{ item.key }}"
   loop: "{{ secretsmanager_passwords_self }}"
 
+# If this fails, ensure secret has been created via terraform first and has been
+# shared into this account
 - name: Form Secret Ids - Other accounts
   set_fact:
     secretsmanager_passwords_dict: |
@@ -51,7 +54,7 @@
     secretsmanager_passwords_dict: |
       {{ secretsmanager_passwords_dict | combine({
            item.key: {
-             'passwords': {} if 'placeholder' in secretsmanager_passwords_dict[item.key].value else secretsmanager_passwords_dict[item.key].value
+             'passwords': {} if 'placeholder' in secretsmanager_passwords_dict[item.key].value else secretsmanager_passwords_dict[item.key].value|from_json
            }
          }, recursive=true) }}
   loop_control:
@@ -60,7 +63,7 @@
 
 # The if statement:
 # - use the password defined in the secretsmanager_passwords variable if there is one
-# - else use existing password defined in the secretsmanager_secret
+# - else use existing password defined in the secretsmanager_secret and force_rotate not set
 # - else generate random password
 - name: Generate any missing passwords
   set_fact:
@@ -69,15 +72,18 @@
            item[0].key: {
              'passwords': {
                item[1].keys()|first:
-                 item[1].values()|first if item[1].values()|first != None
-                 else secretsmanager_passwords_dict[item[0].key].passwords[item[1].keys()|first] if item[1].keys()|first in secretsmanager_passwords_dict[item[0].key]
+                 item[1].values()|first 
+                   if item[1].values()|first != None
+                 else secretsmanager_passwords_dict[item[0].key].passwords[item[1].keys()|first]
+                   if item[1].keys()|first in secretsmanager_passwords_dict[item[0].key].passwords 
+                   and [item[0].key, item[1].keys()|first]|join(':') not in secretmanager_passwords_force_rotate
                  else lookup('ansible.builtin.password', '/dev/null chars=ascii_letters length=1')
                  + lookup('ansible.builtin.password', '/dev/null chars=ascii_letters,digits length=15')
              }
            }
          }, recursive=true) }}
   loop_control:
-    label: "{{ item[0].key }}:{{ item[0].secret }}:{{ item[1].keys()|first }}"
+    label: "{{ item[0].key }}:{{ item[1].keys()|first }}"
   with_subelements:
     - "{{ secretsmanager_passwords }}"
     - users
@@ -87,27 +93,49 @@
     secretsmanager_passwords_dict: |
       {{ secretsmanager_passwords_dict | combine({
            item.key: {
-               'upload': secretsmanager_passwords_dict[item.key].passwords != secretsmanager_passwords_dict[item.key].value
+               'upload': secretsmanager_passwords_dict[item.key].passwords|to_json != secretsmanager_passwords_dict[item.key].value
            }
          }, recursive=true) }}
   loop_control:
     label: "{{ item.key }}"
   loop: "{{ secretsmanager_passwords }}"
 
-- debug:
-    var: secretsmanager_passwords_dict|dict2items
+# NOTE: if this fails, it might be because a password is marked as requiring
+# update in a different account to where the secret is stored.  Update
+# it in the account where the secret is stored instead
+- name: Retrieve resource policy for any secrets requiring update
+  ansible.builtin.shell: |
+    if [[ {{ secretsmanager_passwords_dict[item.key].upload }} == True ]]; then
+      PATH=$PATH:/usr/local/bin
+      aws secretsmanager get-resource-policy --secret-id "{{ secretsmanager_passwords_dict[item.key].id }}" --query ResourcePolicy --output text
+    fi
+  loop_control:
+    label: "{{ item.key }}"
+  loop: "{{ secretsmanager_passwords }}"
+  check_mode: false
+  changed_when: false
+  register: secret_resource_policy
 
-- name: Check secrets which require da
+- name: Add resource policy to fact
+  set_fact:
+    secretsmanager_passwords_dict: |
+      {{ secretsmanager_passwords_dict | combine({
+           item.item.key: {
+             'policy': item.stdout
+           }
+         }, recursive=true) }}
+  loop: "{{ secret_resource_policy.results }}"
+
+- name: Check secrets which require updating
   set_fact:
     secretsmanager_passwords_to_update: "{{ secretsmanager_passwords_dict | dict2items | selectattr('value.upload', 'equalto', true) }}"
 
-- debug:
-    var: secretsmanager_passwords_to_update
-
-- name: Only create a new secret, but do not update if alredy exists by name
+- name: Upload updated secrets
   community.aws.secretsmanager_secret:
-    name: item.value.id
-    secret_json: item.value.passwords
+    region: "eu-west-2"
+    name: "{{ item.value.id }}"
+    secret: "{{ item.value.passwords|to_json }}"
+    resource_policy: "{{ item.value.policy }}"
   loop_control:
     label: "{{ item.key }}"
   loop: "{{ secretsmanager_passwords_to_update }}"

--- a/ansible/roles/secretsmanager-passwords/tasks/main.yml
+++ b/ansible/roles/secretsmanager-passwords/tasks/main.yml
@@ -72,10 +72,10 @@
            item[0].key: {
              'passwords': {
                item[1].keys()|first:
-                 item[1].values()|first 
+                 item[1].values()|first
                    if item[1].values()|first != None
                  else secretsmanager_passwords_dict[item[0].key].passwords[item[1].keys()|first]
-                   if item[1].keys()|first in secretsmanager_passwords_dict[item[0].key].passwords 
+                   if item[1].keys()|first in secretsmanager_passwords_dict[item[0].key].passwords
                    and [item[0].key, item[1].keys()|first]|join(':') not in secretmanager_passwords_force_rotate
                  else lookup('ansible.builtin.password', '/dev/null chars=ascii_letters length=1')
                  + lookup('ansible.builtin.password', '/dev/null chars=ascii_letters,digits length=15')
@@ -147,3 +147,15 @@
   loop_control:
     label: "{{ item.key }}"
   loop: "{{ secretsmanager_passwords_to_update }}"
+
+- name: Update upload fact
+  set_fact:
+    secretsmanager_passwords_dict: |
+      {{ secretsmanager_passwords_dict | combine({
+           item.key: {
+               'upload': False
+           }
+         }, recursive=true) }}
+  loop_control:
+    label: "{{ item.key }}"
+  loop: "{{ secretsmanager_passwords }}"


### PR DESCRIPTION
Updated oracle-oem-agent-setup role to use SecretManager secrets instead of SSM Parameters
Added role to retrieve the other mod platform account details
Added role to auto-generate passwords and store as SecretManager secrets