### PR TITLE
DSOS-2635: ad fixes for core shared services

### DIFF
--- a/powershell/Modules/ModPlatformAD/ModPlatformADCredential.psm1
+++ b/powershell/Modules/ModPlatformAD/ModPlatformADCredential.psm1
@@ -10,9 +10,6 @@ function Get-ModPlatformADCredential {
     domain join username. EC2 requires permissions to join the given role,
     a SSM parameter containing account IDs, and the aws cli.
 
-.PARAMETER AccountIdsSSMParameterName
-    Name of SSM parameter containing account IDs JSON. Default is account_ids
-
 .PARAMETER ModPlatformADCredential
     HashTable as returned from Get-ModPlatformADConfig function
 
@@ -27,17 +24,21 @@ function Get-ModPlatformADCredential {
   [CmdletBinding()]
   param (
     [Parameter(Mandatory=$true)][hashtable]$ModPlatformADConfig,
-    [string]$AccountIdsSSMParameterName = "account_ids"
   )
 
   $ErrorActionPreference = "Stop"
 
+  $AccountIdsSSMParameterName = $ModPlatformADConfig.AccountIdsSSMParameterName
   $AccountIdsRaw = aws ssm get-parameter --name $AccountIdsSSMParameterName --with-decryption --query Parameter.Value --output text
   $AccountIds = "$AccountIdsRaw" | ConvertFrom-Json
   $SecretAccountId = $AccountIds.[string]$ModPlatformADConfig.SecretAccountName
   $SecretName = $ModPlatformADConfig.SecretName
   $SecretArn = "arn:aws:secretsmanager:eu-west-2:${SecretAccountId}:secret:${SecretName}"
+  $SecretRoleName = $null
   if ($ModPlatformADConfig.ContainsKey("SecretRoleName")) {
+    $SecretRoleName = $ModPlatformADConfig.SecretRoleName
+  }
+  if ($SecretRoleName) {
     $AccountId = aws sts get-caller-identity --query Account --output text
     $SecretRoleName = $ModPlatformADConfig.SecretRoleName
     $RoleArn = "arn:aws:iam::${AccountId}:role/${SecretRoleName}"

--- a/powershell/Modules/ModPlatformAD/ModPlatformADCredential.psm1
+++ b/powershell/Modules/ModPlatformAD/ModPlatformADCredential.psm1
@@ -23,7 +23,7 @@ function Get-ModPlatformADCredential {
 
   [CmdletBinding()]
   param (
-    [Parameter(Mandatory=$true)][hashtable]$ModPlatformADConfig,
+    [Parameter(Mandatory=$true)][hashtable]$ModPlatformADConfig
   )
 
   $ErrorActionPreference = "Stop"

--- a/powershell/Scripts/ModPlatformAD/Join-ModPlatformAD.ps1
+++ b/powershell/Scripts/ModPlatformAD/Join-ModPlatformAD.ps1
@@ -18,8 +18,7 @@
 [CmdletBinding()]
 param (
   [string]$NewHostname = "tag:Name",
-  [string]$DomainNameFQDN,
-  [string]$AccountIdsSSMParameterName = "account_ids"
+  [string]$DomainNameFQDN
 )
 
 Import-Module ModPlatformAD -Force
@@ -27,7 +26,7 @@ Import-Module ModPlatformAD -Force
 $ErrorActionPreference = "Stop"
 
 $ADConfig = Get-ModPlatformADConfig -DomainNameFQDN $DomainNameFQDN
-$ADCredential = Get-ModPlatformADCredential -ModPlatformADConfig $ADConfig -AccountIdsSSMParameterName $AccountIdsSSMParameterName
+$ADCredential = Get-ModPlatformADCredential -ModPlatformADConfig $ADConfig
 $Renamed = Rename-ModPlatformADComputer -NewHostname $NewHostname -ModPlatformADCredential $ADCredential
 if ($Renamed) {
   Write-Output "Renamed computer to ${Renamed}"

--- a/powershell/Scripts/ModPlatformAD/Leave-ModPlatformAD.ps1
+++ b/powershell/Scripts/ModPlatformAD/Leave-ModPlatformAD.ps1
@@ -17,8 +17,7 @@
 
 [CmdletBinding()]
 param (
-  [string]$DomainNameFQDN,
-  [string]$AccountIdsSSMParameterName = "account_ids"
+  [string]$DomainNameFQDN
 )
 
 Import-Module ModPlatformAD -Force
@@ -26,7 +25,7 @@ Import-Module ModPlatformAD -Force
 $ErrorActionPreference = "Stop"
 
 $ADConfig = Get-ModPlatformADConfig -DomainNameFQDN $DomainNameFQDN
-$ADCredential = Get-ModPlatformADCredential -ModPlatformADConfig $ADConfig -AccountIdsSSMParameterName $AccountIdsSSMParameterName
+$ADCredential = Get-ModPlatformADCredential -ModPlatformADConfig $ADConfig
 if (Remove-ModPlatformADComputer -ModPlatformADCredential $ADCredential) {
   Exit 3010 # triggers reboot if running from SSM Doc
 }


### PR DESCRIPTION
Re-jigged the AD config to better support core-shared-services account.  The name of the account_id SSM parameter is not part of the AD config hashmap.  Tested in core-shared-services-production and hmpps-domain-services-test for backward compat.