### PR TITLE
Nomis: DSOS-2144: add debug to healthcheck script

### DIFF
--- a/ansible/roles/nomis-weblogic/templates/10.3/etc/healthcheck/healthcheck.sh
+++ b/ansible/roles/nomis-weblogic/templates/10.3/etc/healthcheck/healthcheck.sh
@@ -6,22 +6,24 @@ keepalive() {
 
 while true
 do
-    /etc/init.d/weblogic-all healthcheck > /dev/null 2>&1
+    output=$(/etc/init.d/weblogic-all healthcheck 2>&1)
     status=$?
     if [ $status -eq 1 ]
     then
         if [ -f "/u01/tag/static/keepalive.htm" ]
         then
-            echo "Removing keepalive" | logger -p local3.info -t "healthcheck"
+            echo "${output}"
+            /etc/init.d/weblogic-all status
+            echo "Removing keepalive"
             rm -f /u01/tag/static/keepalive.htm
         fi
     else
         if [ ! -f "/u01/tag/static/keepalive.htm" ]
         then
-            echo "Creating keepalive /u01/tag/static/keepalive.htm" | logger -p local3.info -t "healthcheck"
+            echo "${output}"
+            echo "Creating keepalive /u01/tag/static/keepalive.htm"
             keepalive > /u01/tag/static/keepalive.htm
             chown oracle:oinstall /u01/tag/static/keepalive.htm
-            echo
         fi
     fi
     sleep 120

--- a/ansible/roles/nomis-weblogic/templates/10.3/etc/init.d/weblogic-all
+++ b/ansible/roles/nomis-weblogic/templates/10.3/etc/init.d/weblogic-all
@@ -95,7 +95,7 @@ get_unhealthy_services() {
     fi
   fi
   if [[ -x /etc/init.d/opmn ]]; then
-    if [[ $(/etc/init.d/opmn status | grep -c Alive) != 3 ]]; then
+   if [[ $(/etc/init.d/opmn status | grep -c Alive) -lt 3 ]]; then
       unhealthy+=(opmn)
     fi
   fi


### PR DESCRIPTION
Add some additional debug to nomis weblogic healthcheck script and made the opmn check a bit more robust.  Tested and applied across all servers.