### PR TITLE
nomis: DSOS-1944: improve weblogic init scripts

### DIFF
--- a/ansible/roles/nomis-weblogic/tasks/create-additional-form-servers.yml
+++ b/ansible/roles/nomis-weblogic/tasks/create-additional-form-servers.yml
@@ -9,20 +9,20 @@
     weblogic_managed_app: "{{ weblogic_form_server_config.name }}"
     weblogic_managed_app_port: "{{ weblogic_form_server_config.port }}"
 
-- name: Check if managed app already configured
+- name: {{ weblogic_managed_app }} Check if managed app already configured
   ansible.builtin.stat:
     path: /etc/init.d/{{ weblogic_managed_app }}
   register: weblogic_created_managed_app_check
 
-- name: Configure forms
+- name: Configure additional managed app
   block:
     # ensure everything is running
-    - name: Start services if not already running
+    - name: {{ weblogic_managed_app }} Start services if not already running
       ansible.builtin.service:
         name: weblogic-all
         state: started
 
-    - name: Copy managed app configuration file
+    - name: {{ weblogic_managed_app }} Copy managed app configuration file
       ansible.builtin.template:
         src: "10.3/u01/software/weblogic/{{ weblogic_form_server_config.properties_src }}.properties"
         dest: "{{ item }}"
@@ -31,7 +31,7 @@
       loop:
         - /u01/software/weblogic/{{ weblogic_managed_app }}.properties
 
-    - name: Create config directory
+    - name: {{ weblogic_managed_app }} Create config directory
       ansible.builtin.file:
         path: "{{ item }}"
         state: directory
@@ -41,7 +41,7 @@
       loop:
         - /u01/app/oracle/Middleware/user_projects/domains/NomisDomain/config/fmwconfig/servers/{{ weblogic_managed_app }}/applications/formsapp_11.1.2/config
 
-    - name: Copy config files
+    - name: {{ weblogic_managed_app }} Copy config files
       ansible.builtin.copy:
         src: "/u01/app/oracle/Middleware/user_projects/domains/NomisDomain/config/fmwconfig/servers/WLS_FORMS/applications/formsapp_11.1.2/config/{{ item }}"
         dest: "/u01/app/oracle/Middleware/user_projects/domains/NomisDomain/config/fmwconfig/servers/{{ weblogic_managed_app }}/applications/formsapp_11.1.2/config/{{ item }}"
@@ -52,7 +52,7 @@
         - formsweb.cfg
         - tag.env
 
-    - name: Create managed app
+    - name: {{ weblogic_managed_app }} Create managed app
       become_user: oracle
       ansible.builtin.shell: |
         set -eo pipefail
@@ -66,7 +66,7 @@
       async: 7200
       poll: 60
 
-    - name: Create managed app security directory
+    - name: {{ weblogic_managed_app }} Create managed app security directory
       ansible.builtin.file:
         path: "{{ item }}"
         state: directory
@@ -77,7 +77,7 @@
         - "/u01/app/oracle/Middleware/user_projects/domains/NomisDomain/servers/{{ weblogic_managed_app }}/security"
 
     # the boot.properties file is automatically updated by the weblogic server
-    - name: Copy managed app boot properties
+    - name: {{ weblogic_managed_app }} Copy managed app boot properties
       ansible.builtin.template:
         src: "10.3/u01/app/oracle/Middleware/user_projects/domains/NomisDomain/servers/AdminServer/security/boot.properties"
         dest: "{{ item }}"
@@ -87,7 +87,7 @@
       loop:
         - "/u01/app/oracle/Middleware/user_projects/domains/NomisDomain/servers/{{ weblogic_managed_app }}/security/boot.properties"
 
-    - name: Copy managed app init.d script
+    - name: {{ weblogic_managed_app }} Copy managed app init.d script
       vars:
         weblogic_managed_server_name: "{{ weblogic_managed_app }}"
       ansible.builtin.template:
@@ -96,24 +96,24 @@
         mode: "0755"
 
     # this ensures values in boot.properties become encrypted
-    - name: Restart service
+    - name: {{ weblogic_managed_app }} Restart service
       ansible.builtin.service:
         name: "{{ weblogic_managed_app }}"
         state: restarted
       async: 600
       poll: 20
 
-    - name: Update forms config
+    - name: {{ weblogic_managed_app }} Update forms config
       import_tasks: copy-forms-conf.yml
 
-    - name: Restart opmn service
+    - name: {{ weblogic_managed_app }} Restart opmn service
       ansible.builtin.service:
         name: opmn
         state: restarted
       when: weblogic_copy_forms_conf.changed
 
   always:
-    - name: Remove temporary forms configuration files
+    - name: {{ weblogic_managed_app }} Remove temporary forms configuration files
       ansible.builtin.file:
         path: "{{ item }}"
         state: absent
