### PR TITLE
BAU: we were seeing 499 bang on 60s, up this to 120s to avoid the 499

### DIFF
--- a/ansible/roles/ndh-app/templates/etc/nginx/nginx.conf.j2
+++ b/ansible/roles/ndh-app/templates/etc/nginx/nginx.conf.j2
@@ -29,6 +29,9 @@ http {
         ssl_certificate /etc/nginx/ssl/nginx.crt;
         ssl_certificate_key /etc/nginx/ssl/nginx.key;
         ssl_protocols TLSv1.1;
+        proxy_read_timeout 120s;
+        proxy_send_timeout 120s;
+        proxy_connect_timeout 120s;
         server_name {{ ndh_proxy_host }};
         location / {
                 proxy_set_header Host $host;


### PR DESCRIPTION
Seeing HTTP 499 on upstream requests, which is indicative of a proxy timeout. update the proxy timeout to cope with a bit of lag