### PR TITLE
DSOS: minor fix to rman backup script

### DIFF
--- a/ansible/roles/oracle-db-backup/templates/rman_backup.sh.j2
+++ b/ansible/roles/oracle-db-backup/templates/rman_backup.sh.j2
@@ -80,6 +80,7 @@ set_ora_env () {
 }
 
 get_rcat_creds () {
+(
   account_id=$(aws sts get-caller-identity --query Account --output text)
   secret_account_id="{{ account_ids[oem_account_name] }}"
   if [[ $account_id != $secret_account_id ]]; then
@@ -92,6 +93,7 @@ get_rcat_creds () {
   fi
   secret_arn="arn:aws:secretsmanager:eu-west-2:${secret_account_id}:secret:{{ rcvcat_passwords_secret_name }}"
   aws secretsmanager get-secret-value --secret-id "${secret_arn}" --query SecretString --output text | jq -r .rcvcatowner
+)
 }
 
 validate () {


### PR DESCRIPTION
Ensure assume role section is in a sub-shell.  So temporary AWS creds don't persist outside of the function.
Script is working fine.  The change is just in case this code is copied into other scripts (which has been case already for DBAs)