### PR TITLE
DSOS-2359: add cloudwatch monitoring to other apps

### DIFF
--- a/ansible/group_vars/server_type_csr_db.yml
+++ b/ansible/group_vars/server_type_csr_db.yml
@@ -51,8 +51,16 @@ server_type_roles_list:
   - get-ec2-facts
   - set-ec2-hostname
   - domain-search
+  - ansible-script
+  - epel
   - oracle-19c
   - tcp-keepalive
+  - collectd
+  - amazon-cloudwatch-agent
+  - amazon-cloudwatch-agent-collectd
+  - collectd-service-metrics
+  - collectd-oracle-db-connected
+  - collectd-textfile-monitoring
 
 # the below vars are defined in multiple groups.  Keep the values the same to avoid unexpected behaviour
 roles_list: "{{ (ami_roles_list | default([]) | difference(server_type_roles_list | default([]))) + (server_type_roles_list | default([])) }}"

--- a/ansible/group_vars/server_type_ncr_bip.yml
+++ b/ansible/group_vars/server_type_ncr_bip.yml
@@ -26,10 +26,16 @@ server_type_roles_list:
   - message-of-the-day
   - amazon-ssm-agent
   - amazon-cli
+  - ansible-script
+  - epel
   - disks
   - oracle-19c-client
   - oracle-tns-entries
   - ncr-bip
+  - collectd
+  - amazon-cloudwatch-agent
+  - amazon-cloudwatch-agent-collectd
+  - collectd-service-metrics
 
 roles_list: "{{ (ami_roles_list | default([]) | difference(server_type_roles_list | default([]))) + (server_type_roles_list | default([])) }}"
 

--- a/ansible/group_vars/server_type_ncr_bip_cmc.yml
+++ b/ansible/group_vars/server_type_ncr_bip_cmc.yml
@@ -26,10 +26,16 @@ server_type_roles_list:
   - message-of-the-day
   - amazon-ssm-agent
   - amazon-cli
+  - ansible-script
+  - epel
   - disks
   - oracle-19c-client
   - oracle-tns-entries
   - ncr-bip-cmc
+  - collectd
+  - amazon-cloudwatch-agent
+  - amazon-cloudwatch-agent-collectd
+  - collectd-service-metrics
 
 roles_list: "{{ (ami_roles_list | default([]) | difference(server_type_roles_list | default([]))) + (server_type_roles_list | default([])) }}"
 

--- a/ansible/group_vars/server_type_ncr_db.yml
+++ b/ansible/group_vars/server_type_ncr_db.yml
@@ -21,11 +21,19 @@ roles_list:
   - message-of-the-day
   - amazon-ssm-agent
   - amazon-cli
+  - ansible-script
+  - epel
   - disks
   - azcopy
   - oracle-19c
   - oracle-secure-backup
   - oracle-db-backup
+  - collectd
+  - amazon-cloudwatch-agent
+  - amazon-cloudwatch-agent-collectd
+  - collectd-service-metrics
+  - collectd-oracle-db-connected
+  - collectd-textfile-monitoring
 
 packages_yum_install:
   - zip-3.0-23.el8

--- a/ansible/group_vars/server_type_ncr_tomcat.yml
+++ b/ansible/group_vars/server_type_ncr_tomcat.yml
@@ -26,8 +26,14 @@ server_type_roles_list:
   - message-of-the-day
   - amazon-ssm-agent
   - amazon-cli
+  - ansible-script
+  - epel
   - disks
   - ncr-tomcat
+  - collectd
+  - amazon-cloudwatch-agent
+  - amazon-cloudwatch-agent-collectd
+  - collectd-service-metrics
 
 roles_list: "{{ (ami_roles_list | default([]) | difference(server_type_roles_list | default([]))) + (server_type_roles_list | default([])) }}"
 

--- a/ansible/group_vars/server_type_oasys_bip.yml
+++ b/ansible/group_vars/server_type_oasys_bip.yml
@@ -12,10 +12,15 @@ roles_list:
   - packages
   - message-of-the-day
   - amazon-ssm-agent
-  #- amazon-cloudwatch-agent
   - amazon-cli
+  - ansible-script
+  - epel
   - disks
   - oasys-bip
+  - collectd
+  - amazon-cloudwatch-agent
+  - amazon-cloudwatch-agent-collectd
+  - collectd-service-metrics
 
 users_and_groups_system:
   - name: oracle

