### PR TITLE
DSOS-2205: oracle oem agent setup ssm fix

### DIFF
--- a/ansible/roles/nomis-weblogic/defaults/main.yml
+++ b/ansible/roles/nomis-weblogic/defaults/main.yml
@@ -42,11 +42,11 @@ weblogic_other_form_servers:
 weblogic_all_form_servers: "{{ weblogic_other_form_servers + weblogic_additional_form_servers }}"
 
 weblogic_ssm_passwords:
-  - key: "weblogic"
+  weblogic:
     parameter: "/oracle/weblogic/{{ nomis_environment }}/passwords"
     users:
       - weblogic: auto
-  - key: "db"
+  db:
     parameter: "/oracle/database/{{ db_config.db_name }}/weblogic-passwords"
     users:
       - tagsar:

--- a/ansible/roles/oracle-11g/defaults/main.yml
+++ b/ansible/roles/oracle-11g/defaults/main.yml
@@ -25,7 +25,7 @@ database_env:
   PATH: "{{ database_home }}/bin:/usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/home/oracle/.local/bin:/home/oracle/bin"
 
 db_ssm_passwords:
-  - key: "asm"
+  asm:
     parameter: "/ec2/{{ ec2_name }}/asm-passwords"
     users:
       - ASMSNMP: auto

--- a/ansible/roles/oracle-19c/defaults/main.yml
+++ b/ansible/roles/oracle-19c/defaults/main.yml
@@ -36,7 +36,7 @@ grid_install_script: grid_install.sh
 password_response_file: grid_pw.rsp
 
 db_ssm_passwords:
-  - key: "asm"
+  asm:
     parameter: "/ec2/{{ ec2_name }}/asm-passwords"
     users:
       - ASMSNMP: auto

--- a/ansible/roles/oracle-db-backup/defaults/main.yml
+++ b/ansible/roles/oracle-db-backup/defaults/main.yml
@@ -27,7 +27,7 @@ adhoc_backup_for: "HA"
 # The rman-backup script requires OEM creds retrieved from hmpps-oem account
 rcvcat_passwords_secret_name: "/oracle/database/{{ rcvcat_db_name.rcvcat_db_name }}/passwords"
 rc_secretsmanager_passwords:
-  - key: "rc"
+  rc:
     account_name: "hmpps-oem-{{ aws_environment }}"
     assume_role_name: "EC2OracleEnterpriseManagementSecretsRole"
     secret: "{{ rcvcat_passwords_secret_name }}"

