### PR TITLE
ndh: DSOS-2421: add secrets plus proxy fix

### DIFF
--- a/ansible/group_vars/environment_name_nomis_data_hub_test.yml
+++ b/ansible/group_vars/environment_name_nomis_data_hub_test.yml
@@ -2,3 +2,4 @@
 ansible_aws_ssm_bucket_name: s3-bucket20230309164626616600000002
 image_builder_s3_bucket_name: nomis-data-hub-software20230309164626754200000003
 dns_zone_internal: nomis-data-hub.hmpps-test.modernisation-platform.internal
+ndelius_proxy_pass: interface.test.probation.service.justice.gov.uk

--- a/ansible/roles/ndh-app/defaults/main.yml
+++ b/ansible/roles/ndh-app/defaults/main.yml
@@ -1,13 +1,29 @@
+ndh_environment: "{{ ec2.tags['ndh-environment'] }}"
 ndh_app_bucket: "nomis-data-hub-software20230309164626754200000003"
 ndh_app_object: "/ndh-installation-files/LinuxAppsServer/Appsdirs.zip"
 
-test_domain_name: "t1"
-test_app_host: "t1-ndh-app"
-test_host_os: "Red Hat Enterprise Linux Server"
-test_host_os_version: "7.9"
-test_ems_host: "t1-ndh-ems"
-test_ems_port_1: "7222"
-test_ems_port_2: "7224"
+# following parameters are set in get_facts
+#ndh_admin_user:
+#ndh_admin_pass:
+#ndh_harkemsadmin_ssl_pass:
 
-ndh_proxy_host: "test"
-ndelius_proxy_pass: "interface.test.probation.service.justice.gov.uk"
+# override these default in environment group_vars if necessary
+ndh_domain_name: "{{ ndh_environment }}"
+ndh_ems_host: "{{ ndh_ems_host_a }}"
+ndh_ems_host_a: "{{ ndh_environment }}-ndh-ems-a"
+ndh_ems_host_b: "{{ ndh_environment }}-ndh-ems-b"
+ndh_app_host: "{{ ndh_app_host_a }}"
+ndh_app_host_a: "{{ ndh_environment }}-ndh-app-a"
+ndh_app_host_b: "{{ ndh_environment }}-ndh-app-b"
+ndh_ems_port_1: "7222"
+ndh_ems_port_2: "7224"
+ndh_host_os: "RHEL"
+ndh_host_os_version: "7.9"
+
+ndh_secretsmanager_passwords:
+  ndh-shared:
+    secret: "/ndh/{{ ndh_environment }}/shared"
+    users:
+      - admin_user:
+      - admin_pass:
+      - harkemsadmin_ssl_pass:

--- a/ansible/roles/ndh-app/defaults/main.yml
+++ b/ansible/roles/ndh-app/defaults/main.yml
@@ -19,6 +19,10 @@ ndh_ems_port_1: "7222"
 ndh_ems_port_2: "7224"
 ndh_host_os: "RHEL"
 ndh_host_os_version: "7.9"
+ndh_proxy_host: "{{ ndh_environment }}"
+
+# set this to probation interface URL in relevant environment group_vars
+#ndelius_proxy_pass:
 
 ndh_secretsmanager_passwords:
   ndh-shared:

--- a/ansible/roles/ndh-app/handlers/main.yml
+++ b/ansible/roles/ndh-app/handlers/main.yml
@@ -1,5 +1,3 @@
 ---
 - name: test nginx config
   ansible.builtin.command: nginx -t
-  tags:
-    - amibuild

--- a/ansible/roles/ndh-app/meta/main.yml
+++ b/ansible/roles/ndh-app/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - role: get-ec2-facts

--- a/ansible/roles/ndh-app/tasks/configure_proxy.yml
+++ b/ansible/roles/ndh-app/tasks/configure_proxy.yml
@@ -6,23 +6,17 @@
     baseurl: https://nginx.org/packages/rhel/{{ ansible_distribution_major_version }}/$basearch/
     gpgcheck: no
     enabled: yes
-  tags:
-    - amibuild
 
 - name: Install nginx
   ansible.builtin.package:
     name: nginx
     state: latest
-  tags:
-    - amibuild
 
 - name: Enable nginx
   ansible.builtin.service:
     name: nginx
     enabled: yes
     state: stopped
-  tags:
-    - amibuild
 
 - name: Add nginx proxy config
   ansible.builtin.template:
@@ -30,12 +24,8 @@
     dest: /etc/nginx/nginx.conf
   notify:
     - test nginx config
-  tags:
-    - amibuild
 
 - meta: flush_handlers
-  tags:
-    - amibuild
 
 - name: Create ssl directory in /etc/nginx
   ansible.builtin.file:
@@ -43,16 +33,12 @@
     state: directory
     owner: nginx
     group: nginx
-  tags:
-    - amibuild
 
 - name: Generate a private key
   community.crypto.openssl_privatekey:
     path: /etc/nginx/ssl/nginx.key
     type: RSA
     size: 2048