@@ -122,3 +122,19 @@
 
   # block
   when: not weblogic_created_managed_app_check.stat.exists
+
+
+- name: Update additional managed app
+  block:
+    # ensure everything is running
+
+    - name: {{ weblogic_managed_app }} Update managed app init.d script
+      vars:
+        weblogic_managed_server_name: "{{ weblogic_managed_app }}"
+      ansible.builtin.template:
+        src: "10.3/etc/init.d/weblogic-managed-server"
+        dest: "/etc/init.d/{{ weblogic_managed_server_name }}"
+        mode: "0755"
+
+  # block
+  when: weblogic_created_managed_app_check.stat.exists

--- a/ansible/roles/nomis-weblogic/tasks/create-additional-form-servers.yml
+++ b/ansible/roles/nomis-weblogic/tasks/create-additional-form-servers.yml
@@ -123,7 +123,6 @@
   # block
   when: not weblogic_created_managed_app_check.stat.exists
 
-
 - name: Update additional managed app
   block:
     # ensure everything is running

--- a/ansible/roles/nomis-weblogic/tasks/create-additional-form-servers.yml
+++ b/ansible/roles/nomis-weblogic/tasks/create-additional-form-servers.yml
@@ -9,7 +9,7 @@
     weblogic_managed_app: "{{ weblogic_form_server_config.name }}"
     weblogic_managed_app_port: "{{ weblogic_form_server_config.port }}"
 
-- name: Check if managed app already configured
+- name: "{{ weblogic_managed_app }} Check if managed app already configured"
   ansible.builtin.stat:
     path: /etc/init.d/{{ weblogic_managed_app }}
   register: weblogic_created_managed_app_check
@@ -17,12 +17,12 @@
 - name: Configure additional managed app
   block:
     # ensure everything is running
-    - name: {{ weblogic_managed_app }} Start services if not already running
+    - name: "{{ weblogic_managed_app }} Start services if not already running"
       ansible.builtin.service:
         name: weblogic-all
         state: started
 
-    - name: {{ weblogic_managed_app }} Copy managed app configuration file
+    - name: "{{ weblogic_managed_app }} Copy managed app configuration file"
       ansible.builtin.template:
         src: "10.3/u01/software/weblogic/{{ weblogic_form_server_config.properties_src }}.properties"
         dest: "{{ item }}"
@@ -31,7 +31,7 @@
       loop:
         - /u01/software/weblogic/{{ weblogic_managed_app }}.properties
 
-    - name: {{ weblogic_managed_app }} Create config directory
+    - name: "{{ weblogic_managed_app }} Create config directory"
       ansible.builtin.file:
         path: "{{ item }}"
         state: directory
@@ -41,7 +41,7 @@
       loop:
         - /u01/app/oracle/Middleware/user_projects/domains/NomisDomain/config/fmwconfig/servers/{{ weblogic_managed_app }}/applications/formsapp_11.1.2/config
 
-    - name: {{ weblogic_managed_app }} Copy config files
+    - name: "{{ weblogic_managed_app }} Copy config files"
       ansible.builtin.copy:
         src: "/u01/app/oracle/Middleware/user_projects/domains/NomisDomain/config/fmwconfig/servers/WLS_FORMS/applications/formsapp_11.1.2/config/{{ item }}"
         dest: "/u01/app/oracle/Middleware/user_projects/domains/NomisDomain/config/fmwconfig/servers/{{ weblogic_managed_app }}/applications/formsapp_11.1.2/config/{{ item }}"
@@ -52,7 +52,7 @@
         - formsweb.cfg
         - tag.env
 
-    - name: {{ weblogic_managed_app }} Create managed app
+    - name: "{{ weblogic_managed_app }} Create managed app"
       become_user: oracle
       ansible.builtin.shell: |
         set -eo pipefail
@@ -66,7 +66,7 @@
       async: 7200
       poll: 60
 
-    - name: {{ weblogic_managed_app }} Create managed app security directory
+    - name: "{{ weblogic_managed_app }} Create managed app security directory"
       ansible.builtin.file:
         path: "{{ item }}"
         state: directory
@@ -77,7 +77,7 @@
         - "/u01/app/oracle/Middleware/user_projects/domains/NomisDomain/servers/{{ weblogic_managed_app }}/security"
 
     # the boot.properties file is automatically updated by the weblogic server
-    - name: {{ weblogic_managed_app }} Copy managed app boot properties
+    - name: "{{ weblogic_managed_app }} Copy managed app boot properties"
       ansible.builtin.template:
         src: "10.3/u01/app/oracle/Middleware/user_projects/domains/NomisDomain/servers/AdminServer/security/boot.properties"
         dest: "{{ item }}"
@@ -87,7 +87,7 @@
       loop:
         - "/u01/app/oracle/Middleware/user_projects/domains/NomisDomain/servers/{{ weblogic_managed_app }}/security/boot.properties"
 
