### PR TITLE
DSOS-2090: add ec2_name, aws_environment and application global vars

### DIFF
--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -5,4 +5,3 @@
 ec2_name: "no_name"               # the tags.Name on either EC2 or AutoScalingGroup
 aws_environment: "no_environment" # development, test, preproduction or production
 application: "no_application"     # the aws account minus the environment, e.g. nomis
-my_test_var: "test"

--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -2,7 +2,7 @@
 # inventory, or passed in to command line via extra_vars parameter when
 # running locally.  Setting dummy values here to ensure the ansible doesn't
 # crash out if they aren't set, e.g. when running AMI builds
-ec2_name: "no_name"
-aws_environment: "no_environment"
-application: "no_application"
+ec2_name: "no_name"               # the tags.Name on either EC2 or AutoScalingGroup
+aws_environment: "no_environment" # development, test, preproduction or production
+application: "no_application"     # the aws account minus the environment, e.g. nomis
 my_test_var: "test"

--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -1,0 +1,8 @@
+# The below variables are either set automatically from tags via dynamic
+# inventory, or passed in to command line via extra_vars parameter when
+# running locally.  Setting dummy values here to ensure the ansible doesn't
+# crash out if they aren't set, e.g. when running AMI builds
+ec2_name: "no_name"
+aws_environment: "no_environment"
+application: "no_application"
+my_test_var: "test"

--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -2,6 +2,6 @@
 # inventory, or passed in to command line via extra_vars parameter when
 # running locally.  Setting dummy values here to ensure the ansible doesn't
 # crash out if they aren't set, e.g. when running AMI builds
-ec2_name: "no_name"               # the tags.Name on either EC2 or AutoScalingGroup
+ec2_name: "no_name" # the tags.Name on either EC2 or AutoScalingGroup
 aws_environment: "no_environment" # development, test, preproduction or production
-application: "no_application"     # the aws account minus the environment, e.g. nomis
+application: "no_application" # the aws account minus the environment, e.g. nomis

--- a/ansible/group_vars/aws_ec2.yml
+++ b/ansible/group_vars/aws_ec2.yml
@@ -2,4 +2,3 @@ ansible_connection: community.aws.aws_ssm
 ansible_aws_ssm_timeout: 300 # long enough for operations that don't support async, e.g. unarchive
 ansible_aws_ssm_reconnection_retries: 0 # Retrying doesn't work well with shell commands that timeout, better to fail immediately.
 ansible_aws_ssm_region: eu-west-2
-instance_id: "{{ hostvars[inventory_hostname].instance_id }}" # for scenarios where {{ ansible_host }} is set to the ip address rather than instance_id

--- a/ansible/group_vars/environment_name_corporate_staff_rostering_development.yml
+++ b/ansible/group_vars/environment_name_corporate_staff_rostering_development.yml
@@ -1,6 +1,4 @@
 ---
-application: corporate-staff-rostering
-aws_environment: development
 ansible_aws_ssm_bucket_name: s3-bucket20230609090952135600000001
 image_builder_s3_bucket_name: csr-software20230609090942172100000002
 dns_zone_internal: corporate-staff-rostering.hmpps-development.modernisation-platform.internal

--- a/ansible/group_vars/environment_name_corporate_staff_rostering_preproduction.yml
+++ b/ansible/group_vars/environment_name_corporate_staff_rostering_preproduction.yml
@@ -1,6 +1,4 @@
 ---
-application: corporate-staff-rostering
-aws_environment: preproduction
 ansible_aws_ssm_bucket_name: s3-bucket20230609110811735400000001
 image_builder_s3_bucket_name: csr-software20230609090942172100000002
 dns_zone_internal: corporate-staff-rostering.hmpps-preproduction.modernisation-platform.internal

--- a/ansible/group_vars/environment_name_corporate_staff_rostering_production.yml
+++ b/ansible/group_vars/environment_name_corporate_staff_rostering_production.yml
@@ -1,6 +1,4 @@
 ---
-application: corporate-staff-rostering
-aws_environment: production
 ansible_aws_ssm_bucket_name: s3-bucket20230609110809465800000001
 image_builder_s3_bucket_name: csr-software20230609090942172100000002
 dns_zone_internal: corporate-staff-rostering.hmpps-production.modernisation-platform.internal

--- a/ansible/group_vars/environment_name_corporate_staff_rostering_test.yml
+++ b/ansible/group_vars/environment_name_corporate_staff_rostering_test.yml
@@ -1,6 +1,4 @@
 ---
-application: corporate-staff-rostering
-aws_environment: test
 ansible_aws_ssm_bucket_name: s3-bucket20230609090941956900000001
 image_builder_s3_bucket_name: csr-software20230609090942172100000002
 db_backup_s3_bucket_name: csr-db-backup-bucket20230822131811925900000001