--- a/ansible/roles/oracle-db-standby-setup/README.md
+++ b/ansible/roles/oracle-db-standby-setup/README.md
@@ -53,6 +53,15 @@ db_configs:
       - { name: NOMIS_APIRO, role: PRIMARY }
 ```
 
+Ensure "sys" password is stored in SSM Parameter in
+
+```
+/oracle/database/{{ db_name }}/passwords
+```
+
+This parameter should be created by terraform and then password set manually afterwards.
+
+
 # Example
 
 1. Setup primary database to support the new standby database

--- a/ansible/roles/oracle-db-standby-setup/defaults/main.yml
+++ b/ansible/roles/oracle-db-standby-setup/defaults/main.yml
@@ -4,3 +4,18 @@ temp_dir: /u02/stage/temp
 duplicate_target_db_cmd: "duplicate target database for standby "
 standby_creation_cmd_filename: "standby_creation.cmd"
 rman_backup_location: /u02/DB_BKP
+
+# The db_configs map must be defined and have an entry
+# corresponding to oracle-db-name.  Define in group_vars.
+db_configs: {}
+db_primary_name: None
+db_standby_name: None
+db_primary: "{{ db_configs[ db_primary_name ] }}"
+db_standby: "{{ db_configs[ db_standby_name ] }}"
+
+# ensure sys password is defined in the standby DB passwords SSM parameter
+db_ssm_passwords:
+  db:
+    parameter: "/oracle/database/{{ db_standby.db_name }}/passwords"
+    users:
+      - sys:

--- a/ansible/roles/oracle-db-standby-setup/tasks/get_facts.yml
+++ b/ansible/roles/oracle-db-standby-setup/tasks/get_facts.yml
@@ -2,12 +2,7 @@
 - name: Fail if missing parameters
   fail:
     msg: "Ensure both {{ db_primary_name }} and {{ db_standby_name }} variables are defined in db_configs fact"
-  when: db_configs[db_primary_name] is not defined or db_configs[db_standby_name] is not defined
-
-- name: Set database facts
-  set_fact:
-    db_primary: "{{ db_configs[ db_primary_name ] }}"
-    db_standby: "{{ db_configs[ db_standby_name ] }}"
+  when: db_primary is not defined or db_standby is not defined
 
 - name: Debug primary database
   debug:
@@ -27,22 +22,15 @@
     msg: Cannot have both storage_account_name and s3_bucket defined in the primary db_config
   when: db_primary.storage_account_name is defined and db_primary.s3_bucket is defined
 
-- name: Set SSM parameters path fact from ec2 ssm-parameters-prefix and Name tag
-  set_fact:
-    ssm_parameters_path: '/{{ ssm_parameters_prefix }}/{{ ec2.tags["Name"] }}'
+- name: Get DB passwords
+  import_role:
+    name: ssm-passwords
+  vars:
+    ssm_passwords: "{{ db_ssm_passwords }}"
 
-- name: Set SSM parameters database path facts
+- name: Set sys password fact
   set_fact:
-    ssm_parameters_path_db_sys_password: "{{ ssm_parameters_path }}/{{ db_primary.db_name }}/syspassword"
-    ssm_parameters_path_az_sas_token: "{{ ssm_parameters_path }}/az_sas_token"
-
-# Upload password manually, e.g. aws ssm put-parameter --name "/database/t1-nomis-db-1-b/TRDATT1/syspassword" --type "SecureString" --data-type "text" --value "Password123" --profile nomis-test
-- debug:
-    msg: "System password must be uploaded to {{ ssm_parameters_path_db_sys_password }}"
-
-- name: Get SSM parameters
-  set_fact:
-    db_sys_password: "{{ lookup('aws_ssm', ssm_parameters_path_db_sys_password, region=ansible_ec2_placement_region) }}"
+    db_sys_password: "{{ ssm_passwords_dict['db'].passwords['sys'] }}"
 
 - block:
     - name: Get Egress Ip
@@ -56,11 +44,11 @@
         msg: "{{ internet_egress_ip.stdout }} must be allowed in dso-infra-azure-fixngo:terragrunt/NOMSProduction1/pd-noms-azcopy-orabkup/terraform.tfvars and devtest equivalent"
 
     - debug:
-        msg: "SAS token must be uploaded {{ ssm_parameters_path_az_sas_token }}, use modernisation-platform-environments:/environments/nomis/scripts/update-db-az-sas-token.sh"
+        msg: "SAS token must be uploaded /azure/sas_token, use modernisation-platform-environments:/environments/nomis/scripts/update-db-az-sas-token.sh"
 
     - name: Get SAS Token SSM parameter
       set_fact:
-        sas_token: "{{ lookup('aws_ssm', ssm_parameters_path_az_sas_token, region=ansible_ec2_placement_region) }}"
+        sas_token: "{{ lookup('aws_ssm', '/azure/sas_token', region=ansible_ec2_placement_region) }}"
 
   # block
   when: db_primary.storage_account_name is defined

--- a/ansible/roles/oracle-oem-agent-setup/defaults/main.yml
+++ b/ansible/roles/oracle-oem-agent-setup/defaults/main.yml
@@ -15,20 +15,20 @@ agentpatcher_patch: p33355570_135000_Generic.zip
 agentpatcher_version: 13.9.5.5.0
 agent_home: "{{ oem_agent_base }}/agent_13.5.0.0.0"
 oem_secretsmanager_passwords:
-  - key: "oem"
+  oem:
     account_name: "hmpps-oem-{{ aws_environment }}"
     assume_role_name: "EC2OracleEnterpriseManagementSecretsRole"
     secret: "/oracle/oem/passwords"
     users:
       - agentreg:
-  - key: "emrep"
+  emrep:
     account_name: "hmpps-oem-{{ aws_environment }}"
     assume_role_name: "EC2OracleEnterpriseManagementSecretsRole"
     secret: "/oracle/database/EMREP/passwords"
     users:
       - sysman:
 oem_ssm_passwords:
-  - key: "asm"
+  asm:
     parameter: "/ec2/{{ ec2_name }}/asm-passwords"
     users:
       - ASMSNMP:

--- a/ansible/roles/oracle-oem-agent-setup/templates/add_targets.sh.j2
+++ b/ansible/roles/oracle-oem-agent-setup/templates/add_targets.sh.j2
@@ -16,7 +16,7 @@ then
         echo "emcli add HAS target"
         ./emcli add_target -name="has_${HOST_FQDN_NAME}" -type="has" -host="${HOST_FQDN_NAME}" -properties="OracleHome:${GRID_HOME};orcl_gtp_lifecycle_status:${LIFECYCLE_STATUS}"
         echo "emcli add ASM target"
-	ASMSNMPPASSWORD=`aws ssm get-parameter --name "/database/${HOSTNAME}/ASMSNMP" --query Parameter.Value --with-decryption`
+        ASMSNMPPASSWORD=$(aws ssm get-parameter --name "{{ oem_ssm_passwords.asm.parameter }}" --query Parameter.Value --with-decryption --output text | egrep -o '"ASMSNMP":[^"]*"[^"]*"' | cut -d\" -f4)
         ./emcli add_target -name="+ASM_${HOST_FQDN_NAME}" -type="osm_instance" -host="${HOST_FQDN_NAME}" -credentials="UserName:asmsnmp;password:${ASMSNMPPASSWORD};Role:sysdba" -properties="SID:+ASM;Port:1521;OracleHome:${GRID_HOME};MachineName:${HOST_FQDN_NAME}"
         echo "emcli add Listener"
         ./emcli add_target -name="LISTENER_${HOST_FQDN_NAME}" -type="oracle_listener" -host="${HOST_FQDN_NAME}" -properties="LsnrName:LISTENER;ListenerOraDir:${GRID_HOME}/network/admin;Port:1521;OracleHome:${GRID_HOME};Machine:${HOST_FQDN_NAME}"
@@ -38,8 +38,8 @@ then
         ./emcli add_target -name="${DB_HOME_NAME}_${HOST_FQDN_NAME}" -type="oracle_home" -host="${HOST_FQDN_NAME}" -properties="HOME_TYPE:O;INSTALL_LOCATION:${DB_HOME};INVENTORY:${INVENTORY_LOC};orcl_gtp_lifecycle_status:${LIFECYCLE_STATUS}"
         for i in `grep db  /etc/oratab| grep -v "^#" | awk -F: '{ print $1 }'`
         do
-		echo ${i}
-		DBPASSWORD=`aws ssm get-parameter --name "/database/${HOSTNAME}/${i}/dbsnmp" --query Parameter.Value --with-decryption`
+                echo ${i}
+                DBPASSWORD=$(aws ssm get-parameter --name "/oracle/database/${i}/passwords" --query Parameter.Value --with-decryption --output text | egrep -o '"dbsnmp":[^"]*"[^"]*"' | cut -d\" -f4)
                 ./emcli add_target -name="${i}" -type="oracle_database" -host="${HOST_FQDN_NAME}" -credentials="UserName:dbsnmp;password:${DBPASSWORD};Role:Normal" -properties="SID:${i};Port:1521;OracleHome:${DB_HOME};MachineName:${HOST_FQDN_NAME};"
                 # oracle_dbsys added  due to encountered bug 
                 if [ `./emcli get_targets -targets=oracle_dbsys | grep ${i} | wc -l` -eq 0 ] 

--- a/ansible/roles/oracle-oms-setup/defaults/main.yml
+++ b/ansible/roles/oracle-oms-setup/defaults/main.yml
@@ -47,25 +47,25 @@ db_env:
 
 emrepo_db_name: "{{ db_configs[emrepo] }}"
 oms_ssm_passwords:
-  - key: "emrep"
+  emrep:
     parameter: "/oracle/database/{{ emrepo_db_name.emrepo_db_name }}/passwords"
     users:
       - sys: auto
       - system: auto
-  - key: "oem"
+  oem:
     parameter: "/oracle/oem/passwords"
     users:
       - weblogic_admin: auto
       - nodemanager: auto
 
 oms_secretsmanager_passwords:
-  - key: "emrep"
+  emrep:
     assume_role_name: ""
     account_name: "{{ application }}-{{ aws_environment }}"
     secret: "/oracle/database/{{ emrepo_db_name.emrepo_db_name }}/passwords"
     users:
       - sysman: auto
-  - key: "oem"
+  oem:
     assume_role_name: ""
     account_name: "{{ application }}-{{ aws_environment }}"
     secret: "/oracle/oem/passwords"

--- a/ansible/roles/oracle-recovery-catalog/defaults/main.yml
+++ b/ansible/roles/oracle-recovery-catalog/defaults/main.yml
@@ -8,14 +8,14 @@ db_configs: {}
 rcvcat: "RCVCAT"
 rcvcat_db_name: "{{ db_configs[rcvcat] }}"
 rc_ssm_passwords:
-  - key: "rc"
+  rc:
     parameter: "/oracle/database/{{ rcvcat_db_name.rcvcat_db_name }}/passwords"
     users:
       - sys: auto
       - system: auto
 
 rc_secretsmanager_passwords:
-  - key: "rc"
+  key: "rc"
     assume_role_name: ""
     account_name: "{{ application }}-{{ aws_environment }}"
     secret: "/oracle/database/{{ rcvcat_db_name.rcvcat_db_name }}/passwords"

--- a/ansible/roles/oracle-recovery-catalog/defaults/main.yml
+++ b/ansible/roles/oracle-recovery-catalog/defaults/main.yml
@@ -15,7 +15,7 @@ rc_ssm_passwords:
       - system: auto
 
 rc_secretsmanager_passwords:
-  key: "rc"
+  rc:
     assume_role_name: ""
     account_name: "{{ application }}-{{ aws_environment }}"
     secret: "/oracle/database/{{ rcvcat_db_name.rcvcat_db_name }}/passwords"

--- a/ansible/roles/secretsmanager-passwords/README.md
+++ b/ansible/roles/secretsmanager-passwords/README.md
@@ -58,13 +58,13 @@ Ensure the secret has been shared with EC2 instances in this account.
     name: secretsmanager-passwords
   vars:
     secretsmanager_passwords:
-      - key: "oem_passwords"
+      oem_passwords:
         account_name: "hmpps-oem-{{ environment }}"
         assume_role_name: EC2OracleEnterpriseManagementSecretsRole
         secret: "/ec2/oracle/oem/passwords"
         users:
           - agentreg: auto # password auto generated if not present
-      - key: "emrep_passwords"
+      emrep_passwords:
         account_name: "hmpps-oem-{{ environment }}"
         assume_role_name: EC2OracleEnterpriseManagementSecretsRole
         secret: "/ec2/oracle/database/EMREP/passwords"
@@ -74,6 +74,13 @@ Ensure the secret has been shared with EC2 instances in this account.
 
 The role will automatically generate passwords and update the
 secret value.
+The role will automatically generate passwords and update the
+secret value. This will be available to access in subsequent ansible
+code using the `secretsmanager_passwords_dict` fact:
+
+```
+agentregpassword: "{{ secretsmanager_passwords_dict['oem_passwords'].passwords['agentreg'] }}"
+```
 
 See OEM secrets for an example of how this is used in practice.
 

--- a/ansible/roles/secretsmanager-passwords/defaults/main.yml
+++ b/ansible/roles/secretsmanager-passwords/defaults/main.yml
@@ -1,18 +1,18 @@
 ---
 secretsmanager_passwords:
-# - key: "unique_key_for_ansible_dictionary1_cross_account" e.g. my_password
-#   assume_role_name: EC2OracleEnterpriseManagementSecretsRole
-#   account_name: "my-aws-account-name1"      e.g. hmpps-oem-test
-#   secret: "my-secretsmanager-secret-name1"  e.g. /ec2/oracle/oem/passwords"
-#   users:  # list of users and optional passwords (don't commit)
-#     - myuser1: myfixedvalue
-#     - myuser2: auto # automatically generated if not already present
-# - key: "unique_key_for_ansible_dictionary2_same_account"
-#   assume_role_name: ""
-#   account_name: "{{ application }}-{{ aws_environment }}"
-#   secret: "my-secretsmanager-secret-name2"
-#   users:
-#     - myuser3: # password must be set outside of code
+# - unique_key_for_ansible_dictionary1_cross_account:  e.g. my_password
+#     assume_role_name: EC2OracleEnterpriseManagementSecretsRole
+#     account_name: "my-aws-account-name1"      e.g. hmpps-oem-test
+#     secret: "my-secretsmanager-secret-name1"  e.g. /ec2/oracle/oem/passwords"
+#     users:  # list of users and optional passwords (don't commit)
+#       - myuser1: myfixedvalue
+#       - myuser2: auto # automatically generated if not already present
+# - unique_key_for_ansible_dictionary2_same_account:
+#     assume_role_name: ""
+#     account_name: "{{ application }}-{{ aws_environment }}"
+#     secret: "my-secretsmanager-secret-name2"
+#     users:
+#       - myuser3: # password must be set outside of code
 
 secretsmanager_passwords_force_rotate: ""
 # include the secret key and username to force rotation, e.g. "unique_key_for_ansible_dictionary1:myuser1"

--- a/ansible/roles/secretsmanager-passwords/tasks/main.yml
+++ b/ansible/roles/secretsmanager-passwords/tasks/main.yml
@@ -59,6 +59,9 @@
     label: "{{ item.key }}"
   loop: "{{ secretsmanager_passwords | dict2items }}"
 
+# If this fails, either set user to 'auto', or temporary set the password in ansible,
+# or manually add the user's password to the given secret
+#
 # The if statement:
 # - use the password defined in the secretsmanager_passwords variable if there is one
 # - else use existing password defined in the secretsmanager_secret and force_rotate not set
@@ -69,7 +72,7 @@
     secretsmanager_passwords_dict: |
       {{ secretsmanager_passwords_dict | combine({
            item[0].key: {
-             'passwords': {
+             'newpasswords': {
                item[1].keys()|first:
                  item[1].values()|first
                    if item[1].values()|first != None and item[1].values()|first != 'auto'
@@ -80,10 +83,16 @@
                  + lookup('ansible.builtin.password', '/dev/null chars=ascii_letters,digits length=14')
                    if item[1].values()|first == 'auto'
                  else None
+             },
+             'oldpasswords': {
+               item[1].keys()|first:
+                 secretsmanager_passwords_dict[item[0].key].passwords[item[1].keys()|first]
+                   if item[1].keys()|first in secretsmanager_passwords_dict[item[0].key].passwords
+                 else ''
              }
            }
          }, recursive=true) }}
-  failed_when: secretsmanager_passwords_dict[item[0].key].passwords[item[1].keys()|first] == None
+  failed_when: secretsmanager_passwords_dict[item[0].key].newpasswords[item[1].keys()|first] == None
   loop_control:
     label: "{{ item[0].key }}:{{ item[1].keys()|first }}"
   with_subelements:
@@ -95,7 +104,8 @@
     secretsmanager_passwords_dict: |
       {{ secretsmanager_passwords_dict | combine({
            item.key: {
-               'upload': secretsmanager_passwords_dict[item.key].passwords|to_json != secretsmanager_passwords_dict[item.key].value
+               'passwords' : secretsmanager_passwords_dict[item.key].passwords | combine(secretsmanager_passwords_dict[item.key].newpasswords),
+               'upload': secretsmanager_passwords_dict[item.key].newpasswords != secretsmanager_passwords_dict[item.key].oldpasswords
            }
          }, recursive=true) }}
   loop_control:

--- a/ansible/roles/secretsmanager-passwords/tasks/main.yml
+++ b/ansible/roles/secretsmanager-passwords/tasks/main.yml
@@ -77,7 +77,7 @@
                    if item[1].keys()|first in secretsmanager_passwords_dict[item[0].key].passwords
                    and [item[0].key, item[1].keys()|first]|join(':') not in secretsmanager_passwords_force_rotate
                  else lookup('ansible.builtin.password', '/dev/null chars=ascii_letters length=1')
-                 + lookup('ansible.builtin.password', '/dev/null chars=ascii_letters,digits length=15')
+                 + lookup('ansible.builtin.password', '/dev/null chars=ascii_letters,digits length=14')
                    if item[1].values()|first == 'auto'
                  else None
              }

--- a/ansible/roles/secretsmanager-passwords/tasks/main.yml
+++ b/ansible/roles/secretsmanager-passwords/tasks/main.yml
@@ -15,20 +15,20 @@
     PATH=$PATH:/usr/local/bin
     set -e
     account_id=$(aws sts get-caller-identity --query Account --output text)
-    secret_account_id="{{ account_ids[item.account_name] }}"
+    secret_account_id="{{ account_ids[item.value.account_name] }}"
     if [[ $account_id != $secret_account_id ]]; then
-      role_arn="arn:aws:iam::${account_id}:role/{{ item.assume_role_name }}"
+      role_arn="arn:aws:iam::${account_id}:role/{{ item.value.assume_role_name }}"
       session="{{ item.key }}-ansible"
       creds=$(aws sts assume-role --role-arn "${role_arn}" --role-session-name "${session}"  --output text --query "Credentials.[AccessKeyId,SecretAccessKey,SessionToken]")
       export AWS_ACCESS_KEY_ID=$(echo "${creds}" | tail -1 | cut -f1)
       export AWS_SECRET_ACCESS_KEY=$(echo "${creds}" | tail -1 | cut -f2)
       export AWS_SESSION_TOKEN=$(echo "${creds}" | tail -1 | cut -f3)
     fi
-    secret_arn="arn:aws:secretsmanager:eu-west-2:${secret_account_id}:secret:{{ item.secret }}"
+    secret_arn="arn:aws:secretsmanager:eu-west-2:${secret_account_id}:secret:{{ item.value.secret }}"
     aws secretsmanager get-secret-value --secret-id "${secret_arn}" --query SecretString --output text
   loop_control:
     label: "{{ item.key }}"
-  loop: "{{ secretsmanager_passwords }}"
+  loop: "{{ secretsmanager_passwords | dict2items }}"
   check_mode: false
   changed_when: false
   register: get_secrets_shell
@@ -51,13 +51,13 @@
     secretsmanager_passwords_dict: |
       {{ secretsmanager_passwords_dict | combine({
            item.key: {
-             'config': item,
+             'config': item.value,
              'passwords': {} if 'placeholder' in secretsmanager_passwords_dict[item.key].value else secretsmanager_passwords_dict[item.key].value|from_json
            }
          }, recursive=true) }}
   loop_control:
     label: "{{ item.key }}"
-  loop: "{{ secretsmanager_passwords }}"
+  loop: "{{ secretsmanager_passwords | dict2items }}"
 
 # The if statement:
 # - use the password defined in the secretsmanager_passwords variable if there is one
@@ -87,8 +87,8 @@
   loop_control:
     label: "{{ item[0].key }}:{{ item[1].keys()|first }}"
   with_subelements:
-    - "{{ secretsmanager_passwords }}"
-    - users
+    - "{{ secretsmanager_passwords | dict2items }}"
+    - value.users
 
 - name: Check secrets which require updating
   set_fact:
@@ -100,7 +100,7 @@
          }, recursive=true) }}
   loop_control:
     label: "{{ item.key }}"
-  loop: "{{ secretsmanager_passwords }}"
+  loop: "{{ secretsmanager_passwords | dict2items }}"
 
 - name: Check secrets which require updating
   set_fact:
@@ -135,4 +135,4 @@
          }, recursive=true) }}
   loop_control:
     label: "{{ item.key }}"
-  loop: "{{ secretsmanager_passwords }}"
+  loop: "{{ secretsmanager_passwords | dict2items }}"

--- a/ansible/roles/ssm-passwords/README.md
+++ b/ansible/roles/ssm-passwords/README.md
@@ -35,18 +35,23 @@ variable accordingly
     name: secretsmanager-passwords
   vars:
     ssm_passwords:
-      - key: "oem_passwords"
+      oem_passwords:
         parameter: "/ec2/oracle/oem/passwords"
         users:
           - agentreg: auto # auto generated if not present
-      - key: "emrep_passwords"
+      emrep_passwords:
         parameter: "/ec2/oracle/database/EMREP/passwords"
         users:
           - sysman: # password must be set outside of code
 ```
 
 The role will automatically generate passwords and update the
