### PR TITLE
Adding labeler workflow in order to label PRs

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,10 @@
+github-workflow:
+  - changed-files:
+    - any-glob-to-any-file:
+      - ".github/workflows/**"
+
+configuration-management-repository:
+  - changed-files:
+    - any-glob-to-any-file:
+      - "**/*.*"
+      - "**/*"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,17 @@
+name: "Pull Request Labeler"
+
+on:
+  pull_request_target:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5.0.0
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
This PR introduces the labeler workflow and the labeler configuration. This is so that we can label PRs created against this repository as `configuration-management-repository` and then exclude them from the list of PRs in the slack reminder settings.