--- a/ansible/group_vars/environment_name_hmpps_oem_development.yml
+++ b/ansible/group_vars/environment_name_hmpps_oem_development.yml
@@ -1,6 +1,4 @@
 ---
-application: hmpps-oem
-aws_environment: development
 ansible_aws_ssm_bucket_name: s3-bucket20230608141801676400000001
 image_builder_s3_bucket_name: hmpps-oem-software20230608132809146600000002
 dns_zone_internal: hmpps-oem.hmpps-development.modernisation-platform.internal

--- a/ansible/group_vars/environment_name_hmpps_oem_preproduction.yml
+++ b/ansible/group_vars/environment_name_hmpps_oem_preproduction.yml
@@ -1,6 +1,4 @@
 ---
-application: hmpps-oem
-aws_environment: preproduction
 ansible_aws_ssm_bucket_name: s3-bucket20230608143839074500000001
 image_builder_s3_bucket_name: hmpps-oem-software20230608132809146600000002
 dns_zone_internal: hmpps-oem.hmpps-preproduction.modernisation-platform.internal

--- a/ansible/group_vars/environment_name_hmpps_oem_production.yml
+++ b/ansible/group_vars/environment_name_hmpps_oem_production.yml
@@ -1,6 +1,4 @@
 ---
-application: hmpps-oem
-aws_environment: production
 ansible_aws_ssm_bucket_name: s3-bucket20230608143835254200000001
 image_builder_s3_bucket_name: hmpps-oem-software20230608132809146600000002
 dns_zone_internal: hmpps-oem.hmpps-production.modernisation-platform.internal

--- a/ansible/group_vars/environment_name_hmpps_oem_test.yml
+++ b/ansible/group_vars/environment_name_hmpps_oem_test.yml
@@ -1,6 +1,4 @@
 ---
-application: hmpps-oem
-aws_environment: test
 ansible_aws_ssm_bucket_name: s3-bucket20230608132808605000000001
 image_builder_s3_bucket_name: hmpps-oem-software20230608132809146600000002
 db_backup_s3_bucket_name: devtest-hmpps-oem-db-backup-bucket-20230801085755707000000001

--- a/ansible/group_vars/environment_name_nomis_combined_reporting_development.yml
+++ b/ansible/group_vars/environment_name_nomis_combined_reporting_development.yml
@@ -1,6 +1,4 @@
 ---
-application: nomis-combined-reporting
-aws_environment: development
 ansible_aws_ssm_bucket_name: s3-bucket20230228122737682700000001
 image_builder_s3_bucket_name: nomis-combined-reporting-software20230330140932343400000001
 dns_zone_internal: nomis-combined-reporting.hmpps-development.modernisation-platform.internal

--- a/ansible/group_vars/environment_name_nomis_combined_reporting_preproduction.yml
+++ b/ansible/group_vars/environment_name_nomis_combined_reporting_preproduction.yml
@@ -1,6 +1,4 @@
 ---
-application: nomis-combined-reporting
-aws_environment: preproduction
 ansible_aws_ssm_bucket_name: s3-bucket20230301111337484000000001
 image_builder_s3_bucket_name: nomis-combined-reporting-software20230330140932343400000001
 dns_zone_internal: nomis-combined-reporting.hmpps-preproduction.modernisation-platform.internal

--- a/ansible/group_vars/environment_name_nomis_combined_reporting_production.yml
+++ b/ansible/group_vars/environment_name_nomis_combined_reporting_production.yml
@@ -1,6 +1,4 @@
 ---
-application: nomis-combined-reporting
-aws_environment: production
 ansible_aws_ssm_bucket_name: s3-bucket20230301110833610700000001
 image_builder_s3_bucket_name: nomis-combined-reporting-software20230330140932343400000001
 dns_zone_internal: nomis-combined-reporting.hmpps-production.modernisation-platform.internal

--- a/ansible/group_vars/environment_name_nomis_combined_reporting_test.yml
+++ b/ansible/group_vars/environment_name_nomis_combined_reporting_test.yml
@@ -1,6 +1,4 @@
 ---
-application: nomis-combined-reporting
-aws_environment: test
 ansible_aws_ssm_bucket_name: s3-bucket20230301110846292900000001
 db_backup_s3_bucket_name: ncr-db-backup-bucket20230815134351976500000003
 image_builder_s3_bucket_name: nomis-combined-reporting-software20230330140932343400000001

--- a/ansible/group_vars/environment_name_nomis_development.yml
+++ b/ansible/group_vars/environment_name_nomis_development.yml
@@ -1,7 +1,4 @@
 ---
-application: nomis
-aws_environment: development
-
 ansible_aws_ssm_bucket_name: s3-bucket20230824133223473100000007
 db_backup_s3_bucket_name: nomis-db-backup-bucket20230824133223461100000006
 image_builder_s3_bucket_name: ec2-image-builder-nomis20220314103938567000000001