--- a/ansible/group_vars/server_type_oasys_db.yml
+++ b/ansible/group_vars/server_type_oasys_db.yml
@@ -21,8 +21,9 @@ roles_list:
   - packages
   - message-of-the-day
   - amazon-ssm-agent
-  #- amazon-cloudwatch-agent # currently nomis specific
   - amazon-cli
+  - ansible-script
+  - epel
   # - hugepages has issues
   - disks
   - azure-cli
@@ -31,6 +32,12 @@ roles_list:
   # - oracle-db-standby-setup # manually run on a standby
   - oracle-secure-backup
   - oracle-db-backup
+  - collectd
+  - amazon-cloudwatch-agent
+  - amazon-cloudwatch-agent-collectd
+  - collectd-service-metrics
+  - collectd-oracle-db-connected
+  - collectd-textfile-monitoring
 
 packages_yum_install:
   - zip-3.0-23.el8

--- a/ansible/group_vars/server_type_oasys_web.yml
+++ b/ansible/group_vars/server_type_oasys_web.yml
@@ -14,8 +14,14 @@ roles_list:
   - amazon-ssm-agent
   #- amazon-cloudwatch-agent
   - amazon-cli
+  - ansible-script
+  - epel
   - disks
   - oasys-ords
+  - collectd
+  - amazon-cloudwatch-agent
+  - amazon-cloudwatch-agent-collectd
+  - collectd-service-metrics
 
 users_and_groups_system:
   - name: oracle

--- a/ansible/group_vars/server_type_oasys_weblogic.yml
+++ b/ansible/group_vars/server_type_oasys_weblogic.yml
@@ -14,7 +14,13 @@ roles_list:
   - amazon-ssm-agent
   #- amazon-cloudwatch-agent
   - amazon-cli
+  - ansible-script
+  - epel
   - disks
+  - collectd
+  - amazon-cloudwatch-agent
+  - amazon-cloudwatch-agent-collectd
+  - collectd-service-metrics
 
 users_and_groups_system:
   - name: oracle

--- a/ansible/roles/collectd-textfile-monitoring/templates/collectd_textfile_monitoring.sh.j2
+++ b/ansible/roles/collectd-textfile-monitoring/templates/collectd_textfile_monitoring.sh.j2
@@ -12,7 +12,7 @@ while sleep "$INTERVAL"; do
 {% raw %}
     if [[ -e "$file" ]]; then
       IFS=$'\n'
-      metrics=($(grep -E "^[[:alnum:]_-:]+[[:space:]]+[[:digit:]]+" "$file"))
+      metrics=($(grep -E "^[[:alnum:][:punct:]]+[[:space:]]+[[:digit:]]+" "$file" | grep -v ^#))
       metric_name=$(dirname $file | sed 's|^/opt/||g' | sed 's|/|_|g')
       unset IFS
       file_last_modified=$(date -r "$file" +%s)

--- a/ansible/roles/nomis-misload/files/trigger_mis_load.py
+++ b/ansible/roles/nomis-misload/files/trigger_mis_load.py
@@ -12,8 +12,10 @@ def run_batch_file(target, port, username, password, batch_file):
         else:
             print("Unable to execute the batch file. Status code: {}".format(
                 r.status_code))
+            exit(r.status_code)
     except Exception as e:
         print("An error occurred while trying to execute the batch file:", str(e))
+        exit(1)
 
 
 def main():

--- a/ansible/roles/nomis-misload/files/winrm_connection_check.py
+++ b/ansible/roles/nomis-misload/files/winrm_connection_check.py
@@ -12,8 +12,10 @@ def check_winrm_connection(target, username, password, port):
         else:
             print("Unable to establish WinRM connection. Status code: {}".format(
                 r.status_code))
+            exit(r.status_code)
     except Exception as e:
         print("An error occurred while trying to establish WinRM connection:", str(e))
+        exit(1)
 
 
 def main():

--- a/ansible/roles/oracle-db-backup/tasks/rman-backup-setup.yml
+++ b/ansible/roles/oracle-db-backup/tasks/rman-backup-setup.yml
@@ -21,7 +21,7 @@
     state: directory
     recurse: yes
   loop:
-    - /opt/textfile_monitoring/rman_backup
+    - /opt/textfile_monitoring/rman-backup
     - /home/oracle/admin/rman_scripts/logs
     - /home/oracle/admin/rman_scripts/status
 


### PR DESCRIPTION
Add in additional roles for running ansible locally, enabling EPEL repo and supporting custom metrics via cloudwatch
Plus some other minor fixes 
- misload wasn't reporting error code properly
- grep and directory name fix for rman backup
Applied to all relevant servers