-    - name: {{ weblogic_managed_app }} Copy managed app init.d script
+    - name: "{{ weblogic_managed_app }} Copy managed app init.d script"
       vars:
         weblogic_managed_server_name: "{{ weblogic_managed_app }}"
       ansible.builtin.template:
@@ -96,24 +96,24 @@
         mode: "0755"
 
     # this ensures values in boot.properties become encrypted
-    - name: {{ weblogic_managed_app }} Restart service
+    - name: "{{ weblogic_managed_app }} Restart service"
       ansible.builtin.service:
         name: "{{ weblogic_managed_app }}"
         state: restarted
       async: 600
       poll: 20
 
-    - name: {{ weblogic_managed_app }} Update forms config
+    - name: "{{ weblogic_managed_app }} Update forms config"
       import_tasks: copy-forms-conf.yml
 
-    - name: {{ weblogic_managed_app }} Restart opmn service
+    - name: "{{ weblogic_managed_app }} Restart opmn service"
       ansible.builtin.service:
         name: opmn
         state: restarted
       when: weblogic_copy_forms_conf.changed
 
   always:
-    - name: {{ weblogic_managed_app }} Remove temporary forms configuration files
+    - name: "{{ weblogic_managed_app }} Remove temporary forms configuration files"
       ansible.builtin.file:
         path: "{{ item }}"
         state: absent
@@ -128,7 +128,7 @@
   block:
     # ensure everything is running
 
-    - name: {{ weblogic_managed_app }} Update managed app init.d script
+    - name: "{{ weblogic_managed_app }} Update managed app init.d script"
       vars:
         weblogic_managed_server_name: "{{ weblogic_managed_app }}"
       ansible.builtin.template:

--- a/ansible/roles/nomis-weblogic/tasks/create-additional-form-servers.yml
+++ b/ansible/roles/nomis-weblogic/tasks/create-additional-form-servers.yml
@@ -9,7 +9,7 @@
     weblogic_managed_app: "{{ weblogic_form_server_config.name }}"
     weblogic_managed_app_port: "{{ weblogic_form_server_config.port }}"
 
-- name: {{ weblogic_managed_app }} Check if managed app already configured
+- name: Check if managed app already configured
   ansible.builtin.stat:
     path: /etc/init.d/{{ weblogic_managed_app }}
   register: weblogic_created_managed_app_check

--- a/ansible/roles/nomis-weblogic/tasks/create-managed-app.yml
+++ b/ansible/roles/nomis-weblogic/tasks/create-managed-app.yml
@@ -4,7 +4,7 @@
     msg: "Error, please ensure weblogic_managed_app is defined"
   when: weblogic_managed_app is not defined
 
-- name: Check if managed app already configured
+- name: "{{ weblogic_managed_app }} Check if managed app already configured"
   ansible.builtin.stat:
     path: /etc/init.d/{{ weblogic_managed_app }}
   register: weblogic_created_managed_app_check
@@ -13,12 +13,12 @@
   block:
 
     # ensure everything is running
-    - name: {{ weblogic_managed_app }} Start services if not already running
+    - name: "{{ weblogic_managed_app }} Start services if not already running"
       ansible.builtin.service:
         name: weblogic-all
         state: started
 
-    - name: {{ weblogic_managed_app }} Copy managed app configuration files
+    - name: "{{ weblogic_managed_app }} Copy managed app configuration files"
       ansible.builtin.template:
         src: "10.3{{ item }}"
         dest: "{{ item }}"
@@ -27,7 +27,7 @@
       loop:
         - /u01/software/weblogic/{{ weblogic_managed_app }}.properties
 
-    - name: {{ weblogic_managed_app }} Create managed app
+    - name: "{{ weblogic_managed_app }} Create managed app"
       become_user: oracle
       ansible.builtin.shell: |
         set -eo pipefail
@@ -41,7 +41,7 @@
       async: 7200
       poll: 60
 
-    - name: {{ weblogic_managed_app }} Create managed app security directory
+    - name: "{{ weblogic_managed_app }} Create managed app security directory"
       ansible.builtin.file:
         path: "{{ item }}"
         state: directory
@@ -52,7 +52,7 @@
         - "/u01/app/oracle/Middleware/user_projects/domains/NomisDomain/servers/{{ weblogic_managed_app }}/security"
 
     # the boot.properties file is automatically updated by the weblogic server
-    - name: {{ weblogic_managed_app }} Copy managed app boot properties
+    - name: "{{ weblogic_managed_app }} Copy managed app boot properties"
       ansible.builtin.template:
         src: "10.3/u01/app/oracle/Middleware/user_projects/domains/NomisDomain/servers/AdminServer/security/boot.properties"
         dest: "{{ item }}"