-secret value.
+secret value. This will be available to access in subsequent ansible
+code using the `ssm_passwords_dict` fact:
+
+```
+agentregpassword: "{{ ssm_passwords_dict['oem_passwords'].passwords['agentreg'] }}"
+```
 
 See OEM secrets for an example of how this is used in practice.
 

--- a/ansible/roles/ssm-passwords/defaults/main.yml
+++ b/ansible/roles/ssm-passwords/defaults/main.yml
@@ -1,11 +1,11 @@
 ---
 ssm_passwords:
-# - key: "unique_key_for_ansible_dictionary1" e.g. my_password
+# unique_key_for_ansible_dictionary1:   e.g. my_password
 #   parameter: "my-ssm-password-name1"  e.g. /ec2/oracle/oem/passwords"
 #   users:  # list of users and optional passwords (don't commit)
 #     - myuser1: myfixedvalue
 #     - myuser2: auto # automatically generated if not present
-# - key: "unique_key_for_ansible_dictionary2"
+# unique_key_for_ansible_dictionary2:
 #   account_name: "my-aws-account-name2"
 #   parameter: "my-ssm-password-name2"
 #   users:

--- a/ansible/roles/ssm-passwords/tasks/main.yml
+++ b/ansible/roles/ssm-passwords/tasks/main.yml
@@ -47,7 +47,7 @@
                    if item[1].keys()|first in ssm_passwords_dict[item[0].key].passwords
                    and [item[0].key, item[1].keys()|first]|join(':') not in ssm_passwords_force_rotate
                  else lookup('ansible.builtin.password', '/dev/null chars=ascii_letters length=1')
