### PR TITLE
Onr/dsos 2682/add rhel 6 requirements constraints

### DIFF
--- a/ansible/constraints.rhel6.txt
+++ b/ansible/constraints.rhel6.txt
@@ -1,0 +1,1 @@
+cryptography==2.3

--- a/ansible/roles/ansible-requirements/tasks/pip.yml
+++ b/ansible/roles/ansible-requirements/tasks/pip.yml
@@ -1,13 +1,19 @@
 ---
 - name: Install specified python requirements
   ansible.builtin.copy:
-    src: "{{ role_path }}/../../requirements.txt"
-    dest: "~/.ansible-configuration-management-requirements.txt"
+    src: "{{ role_path }}/../../{{ item }}"
+    dest: "~/.ansible-configuration-management-{{ item }}"
+  loop:
+    - requirements.txt
+    - constraints.rhel6.txt
 
 - name: Install specified python requirements using given python interpreter
   ansible.builtin.pip:
     executable: "{{ ansible_python_interpreter | regex_replace('python', 'pip') }}"
     requirements: "~/.ansible-configuration-management-requirements.txt"
+    extra_args: "{{ pip_extra_args }}"
+  vars:
+    pip_extra_args: "{% if '3.6' in ansible_python_interpreter %}-c ~/.ansible-configuration-management-constraints.rhel6.txt{% endif %}"
   when: ansible_python_interpreter is defined
 
 - name: Install specified python requirements using default pip


### PR DESCRIPTION
- if ansible-requirements role is run it'll deal with the issues around the cryptographic library
- constraints.rhel6.txt file required for ami-builder repo to build/run ansible in virtual envs without failures