### PR TITLE
nomis: DSOS-2663: Force kill of frmweb processes on service weblogic-all stop

### DIFF
--- a/ansible/roles/nomis-weblogic/templates/10.3/etc/init.d/weblogic-all
+++ b/ansible/roles/nomis-weblogic/templates/10.3/etc/init.d/weblogic-all
@@ -52,6 +52,7 @@ stop() {
   done
   [[ -x /etc/init.d/weblogic-server ]] &&  /etc/init.d/weblogic-server stop
   [[ -x /etc/init.d/weblogic-node-manager ]] && /etc/init.d/weblogic-node-manager stop
+  pkill -9 -u oracle frmweb
 }
 
 status() {


### PR DESCRIPTION
The frmweb processes don't get tidied up automatically.  Kill -9 on a service stop.