-                 + lookup('ansible.builtin.password', '/dev/null chars=ascii_letters,digits length=15')
+                 + lookup('ansible.builtin.password', '/dev/null chars=ascii_letters,digits length=14')
                    if item[1].values()|first == 'auto'
                  else None
              }

--- a/ansible/roles/ssm-passwords/tasks/main.yml
+++ b/ansible/roles/ssm-passwords/tasks/main.yml
@@ -8,13 +8,13 @@
     ssm_passwords_dict: |
       {{ ssm_passwords_dict | combine({
            item.key: {
-             'parameter': item.parameter,
-             'value': lookup('amazon.aws.aws_ssm', item.parameter, region='eu-west-2')
+             'parameter': item.value.parameter,
+             'value': lookup('amazon.aws.aws_ssm', item.value.parameter, region='eu-west-2')
            }
          }, recursive=true) }}
   loop_control:
     label: "{{ item.key }}"
-  loop: "{{ ssm_passwords }}"
+  loop: "{{ ssm_passwords | dict2items }}"
 
 # If this fails, the SSM parameter doesn't exist or isn't valid json
 - name: Prepare any placeholder parameters
@@ -27,7 +27,7 @@
          }, recursive=true) }}
   loop_control:
     label: "{{ item.key }}"
-  loop: "{{ ssm_passwords }}"
+  loop: "{{ ssm_passwords | dict2items }}"
 
 # The if statement:
 # - use the password defined in the ssm_passwords variable if there is one
