### PR TITLE
onr(get): don't create home for boe_install_user

### DIFF
--- a/ansible/roles/onr-get/tasks/ensure-user-group.yml
+++ b/ansible/roles/onr-get/tasks/ensure-user-group.yml
@@ -7,3 +7,4 @@
   ansible.builtin.user:
     name: "{{ boe_install_user }}"
     group: "{{ boe_install_group }}"
+    create_home: false


### PR DESCRIPTION
We don't login as this user - a home directory isn't needed.