@@ -62,7 +62,7 @@
       loop:
         - "/u01/app/oracle/Middleware/user_projects/domains/NomisDomain/servers/{{ weblogic_managed_app }}/security/boot.properties"
 
-    - name: {{ weblogic_managed_app }} Copy managed app init.d script
+    - name: "{{ weblogic_managed_app }} Copy managed app init.d script"
       vars:
         weblogic_managed_server_name: "{{ weblogic_managed_app }}"
       ansible.builtin.template:
@@ -71,7 +71,7 @@
         mode: "0755"
 
     # this ensures values in boot.properties become encrypted
-    - name: {{ weblogic_managed_app }} Restart service
+    - name: "{{ weblogic_managed_app }} Restart service"
       ansible.builtin.service:
         name: "{{ weblogic_managed_app }}"
         state: restarted
@@ -79,7 +79,7 @@
       poll: 20
 
   always:
-    - name: {{ weblogic_managed_app }} Remove temporary forms configuration files
+    - name: "{{ weblogic_managed_app }} Remove temporary forms configuration files"
       ansible.builtin.file:
         path: "{{ item }}"
         state: absent
@@ -91,7 +91,7 @@
 
 - name: Update managed app
   block:
-    - name: {{ weblogic_managed_app }} Update managed app init.d script
+    - name: "{{ weblogic_managed_app }} Update managed app init.d script"
       vars:
         weblogic_managed_server_name: "{{ weblogic_managed_app }}"
       ansible.builtin.template:

--- a/ansible/roles/nomis-weblogic/tasks/create-managed-app.yml
+++ b/ansible/roles/nomis-weblogic/tasks/create-managed-app.yml
@@ -11,7 +11,6 @@
 
 - name: Configure managed app
   block:
-
     # ensure everything is running
     - name: "{{ weblogic_managed_app }} Start services if not already running"
       ansible.builtin.service:

--- a/ansible/roles/nomis-weblogic/tasks/create-managed-app.yml
+++ b/ansible/roles/nomis-weblogic/tasks/create-managed-app.yml
@@ -4,23 +4,21 @@
     msg: "Error, please ensure weblogic_managed_app is defined"
   when: weblogic_managed_app is not defined
 
-- name: Check if managed app already configured
+- name: {{ weblogic_managed_app }} Check if managed app already configured
   ansible.builtin.stat:
     path: /etc/init.d/{{ weblogic_managed_app }}
   register: weblogic_created_managed_app_check
 
-- name: Configure forms
+- name: Configure managed app
   block:
-    - debug:
-        msg: "Creating managed app {{ weblogic_managed_app }}"
 
     # ensure everything is running
-    - name: Start services if not already running
+    - name: {{ weblogic_managed_app }} Start services if not already running
       ansible.builtin.service:
         name: weblogic-all
         state: started
 
-    - name: Copy managed app configuration files
+    - name: {{ weblogic_managed_app }} Copy managed app configuration files
       ansible.builtin.template:
         src: "10.3{{ item }}"
         dest: "{{ item }}"
@@ -29,7 +27,7 @@
       loop:
         - /u01/software/weblogic/{{ weblogic_managed_app }}.properties
 
-    - name: Create managed app
+    - name: {{ weblogic_managed_app }} Create managed app
       become_user: oracle
       ansible.builtin.shell: |
         set -eo pipefail
@@ -43,7 +41,7 @@
       async: 7200
       poll: 60
 
-    - name: Create managed app security directory
+    - name: {{ weblogic_managed_app }} Create managed app security directory
       ansible.builtin.file:
         path: "{{ item }}"
         state: directory
@@ -54,7 +52,7 @@
         - "/u01/app/oracle/Middleware/user_projects/domains/NomisDomain/servers/{{ weblogic_managed_app }}/security"
 
     # the boot.properties file is automatically updated by the weblogic server
-    - name: Copy managed app boot properties
+    - name: {{ weblogic_managed_app }} Copy managed app boot properties
       ansible.builtin.template:
         src: "10.3/u01/app/oracle/Middleware/user_projects/domains/NomisDomain/servers/AdminServer/security/boot.properties"
         dest: "{{ item }}"
@@ -64,7 +62,7 @@
       loop:
         - "/u01/app/oracle/Middleware/user_projects/domains/NomisDomain/servers/{{ weblogic_managed_app }}/security/boot.properties"
 
-    - name: Copy managed app init.d script
+    - name: {{ weblogic_managed_app }} Copy managed app init.d script
       vars:
         weblogic_managed_server_name: "{{ weblogic_managed_app }}"
       ansible.builtin.template:
@@ -73,7 +71,7 @@
         mode: "0755"
 
     # this ensures values in boot.properties become encrypted
-    - name: Restart service
+    - name: {{ weblogic_managed_app }} Restart service
       ansible.builtin.service:
         name: "{{ weblogic_managed_app }}"
         state: restarted
