### PR TITLE
DSOS-2228: prod oem fix

### DIFF
--- a/ansible/group_vars/environment_name_hmpps_oem_production.yml
+++ b/ansible/group_vars/environment_name_hmpps_oem_production.yml
@@ -1,6 +1,7 @@
 ---
 ansible_aws_ssm_bucket_name: s3-bucket20230608143835254200000001
 image_builder_s3_bucket_name: hmpps-oem-software20230608132809146600000002
+db_backup_s3_bucket_name: prod-hmpps-oem-db-backup-bucket-20230815102157276300000001
 dns_zone_internal: hmpps-oem.hmpps-production.modernisation-platform.internal
 dns_search_domains:
   - nomis.hmpps-production.modernisation-platform.internal

--- a/ansible/group_vars/server_type_hmpps_oem.yml
+++ b/ansible/group_vars/server_type_hmpps_oem.yml
@@ -53,8 +53,8 @@ server_type_roles_list:
   - domain-search
   - oracle-19c
   - oracle-secure-backup
-  - oracle-db-backup
   - oracle-recovery-catalog
+  - oracle-db-backup
   - oracle-oms-setup
   - collectd-service-metrics
 

--- a/ansible/roles/secretsmanager-passwords/tasks/main.yml
+++ b/ansible/roles/secretsmanager-passwords/tasks/main.yml
@@ -74,6 +74,7 @@
 # - else use existing password defined in the secretsmanager_secret and force_rotate not set
 # - else generate random password if the value is set to auto in ssm_passwords
 # - else fail
+# Oracle passwords must start with letter and contain at least one digit
 - name: Generate any missing passwords
   set_fact:
     secretsmanager_passwords_dict: |
@@ -87,7 +88,8 @@
                    if item[1].keys()|first in secretsmanager_passwords_dict[item[0].key].passwords
                    and [item[0].key, item[1].keys()|first]|join(':') not in secretsmanager_passwords_force_rotate
                  else lookup('ansible.builtin.password', '/dev/null chars=ascii_letters length=1')
-                 + lookup('ansible.builtin.password', '/dev/null chars=ascii_letters,digits length=14')
+                 + lookup('ansible.builtin.password', '/dev/null chars=digits length=1')
+                 + lookup('ansible.builtin.password', '/dev/null chars=ascii_letters,digits length=13')
                    if item[1].values()|first == 'auto'
                  else None
              },

--- a/ansible/roles/ssm-passwords/tasks/main.yml
+++ b/ansible/roles/ssm-passwords/tasks/main.yml
@@ -41,6 +41,7 @@
 # - else use existing password defined in the SecretString and force_rotate not set
 # - else generate random password if the value is set to auto in ssm_passwords
 # - else fail
+# Oracle passwords must start with letter and contain at least one digit
 - name: Generate any missing passwords
   set_fact:
     ssm_passwords_dict: |
@@ -54,7 +55,8 @@
                    if item[1].keys()|first in ssm_passwords_dict[item[0].key].passwords
                    and [item[0].key, item[1].keys()|first]|join(':') not in ssm_passwords_force_rotate
                  else lookup('ansible.builtin.password', '/dev/null chars=ascii_letters length=1')
-                 + lookup('ansible.builtin.password', '/dev/null chars=ascii_letters,digits length=14')
+                 + lookup('ansible.builtin.password', '/dev/null chars=digits length=1')
+                 + lookup('ansible.builtin.password', '/dev/null chars=ascii_letters,digits length=13')
                    if item[1].values()|first == 'auto'
                  else None
              },


### PR DESCRIPTION
Add missing bucket
Run oracle-db-backup role after catalog to ensure relevant secrets have been created
Ensure random passwords have at least one digit