-  tags:
-    - amibuild
 
 - name: Create a CSR for the ndh_proxy_host
   community.crypto.openssl_csr:
@@ -67,8 +53,6 @@
     csr_path: /etc/nginx/ssl/nginx.csr
     provider: selfsigned
     force: yes
-  tags:
-    - amibuild
 
 - name: add ndh_proxy_host to /etc/hosts for loopback
   ansible.builtin.lineinfile:
@@ -76,13 +60,9 @@
     regexp: '^(127\.0\.0\.1.*)$'
     line: '\1 {{ ndh_proxy_host }}'
     backrefs: yes
-  tags:
-    - amibuild
 
 - name: Start nginx
   ansible.builtin.service:
     name: nginx
     enabled: yes
     state: started
-  tags:
-    - amibuild

--- a/ansible/roles/ndh-app/tasks/get_facts.yml
+++ b/ansible/roles/ndh-app/tasks/get_facts.yml
@@ -1,17 +1,12 @@
 ---
-- name: get ssm parameters
+- name: get secretsmanager passwords
+  import_role:
+    name: secretsmanager-passwords
+  vars:
+    secretsmanager_passwords: "{{ ndh_secretsmanager_passwords }}"
+
+- name: set secretsmanager facts
   set_fact:
-    ndh_admin_user: "{{ lookup('aws_ssm', 'ndh_admin_user', region=ansible_ec2_placement_region) }}"
-    ndh_admin_pass: "{{ lookup('aws_ssm', 'ndh_admin_pass', region=ansible_ec2_placement_region) }}"
-    ndh_domain_name: "{{ lookup('aws_ssm', 'ndh_domain_name', region=ansible_ec2_placement_region) }}"
-    ndh_ems_host: "{{ lookup('aws_ssm', 'ndh_ems_host_a', region=ansible_ec2_placement_region) }}"
-    ndh_ems_host_a: "{{ lookup('aws_ssm', 'ndh_ems_host_a', region=ansible_ec2_placement_region) }}"
-    ndh_ems_host_b: "{{ lookup('aws_ssm', 'ndh_ems_host_b', region=ansible_ec2_placement_region) }}"
-    ndh_app_host: "{{ lookup('aws_ssm', 'ndh_app_host_a', region=ansible_ec2_placement_region) }}"
-    ndh_app_host_a: "{{ lookup('aws_ssm', 'ndh_app_host_a', region=ansible_ec2_placement_region) }}"
-    ndh_app_host_b: "{{ lookup('aws_ssm', 'ndh_app_host_b', region=ansible_ec2_placement_region) }}"
-    ndh_ems_port_1: "{{ lookup('aws_ssm', 'ndh_ems_port_1', region=ansible_ec2_placement_region) }}"
-    ndh_ems_port_2: "{{ lookup('aws_ssm', 'ndh_ems_port_2', region=ansible_ec2_placement_region) }}"
-    ndh_host_os: "{{ lookup('aws_ssm', 'ndh_host_os', region=ansible_ec2_placement_region) }}"
-    ndh_host_os_version: "{{ lookup('aws_ssm', 'ndh_host_os_version', region=ansible_ec2_placement_region) }}"
-    ndh_harkemsadmin_ssl_pass: "{{ lookup('aws_ssm', 'ndh_harkemsadmin_ssl_pass', region=ansible_ec2_placement_region) }}"
+    ndh_admin_user: "{{ secretsmanager_passwords_dict['ndh-shared'].passwords['admin_user'] }}"
+    ndh_admin_pass: "{{ secretsmanager_passwords_dict['ndh-shared'].passwords['admin_pass'] }}"
+    ndh_harkemsadmin_ssl_pass: "{{ secretsmanager_passwords_dict['ndh-shared'].passwords['harkemsadmin_ssl_pass'] }}"

--- a/ansible/roles/ndh-app/tasks/main.yml
+++ b/ansible/roles/ndh-app/tasks/main.yml
@@ -44,4 +44,5 @@
 
 - import_tasks: configure_proxy.yml
   tags:
-    - amibuild
+    - ec2provision
+  when: ndelius_proxy_pass is defined

--- a/ansible/roles/ndh-app/tasks/main.yml
+++ b/ansible/roles/ndh-app/tasks/main.yml
@@ -2,6 +2,8 @@
 - import_tasks: get_facts.yml
   tags:
     - ec2provision
+    - ndh_get_facts
+
 - import_tasks: templates.yml
   tags:
     - ec2provision

--- a/ansible/roles/ndh-ems/defaults/main.yml
+++ b/ansible/roles/ndh-ems/defaults/main.yml
@@ -1,2 +1,29 @@
+ndh_environment: "{{ ec2.tags['ndh-environment'] }}"
 ndh_ems_bucket: "nomis-data-hub-software20230309164626754200000003"
 ndh_ems_object: "/ndh-installation-files/LinuxEMSServer/EMSdirs.zip"