@@ -81,7 +79,7 @@
       poll: 20
 
   always:
-    - name: Remove temporary forms configuration files
+    - name: {{ weblogic_managed_app }} Remove temporary forms configuration files
       ansible.builtin.file:
         path: "{{ item }}"
         state: absent
@@ -90,3 +88,16 @@
 
   # block
   when: not weblogic_created_managed_app_check.stat.exists
+
+- name: Update managed app
+  block:
+    - name: {{ weblogic_managed_app }} Update managed app init.d script
+      vars:
+        weblogic_managed_server_name: "{{ weblogic_managed_app }}"
+      ansible.builtin.template:
+        src: "10.3/etc/init.d/weblogic-managed-server"
+        dest: "/etc/init.d/{{ weblogic_managed_server_name }}"
+        mode: "0755"
+
+  # block
+  when: weblogic_created_managed_app_check.stat.exists

--- a/ansible/roles/nomis-weblogic/tasks/create-managed-app.yml
+++ b/ansible/roles/nomis-weblogic/tasks/create-managed-app.yml
@@ -4,7 +4,7 @@
     msg: "Error, please ensure weblogic_managed_app is defined"
   when: weblogic_managed_app is not defined
 
-- name: {{ weblogic_managed_app }} Check if managed app already configured
+- name: Check if managed app already configured
   ansible.builtin.stat:
     path: /etc/init.d/{{ weblogic_managed_app }}
   register: weblogic_created_managed_app_check