--- a/ansible/group_vars/environment_name_nomis_preproduction.yml
+++ b/ansible/group_vars/environment_name_nomis_preproduction.yml
@@ -1,7 +1,4 @@
 ---
-application: nomis
-aws_environment: preproduction
-
 ansible_aws_ssm_bucket_name: s3-bucket20220929161938056300000001
 db_backup_s3_bucket_name: nomis-db-backup-bucket20220929161940860900000005
 image_builder_s3_bucket_name: ec2-image-builder-nomis20220314103938567000000001

--- a/ansible/group_vars/environment_name_nomis_production.yml
+++ b/ansible/group_vars/environment_name_nomis_production.yml
@@ -1,7 +1,4 @@
 ---
-application: nomis
-aws_environment: production
-
 ansible_aws_ssm_bucket_name: s3-bucket20220427111226925000000002
 db_backup_s3_bucket_name: nomis-db-backup-bucket20220427111226918600000001
 image_builder_s3_bucket_name: ec2-image-builder-nomis20220314103938567000000001

--- a/ansible/group_vars/environment_name_nomis_test.yml
+++ b/ansible/group_vars/environment_name_nomis_test.yml
@@ -1,7 +1,4 @@
 ---
-application: nomis
-aws_environment: test
-
 ansible_aws_ssm_bucket_name: s3-bucket20210929163229537900000001 # for some reason you need to specify a bucket
 db_backup_s3_bucket_name: nomis-db-backup-bucket20220131102905687200000001
 image_builder_s3_bucket_name: ec2-image-builder-nomis20220314103938567000000001

--- a/ansible/group_vars/environment_name_oasys_development.yml
+++ b/ansible/group_vars/environment_name_oasys_development.yml
@@ -1,7 +1,4 @@
 ---
-application: oasys
-aws_environment: development
-
 ansible_aws_ssm_bucket_name: oasys-development20230403093252068800000001
 image_builder_s3_bucket_name: devtest-oasys-20230411143832198800000001
 dns_zone_internal: oasys.hmpps-development.modernisation-platform.internal

--- a/ansible/group_vars/environment_name_oasys_preproduction.yml
+++ b/ansible/group_vars/environment_name_oasys_preproduction.yml
@@ -1,7 +1,4 @@
 ---
-application: oasys
-aws_environment: preproduction
-
 # s3
 ansible_aws_ssm_bucket_name: oasys-preproduction20230403093924275400000001
 image_builder_s3_bucket_name: prodpreprod-oasys-20230412084245180100000001

--- a/ansible/group_vars/environment_name_oasys_production.yml
+++ b/ansible/group_vars/environment_name_oasys_production.yml
@@ -1,7 +1,4 @@
 ---
-application: oasys
-aws_environment: production
-
 ansible_aws_ssm_bucket_name: oasys-production20230403093924372800000001
 image_builder_s3_bucket_name: prodpreprod-oasys-20230412084245180100000001
 dns_zone_internal: oasys.hmpps-production.modernisation-platform.internal

--- a/ansible/group_vars/environment_name_oasys_test.yml
+++ b/ansible/group_vars/environment_name_oasys_test.yml
@@ -1,7 +1,4 @@
 ---
-application: oasys
-aws_environment: test
-
 ansible_aws_ssm_bucket_name: oasys-test20230403093247696000000001
 image_builder_s3_bucket_name: devtest-oasys-20230411143832198800000001
 dns_zone_internal: oasys.hmpps-test.modernisation-platform.internal

--- a/ansible/hosts/autoscaling_group_aws_ec2.yml
+++ b/ansible/hosts/autoscaling_group_aws_ec2.yml
@@ -16,6 +16,9 @@ hostnames:
 
 compose:
   ansible_host: instance_id # private_ip_address - use ip address if need to go through bastion
+  application: tags['environment-name'].split('-')[:-1]|join('-')
+  aws_environment: tags['environment-name'].split('-')|last
+  ec2_name: tags['Name']
 
 groups:
   bastion: tags.Name is search('bastion')
@@ -30,9 +33,5 @@ keyed_groups:
     prefix: server-type
   - key: tags['os-type'] | lower
     prefix: os-type
-  # - key: tags['environment-name'].split('-')[:-1]|join('-')   # an interesting idea for later maybe
-  #   prefix: application
-  # - key: tags['environment-name'].split('-')|last             # an interesting idea for later maybe
-  #   prefix: aws_environment
 
 strict: no

--- a/ansible/hosts/autoscaling_group_aws_ec2.yml
+++ b/ansible/hosts/autoscaling_group_aws_ec2.yml
@@ -15,14 +15,10 @@ hostnames:
   - "instance-id"
 
 compose:
-  ansible_host: instance_id # private_ip_address - use ip address if need to go through bastion
+  ansible_host: instance_id
   application: tags['environment-name'].split('-')[:-1]|join('-')
   aws_environment: tags['environment-name'].split('-')|last
   ec2_name: tags['Name']
-
-groups:
-  bastion: tags.Name is search('bastion')
-  windows: (platform is defined) and (platform in 'windows')
 
 keyed_groups:
   - key: tags['environment-name']

--- a/ansible/hosts/instance_aws_ec2.yml
+++ b/ansible/hosts/instance_aws_ec2.yml
@@ -11,14 +11,10 @@ hostnames:
   - "tag:Name"
 
 compose:
-  ansible_host: instance_id # private_ip_address - use ip address if need to go through bastion
+  ansible_host: instance_id
   application: tags['environment-name'].split('-')[:-1]|join('-')
   aws_environment: tags['environment-name'].split('-')|last
   ec2_name: tags['Name']
-
-groups:
-  bastion: tags.Name is search('bastion')
-  windows: (platform is defined) and (platform in 'windows')
 
 keyed_groups:
   - key: tags['environment-name']

--- a/ansible/hosts/instance_aws_ec2.yml
+++ b/ansible/hosts/instance_aws_ec2.yml
@@ -12,6 +12,9 @@ hostnames:
 
 compose:
   ansible_host: instance_id # private_ip_address - use ip address if need to go through bastion
+  application: tags['environment-name'].split('-')[:-1]|join('-')
+  aws_environment: tags['environment-name'].split('-')|last
+  ec2_name: tags['Name']
 
 groups:
   bastion: tags.Name is search('bastion')
@@ -30,9 +33,5 @@ keyed_groups:
     prefix: environment-name
   - key: tags['environment-name'] + '_' + tags['delius-environment-name'] + '_' + tags['database']
     prefix: environment-name
-  # - key: tags['environment-name'].split('-')[:-1]|join('-')   # an interesting idea for later maybe
-  #   prefix: application
-  # - key: tags['environment-name'].split('-')|last             # an interesting idea for later maybe
-  #   prefix: aws_environment
 
 strict: no

--- a/ansible/site.yml
+++ b/ansible/site.yml
@@ -36,6 +36,9 @@
 
 - hosts: "{{ target | default('all') }}"
   tasks:
+    - debug:
+        msg: "{{ ec2_name }} {{ application }} {{ aws_environment }} {{ my_test_var }}"
+
     - name: Set roles_defined fact
       set_fact:
         # These are roles_list defined in inventory. Default is empty list.

--- a/ansible/site.yml
+++ b/ansible/site.yml
@@ -36,10 +36,6 @@
 
 - hosts: "{{ target | default('all') }}"
   tasks:
-    - debug:
-        msg: "{{ ec2_name }} {{ application }} {{ aws_environment }}"
-      tags: always
-
     - name: Set roles_defined fact
       set_fact:
         # These are roles_list defined in inventory. Default is empty list.

--- a/ansible/site.yml
+++ b/ansible/site.yml
@@ -37,7 +37,7 @@
 - hosts: "{{ target | default('all') }}"
   tasks:
     - debug:
-        var: "{{ ec2_name }} {{ application }} {{ aws_environment }}"
+        msg: "{{ ec2_name }} {{ application }} {{ aws_environment }}"
       tags: always
 
     - name: Set roles_defined fact

--- a/ansible/site.yml
+++ b/ansible/site.yml
@@ -36,6 +36,10 @@
 
 - hosts: "{{ target | default('all') }}"
   tasks:
+    - debug:
+        var: "{{ ec2_name }} {{ application }} {{ aws_environment }}"
+      tags: always
+
     - name: Set roles_defined fact
       set_fact:
         # These are roles_list defined in inventory. Default is empty list.

--- a/ansible/site.yml
+++ b/ansible/site.yml
@@ -38,6 +38,7 @@
   tasks:
     - debug:
         msg: "{{ ec2_name }} {{ application }} {{ aws_environment }} {{ my_test_var }}"
+      tags: always
 
     - name: Set roles_defined fact
       set_fact:

--- a/ansible/site.yml
+++ b/ansible/site.yml
@@ -36,10 +36,6 @@
 
 - hosts: "{{ target | default('all') }}"
   tasks:
-    - debug:
-        msg: "{{ ec2_name }} {{ application }} {{ aws_environment }} {{ my_test_var }}"
-      tags: always
-
     - name: Set roles_defined fact
       set_fact:
         # These are roles_list defined in inventory. Default is empty list.


### PR DESCRIPTION
Adding ec2_name, aws_environment and applications.
These can then be used in default variable settings without needing to run the get-ec2-facts role.
Also zapped some unused items in the dynamic inventory.
Tested running locally and remotely.