### PR TITLE
DSOS-2361: additional group vars for sub environments

### DIFF
--- a/ansible/hosts/autoscaling_group_aws_ec2.yml
+++ b/ansible/hosts/autoscaling_group_aws_ec2.yml
@@ -23,9 +23,13 @@ compose:
 keyed_groups:
   - key: tags['environment-name']
     prefix: environment-name
+  - key: tags['environment-name'] + '-' + tags[application + '-environment']
+    prefix: environment-name
   - key: tags['ami']
     prefix: ami
   - key: tags['server-type']
+    prefix: server-type
+  - key: tags['server-type'] + '-' + tags[application + '-environment']
     prefix: server-type
   - key: tags['os-type'] | lower
     prefix: os-type

--- a/ansible/hosts/instance_aws_ec2.yml
+++ b/ansible/hosts/instance_aws_ec2.yml
@@ -19,9 +19,13 @@ compose:
 keyed_groups:
   - key: tags['environment-name']
     prefix: environment-name
+  - key: tags['environment-name'] + '-' + tags[application + '-environment']
+    prefix: environment-name
   - key: tags['ami']
     prefix: ami
   - key: tags['server-type']
+    prefix: server-type
+  - key: tags['server-type'] + '-' + tags[application + '-environment']
     prefix: server-type
   - key: tags['os-type'] | lower
     prefix: os-type

--- a/ansible/roles/ansible-script/files/ansible.sh
+++ b/ansible/roles/ansible-script/files/ansible.sh
@@ -77,6 +77,20 @@ run_ansible() {
     fi
   done
 
+  echo "# Checking for $application-environment tag using aws cli"
+  application_environment=$(aws ec2 describe-tags --filters "Name=resource-id,Values=$instance_id" "Name=key,Values=$application-environment" --output=text | head -1 | cut -f5)
+  if [[ -n $application_environment ]]; then
+    for ((i=0; i<${#tags[@]}; i++)); do
+      tag=(${tags[i]})
+      group=$(echo "${tag[1]}_${tag[4]}_${application_environment}" | tr [:upper:] [:lower:] | sed "s/-/_/g")
+      if [[ -e $ansible_dir/${ansible_repo}/${ansible_repo_basedir}/group_vars/$group.yml ]]; then
+        ansible_group_vars="$ansible_group_vars --extra-vars @group_vars/$group.yml"
+      elif [[ -e $ansible_dir/${ansible_repo}/${ansible_repo_basedir}/group_vars/$group/ansible.yml ]]; then
+        ansible_group_vars="$ansible_group_vars --extra-vars @group_vars/$group/ansible.yml"
+      fi
+    done
+  fi
+
   # set python version
   if [[ $(which python3.9 2> /dev/null) ]]; then
     python=$(which python3.9)


### PR DESCRIPTION
Add an additional layer of group vars for when there are stacked environments, e.g. t1, t2, t3 within a stacked account.  If you have tag `nomis-environment` or `oasys-environment`, it will create new groups for those for both environment-name and server-type, e.g. environment_name_nomis_test_t1 or server_type_nomis_web_t1.