### PR TITLE
Oracle Secure Backup fix for older versions of OS

### DIFF
--- a/ansible/roles/oracle-secure-backup/templates/install.sh
+++ b/ansible/roles/oracle-secure-backup/templates/install.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 export PATH=$PATH:"{{ osw_stage_dir }}/jdk1.7.0_80/bin"
-java -jar "{{ osw_stage_dir }}/osbws_install.jar" -ARGFILE "{{ osw_stage_dir }}/{{ osbws_config.name }}_argfile" -IAMRole "{{ ansible_ec2_iam_instance_profile_role }}" -useHttps | logger -p local3.info -t java
+java -jar "{{ osw_stage_dir }}/osbws_install.jar" -ARGFILE "{{ osw_stage_dir }}/{{ osbws_config.name }}_argfile" -IAMRole "{{ ansible_ec2_iam_instance_profile_role }}" -useHttps -no-check-certificate | logger -p local3.info -t java


### PR DESCRIPTION
For RHEL7.9/Oracle11g this is failing due to missing local cert .  Adding additional option to skip cert check