--- a/ansible/roles/nomis-weblogic/templates/10.3/etc/init.d/opmn
+++ b/ansible/roles/nomis-weblogic/templates/10.3/etc/init.d/opmn
@@ -48,6 +48,7 @@ get_process_pids() {
 
 start() {
   echo -n $"Starting $prog: "
+  touch /var/lock/subsys/$prog
   if PIDS=$(get_process_pids); then
     echo -n "Already running"
     echo_success
@@ -58,11 +59,13 @@ start() {
   if ! start_process; then
     echo_failure
     echo
+    rm -f /var/lock/subsys/$prog
     return 1
   fi
   if ! get_process_pids > /dev/null; then
     echo_failure
     echo
+    rm -f /var/lock/subsys/$prog
     return 1
   fi
   echo_success
@@ -71,6 +74,7 @@ start() {
 
 stop() {
   echo -n $"Shutting down $prog: "
+  rm -f /var/lock/subsys/$prog
   if ! PIDS=$(get_process_pids); then
     echo -n "Already stopped"
     echo_success

--- a/ansible/roles/nomis-weblogic/templates/10.3/etc/init.d/weblogic-all
+++ b/ansible/roles/nomis-weblogic/templates/10.3/etc/init.d/weblogic-all
@@ -56,7 +56,7 @@ start_sequential() {
 }
 
 start() {
-  start_sequential
+  start_parallel
 }
 
 stop() {

--- a/ansible/roles/nomis-weblogic/templates/10.3/etc/init.d/weblogic-all
+++ b/ansible/roles/nomis-weblogic/templates/10.3/etc/init.d/weblogic-all
@@ -8,9 +8,12 @@
 # Source function library.
 . /etc/init.d/functions
 
+prog="weblogic-all"
+
 start_parallel() {
   set -e
   echo $"Starting all weblogic processes: "
+  touch /var/lock/subsys/$prog
   [[ -x /etc/init.d/weblogic-node-manager ]] && /etc/init.d/weblogic-node-manager start
   [[ -x /etc/init.d/weblogic-server ]] &&  /etc/init.d/weblogic-server start
 
@@ -46,6 +49,7 @@ start_parallel() {
 start_sequential() {
   set -e
   echo $"Starting all weblogic processes: "
+  touch /var/lock/subsys/$prog
   [[ -x /etc/init.d/weblogic-node-manager ]] && /etc/init.d/weblogic-node-manager start
   [[ -x /etc/init.d/weblogic-server ]] &&  /etc/init.d/weblogic-server start
   managed_services=$(find /etc/init.d/ -name 'WLS*')
@@ -61,6 +65,7 @@ start() {
 
 stop() {
   echo $"Stopping all weblogic processes: "
+  rm -f /var/lock/subsys/$prog
   [[ -x /etc/init.d/opmn ]] && /etc/init.d/opmn stop
   managed_services=$(find /etc/init.d/ -name 'WLS*' | sort -r)
   for managed_service in $managed_services; do

--- a/ansible/roles/nomis-weblogic/templates/10.3/etc/init.d/weblogic-all
+++ b/ansible/roles/nomis-weblogic/templates/10.3/etc/init.d/weblogic-all
@@ -8,7 +8,7 @@
 # Source function library.
 . /etc/init.d/functions
 
-start() {
+start_parallel() {
   set -e
   echo $"Starting all weblogic processes: "
   [[ -x /etc/init.d/weblogic-node-manager ]] && /etc/init.d/weblogic-node-manager start
@@ -41,6 +41,22 @@ start() {
   set -e
 
   [[ -x /etc/init.d/opmn ]] && /etc/init.d/opmn start
+}
+
+start_sequential() {
+  set -e
+  echo $"Starting all weblogic processes: "
+  [[ -x /etc/init.d/weblogic-node-manager ]] && /etc/init.d/weblogic-node-manager start
+  [[ -x /etc/init.d/weblogic-server ]] &&  /etc/init.d/weblogic-server start
+  managed_services=$(find /etc/init.d/ -name 'WLS*')
+  for managed_service in $managed_services; do
+    $managed_service start
+  done
+  [[ -x /etc/init.d/opmn ]] && /etc/init.d/opmn start
+}
+
+start() {
+  start_sequential
 }
 
 stop() {
@@ -169,6 +185,12 @@ case "$1" in
     start
     repair
     ;;
+  start_sequential)
+    start_sequential
+    ;;
+  start_parallel)
+    start_parallel
+    ;;
   stop)
     stop
     ;;
@@ -185,7 +207,7 @@ case "$1" in
     repair
     ;;
   *)
-    echo "Usage: $0 {start|stop|restart|status|healthcheck|repair}"
+    echo "Usage: $0 {start|stop|restart|status|healthcheck|repair|start_sequential|start_parallel}"
     exit 3
 esac
 

--- a/ansible/roles/nomis-weblogic/templates/10.3/etc/init.d/weblogic-healthcheck
+++ b/ansible/roles/nomis-weblogic/templates/10.3/etc/init.d/weblogic-healthcheck
@@ -28,6 +28,7 @@ start_process() {
 
 start() {
   echo -n $"Starting $prog: "
+  touch /var/lock/subsys/$prog
   if PIDS=$(get_healthcheck_pid); then
     echo -n "healthcheck already running: $PIDS"
     echo_success
@@ -39,12 +40,14 @@ start() {
     echo "init.d failed starting $prog" | logger -p local3.info -t "$prog"
     echo_failure
     echo
+    rm -f /var/lock/subsys/$prog
     return 1
   fi
   if ! get_healthcheck_pid > /dev/null; then
     echo "init.d failed getting process pids for $prog" | logger -p local3.info -t "$prog"
     echo_failure
     echo
+    rm -f /var/lock/subsys/$prog
     return 1
   fi
   echo "init.d started $prog" | logger -p local3.info -t "$prog"
@@ -54,6 +57,7 @@ start() {
 
 stop() {
   echo -n $"Stopping $prog: "
+  rm -f /var/lock/subsys/$prog
   if ! PIDS=$(get_healthcheck_pid); then
     echo -n "Already stopped"
     echo_success

--- a/ansible/roles/nomis-weblogic/templates/10.3/etc/init.d/weblogic-managed-server
+++ b/ansible/roles/nomis-weblogic/templates/10.3/etc/init.d/weblogic-managed-server
@@ -23,6 +23,15 @@ wait_process() {
   timeout 290 /home/oracle/admin/scripts/wait_for_entry_in_log.sh /var/log/messages "Server started in RUNNING mode" "$prog:"
 }
 
+stop_process() {
+  if [[ $(whoami) == "root" ]]; then
+    nohup su - oracle -c ". /u01/app/oracle/Middleware/wlserver_10.3/server/bin/setWLSEnv.sh && . /u01/app/oracle/Middleware/user_projects/domains/NomisDomain/bin/setDomainEnv.sh && /u01/app/oracle/Middleware/user_projects/domains/NomisDomain/bin/stopManagedWebLogic.sh {{ weblogic_managed_server_name }}" 2>&1 | logger -p local3.info -t "$prog" &
+  else
+    echo -n "must be run as root"
+    return 1
+  fi
+}
+
 get_process_pids() {
   process_pids1=$(pgrep -u oracle -f "startManagedWebLogic.sh {{ weblogic_managed_server_name }}$" 2> /dev/null)
   process_pids2=$(pgrep -u oracle -f "weblogic.Name={{ weblogic_managed_server_name }} " 2> /dev/null)
@@ -67,6 +76,14 @@ stop() {
   echo -n $"Shutting down $prog: "
   if ! PIDS=$(get_process_pids); then
     echo -n "Already stopped"
+    echo_success
+    echo
+    return 0
+  fi
+  echo "init.d stopping $prog" | logger -p local3.info -t "$prog"
+  stop_process
+  sleep 2
+  if ! PIDS=$(get_process_pids); then
     echo_success
     echo
     return 0

--- a/ansible/roles/nomis-weblogic/templates/10.3/etc/init.d/weblogic-managed-server
+++ b/ansible/roles/nomis-weblogic/templates/10.3/etc/init.d/weblogic-managed-server
@@ -19,7 +19,7 @@ start_process() {
   fi
 }
 
-wait_process() {
+wait_start_process() {
   timeout 290 /home/oracle/admin/scripts/wait_for_entry_in_log.sh /var/log/messages "Server started in RUNNING mode" "$prog:"
 }
 
@@ -30,6 +30,10 @@ stop_process() {
     echo -n "must be run as root"
     return 1
   fi
+}
+
+wait_stop_process() {
+  timeout 15 /home/oracle/admin/scripts/wait_for_entry_in_log.sh /var/log/messages "Done" "$prog:"
 }
 
 get_process_pids() {
@@ -58,7 +62,7 @@ start() {
     echo
     return 1
   fi
-  if ! wait_process; then
+  if ! wait_start_process; then
     echo "init.d failed waiting for $prog" | logger -p local3.info -t "$prog"
   fi
   if ! get_process_pids > /dev/null; then
@@ -82,7 +86,9 @@ stop() {
   fi
   echo "init.d stopping $prog" | logger -p local3.info -t "$prog"
   stop_process
-  sleep 2
+  if ! wait_stop_process; then
+    echo "init.d failed waiting to stop $prog" | logger -p local3.info -t "$prog"
+  fi
   if ! PIDS=$(get_process_pids); then
     echo_success
     echo

--- a/ansible/roles/nomis-weblogic/templates/10.3/etc/init.d/weblogic-managed-server
+++ b/ansible/roles/nomis-weblogic/templates/10.3/etc/init.d/weblogic-managed-server
@@ -51,6 +51,7 @@ get_process_pids() {
 
 start() {
   echo -n $"Starting $prog: "
+  touch /var/lock/subsys/$prog
   if PIDS=$(get_process_pids); then
     echo -n "Already running"
     echo_success
@@ -62,6 +63,7 @@ start() {
     echo "init.d failed starting $prog" | logger -p local3.info -t "$prog"
     echo_failure
     echo
+    rm -f /var/lock/subsys/$prog
     return 1
   fi
   if ! wait_start_process; then
@@ -71,6 +73,7 @@ start() {
     echo "init.d failed getting process pids for $prog" | logger -p local3.info -t "$prog"
     echo_failure
     echo
+    rm -f /var/lock/subsys/$prog
     return 1
   fi
   echo "init.d started $prog" | logger -p local3.info -t "$prog"
@@ -80,6 +83,7 @@ start() {
 
 stop() {
   echo -n $"Shutting down $prog: "
+  rm -f /var/lock/subsys/$prog
   if ! PIDS=$(get_process_pids); then
     echo -n "Already stopped"
     echo_success

--- a/ansible/roles/nomis-weblogic/templates/10.3/etc/init.d/weblogic-managed-server
+++ b/ansible/roles/nomis-weblogic/templates/10.3/etc/init.d/weblogic-managed-server
@@ -20,7 +20,9 @@ start_process() {
 }
 
 wait_start_process() {
-  timeout 290 /home/oracle/admin/scripts/wait_for_entry_in_log.sh /var/log/messages "Server started in RUNNING mode" "$prog:"
+  # <IIOP> ... <[ACTIVE] ExecuteThread: '0' for queue: 'weblogic.kernel.Default (self-tuning)'> ... <IIOP subsystem enabled.>
+  # It can take an age for weblogic to progress from the above line in the logs
+  timeout 900 /home/oracle/admin/scripts/wait_for_entry_in_log.sh /var/log/messages "Server started in RUNNING mode" "$prog:"
 }
 
 stop_process() {

--- a/ansible/roles/nomis-weblogic/templates/10.3/etc/init.d/weblogic-node-manager
+++ b/ansible/roles/nomis-weblogic/templates/10.3/etc/init.d/weblogic-node-manager
@@ -36,6 +36,7 @@ get_process_pids() {
 
 start() {
   echo -n $"Starting $prog: "
+  touch /var/lock/subsys/$prog
   if PIDS=$(get_process_pids); then
     echo -n "Already running"
     echo_success
@@ -47,6 +48,7 @@ start() {
     echo "init.d failed starting $prog" | logger -p local3.info -t "$prog"
     echo_failure
     echo
+    rm -f /var/lock/subsys/$prog
     return 1
   fi
   if ! wait_process; then
@@ -56,6 +58,7 @@ start() {
     echo "init.d failed getting process pids for $prog" | logger -p local3.info -t "$prog"
     echo_failure
     echo
+    rm -f /var/lock/subsys/$prog
     return 1
   fi
   echo "init.d started $prog" | logger -p local3.info -t "$prog"
@@ -65,6 +68,7 @@ start() {
 
 stop() {
   echo -n $"Shutting down $prog: "
+  rm -f /var/lock/subsys/$prog
   if ! PIDS=$(get_process_pids); then
     echo -n "Already stopped"
     echo_success

--- a/ansible/roles/nomis-weblogic/templates/10.3/etc/init.d/weblogic-server
+++ b/ansible/roles/nomis-weblogic/templates/10.3/etc/init.d/weblogic-server
@@ -23,6 +23,15 @@ wait_process() {
   timeout 290 /home/oracle/admin/scripts/wait_for_entry_in_log.sh /var/log/messages "Server started in RUNNING mode" "$prog:"
 }
 
+stop_process() {
+  if [[ $(whoami) == "root" ]]; then
+    nohup su - oracle -c /u01/app/oracle/Middleware/user_projects/domains/NomisDomain/bin/stopWebLogic.sh 2>&1 | logger -p local3.info -t "$prog" &
+  else
+    echo -n "must be run as root"
+    return 1
+  fi
+}
+
 get_process_pids() {
   process_pids1=$(pgrep -u oracle -f "startWebLogic.sh$" 2> /dev/null)
   process_pids2=$(pgrep -u oracle -f "weblogic.Name=AdminServer" 2> /dev/null)
@@ -67,6 +76,14 @@ stop() {
   echo -n $"Shutting down $prog: "
   if ! PIDS=$(get_process_pids); then
     echo -n "Already stopped"
+    echo_success
+    echo
+    return 0
+  fi
+  echo "init.d stopping $prog" | logger -p local3.info -t "$prog"
+  stop_process
+  sleep 2
+  if ! PIDS=$(get_process_pids); then
     echo_success
     echo
     return 0

--- a/ansible/roles/nomis-weblogic/templates/10.3/etc/init.d/weblogic-server
+++ b/ansible/roles/nomis-weblogic/templates/10.3/etc/init.d/weblogic-server
@@ -19,7 +19,7 @@ start_process() {
   fi
 }
 
-wait_process() {
+wait_start_process() {
   timeout 290 /home/oracle/admin/scripts/wait_for_entry_in_log.sh /var/log/messages "Server started in RUNNING mode" "$prog:"
 }
 
@@ -30,6 +30,10 @@ stop_process() {
     echo -n "must be run as root"
     return 1
   fi
+}
+
+wait_stop_process() {
+  timeout 15 /home/oracle/admin/scripts/wait_for_entry_in_log.sh /var/log/messages "Done" "$prog:"
 }
 
 get_process_pids() {
@@ -58,7 +62,7 @@ start() {
     echo
     return 1
   fi
-  if ! wait_process; then
+  if ! wait_start_process; then
     echo "init.d failed waiting for $prog" | logger -p local3.info -t "$prog"
   fi
   if ! get_process_pids > /dev/null; then
@@ -82,7 +86,9 @@ stop() {
   fi
   echo "init.d stopping $prog" | logger -p local3.info -t "$prog"
   stop_process
-  sleep 2
+  if ! wait_stop_process; then
+    echo "init.d failed waiting to stop $prog" | logger -p local3.info -t "$prog"
+  fi
   if ! PIDS=$(get_process_pids); then
     echo_success
     echo

--- a/ansible/roles/nomis-weblogic/templates/10.3/etc/init.d/weblogic-server
+++ b/ansible/roles/nomis-weblogic/templates/10.3/etc/init.d/weblogic-server
@@ -49,6 +49,7 @@ get_process_pids() {
 
 start() {
   echo -n $"Starting $prog: "
+  touch /var/lock/subsys/$prog
   if PIDS=$(get_process_pids); then
     echo -n "Already running"
     echo_success
@@ -60,6 +61,7 @@ start() {
     echo "init.d failed starting $prog" | logger -p local3.info -t "$prog"
     echo_failure
     echo
+    rm -f /var/lock/subsys/$prog
     return 1
   fi
   if ! wait_start_process; then
@@ -69,6 +71,7 @@ start() {
     echo "init.d failed getting process pids for $prog" | logger -p local3.info -t "$prog"
     echo_failure
     echo
+    rm -f /var/lock/subsys/$prog
     return 1
   fi
   echo "init.d started $prog" | logger -p local3.info -t "$prog"
@@ -78,6 +81,7 @@ start() {
 
 stop() {
   echo -n $"Shutting down $prog: "
+  rm -f /var/lock/subsys/$prog
   if ! PIDS=$(get_process_pids); then
     echo -n "Already stopped"
     echo_success


### PR DESCRIPTION
Some improvements to nomis-weblogic ansible role and associated init.d scripts:
- use the weblogic stop scripts on shutdown
- ensure lock files are created so weblogic shuts down properly on powerdown
- increase start timeout from 3 mins to 15 mins, yes, it takes that long
- allow ansible tags ec2patch to update init.d scripts
- improve labelling of ansible tasks