### PR TITLE
nomis: add missing setting for production

### DIFF
--- a/ansible/group_vars/environment_name_nomis_production.yml
+++ b/ansible/group_vars/environment_name_nomis_production.yml
@@ -126,6 +126,9 @@ db_configs:
     service:
       - { name: MIS_TAF, role: PRIMARY }
 
+  PCNOM:
+    db_name: PCNOM
+
   CNOMP:
     db_name: CNOMP
     db_unique_name: CNOMP


### PR DESCRIPTION
Prod DB missing from ansible config