@@ -57,8 +57,8 @@
   loop_control:
     label: "{{ item[0].key }}:{{ item[1].keys()|first }}"
   with_subelements:
-    - "{{ ssm_passwords }}"
-    - users
+    - "{{ ssm_passwords | dict2items }}"
+    - value.users
 
 - name: Check parameters which require updating
   set_fact:
@@ -70,7 +70,7 @@
          }, recursive=true) }}
   loop_control:
     label: "{{ item.key }}"
-  loop: "{{ ssm_passwords }}"
+  loop: "{{ ssm_passwords | dict2items }}"
 
 - name: Create fact with updated parameters
   set_fact:
@@ -99,4 +99,4 @@
          }, recursive=true) }}
   loop_control:
     label: "{{ item.key }}"
-  loop: "{{ ssm_passwords }}"
+  loop: "{{ ssm_passwords | dict2items }}"

--- a/ansible/roles/ssm-passwords/tasks/main.yml
+++ b/ansible/roles/ssm-passwords/tasks/main.yml
@@ -39,7 +39,7 @@
     ssm_passwords_dict: |
       {{ ssm_passwords_dict | combine({
            item[0].key: {
-             'passwords': {
+             'newpasswords': {
                item[1].keys()|first:
                  item[1].values()|first
                    if item[1].values()|first != None and item[1].values()|first != 'auto'
@@ -50,10 +50,16 @@
                  + lookup('ansible.builtin.password', '/dev/null chars=ascii_letters,digits length=14')
                    if item[1].values()|first == 'auto'
                  else None
+             },
+             'oldpasswords': {
+               item[1].keys()|first:
+                 ssm_passwords_dict[item[0].key].passwords[item[1].keys()|first]
+                   if item[1].keys()|first in ssm_passwords_dict[item[0].key].passwords
+                 else ''
              }
            }
          }, recursive=true) }}
-  failed_when: ssm_passwords_dict[item[0].key].passwords[item[1].keys()|first] == None
+  failed_when: ssm_passwords_dict[item[0].key].newpasswords[item[1].keys()|first] == None
   loop_control:
     label: "{{ item[0].key }}:{{ item[1].keys()|first }}"
   with_subelements:
@@ -65,7 +71,8 @@
     ssm_passwords_dict: |
       {{ ssm_passwords_dict | combine({
            item.key: {
-               'upload': ssm_passwords_dict[item.key].passwords|to_json != ssm_passwords_dict[item.key].value
+               'passwords' : ssm_passwords_dict[item.key].passwords | combine(ssm_passwords_dict[item.key].newpasswords),
+               'upload': ssm_passwords_dict[item.key].newpasswords != ssm_passwords_dict[item.key].oldpasswords
            }
          }, recursive=true) }}
   loop_control:


### PR DESCRIPTION
More tweaks to the ansible password management code:
- store the configuration as a map rather than list so values more easily accessed
- update oracle-db-standby-setup role to retrieve sys password from /oracle/database/dbname/passwords
- update associated scripts to use the new ssm path