+
+# following parameters are set in get_facts
+#ndh_admin_user:
+#ndh_admin_pass:
+#ndh_harkemsadmin_ssl_pass:
+
+# override these default in environment group_vars if necessary
+ndh_domain_name: "{{ ndh_environment }}"
+ndh_ems_host: "{{ ndh_ems_host_a }}"
+ndh_ems_host_a: "{{ ndh_environment }}-ndh-ems-a"
+ndh_ems_host_b: "{{ ndh_environment }}-ndh-ems-b"
+ndh_app_host: "{{ ndh_app_host_a }}"
+ndh_app_host_a: "{{ ndh_environment }}-ndh-app-a"
+ndh_app_host_b: "{{ ndh_environment }}-ndh-app-b"
+ndh_ems_port_1: "7222"
+ndh_ems_port_2: "7224"
+ndh_host_os: "RHEL"
+ndh_host_os_version: "7.9"
+
+ndh_secretsmanager_passwords:
+  ndh-shared:
+    secret: "/ndh/{{ ndh_environment }}/shared"
+    users:
+      - admin_user:
+      - admin_pass:
+      - harkemsadmin_ssl_pass:

--- a/ansible/roles/ndh-ems/meta/main.yml
+++ b/ansible/roles/ndh-ems/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - role: get-ec2-facts

--- a/ansible/roles/ndh-ems/tasks/get_facts.yml
+++ b/ansible/roles/ndh-ems/tasks/get_facts.yml
@@ -1,17 +1,12 @@
 ---
-- name: get ssm parameters
+- name: get secretsmanager passwords
+  import_role:
+    name: secretsmanager-passwords
+  vars:
+    secretsmanager_passwords: "{{ ndh_secretsmanager_passwords }}"
+
+- name: set secretsmanager facts
   set_fact:
-    ndh_admin_user: "{{ lookup('aws_ssm', 'ndh_admin_user', region=ansible_ec2_placement_region) }}"
-    ndh_admin_pass: "{{ lookup('aws_ssm', 'ndh_admin_pass', region=ansible_ec2_placement_region) }}"
-    ndh_domain_name: "{{ lookup('aws_ssm', 'ndh_domain_name', region=ansible_ec2_placement_region) }}"
-    ndh_ems_host: "{{ lookup('aws_ssm', 'ndh_ems_host_a', region=ansible_ec2_placement_region) }}"
-    ndh_ems_host_a: "{{ lookup('aws_ssm', 'ndh_ems_host_a', region=ansible_ec2_placement_region) }}"
-    ndh_ems_host_b: "{{ lookup('aws_ssm', 'ndh_ems_host_b', region=ansible_ec2_placement_region) }}"
-    ndh_app_host: "{{ lookup('aws_ssm', 'ndh_app_host_a', region=ansible_ec2_placement_region) }}"
-    ndh_app_host_a: "{{ lookup('aws_ssm', 'ndh_app_host_a', region=ansible_ec2_placement_region) }}"
-    ndh_app_host_b: "{{ lookup('aws_ssm', 'ndh_app_host_b', region=ansible_ec2_placement_region) }}"
-    ndh_ems_port_1: "{{ lookup('aws_ssm', 'ndh_ems_port_1', region=ansible_ec2_placement_region) }}"
-    ndh_ems_port_2: "{{ lookup('aws_ssm', 'ndh_ems_port_2', region=ansible_ec2_placement_region) }}"
-    ndh_host_os: "{{ lookup('aws_ssm', 'ndh_host_os', region=ansible_ec2_placement_region) }}"
-    ndh_host_os_version: "{{ lookup('aws_ssm', 'ndh_host_os_version', region=ansible_ec2_placement_region) }}"
-    ndh_harkemsadmin_ssl_pass: "{{ lookup('aws_ssm', 'ndh_harkemsadmin_ssl_pass', region=ansible_ec2_placement_region) }}"
+    ndh_admin_user: "{{ secretsmanager_passwords_dict['ndh-shared'].passwords['admin_user'] }}"
+    ndh_admin_pass: "{{ secretsmanager_passwords_dict['ndh-shared'].passwords['admin_pass'] }}"
+    ndh_harkemsadmin_ssl_pass: "{{ secretsmanager_passwords_dict['ndh-shared'].passwords['harkemsadmin_ssl_pass'] }}"

--- a/ansible/roles/ndh-ems/tasks/main.yml
+++ b/ansible/roles/ndh-ems/tasks/main.yml
@@ -2,6 +2,8 @@
 - import_tasks: get_facts.yml
   tags:
     - ec2provision
+    - ndh_get_facts
+
 - import_tasks: templates.yml
   tags:
     - ec2provision


### PR DESCRIPTION
Primarily migrating from SSM to Secrets but also tweaked proxy:
- Use defaults for configuration value. Most params can be derived from the ndh environment t1, t2 etc.
- Use SecretsManager for shared secrets between ems and app
- Updated proxy - build on ec2provision rather than in ami
- Moved environment specific proxy variable into group_vars

Tested on test-ndh-ems-a and test-ndh-app-a and verified new parameters have same value as the old.