### PR TITLE
ndh: DSOS-2759: add windows fileshare

### DIFF
--- a/ansible/group_vars/environment_name_nomis_data_hub_production.yml
+++ b/ansible/group_vars/environment_name_nomis_data_hub_production.yml
@@ -3,3 +3,18 @@ ansible_aws_ssm_bucket_name: s3-bucket20230313100641329200000002
 image_builder_s3_bucket_name: nomis-data-hub-software20230309164626754200000003
 dns_zone_internal: nomis-data-hub.hmpps-production.modernisation-platform.internal
 ndelius_proxy_pass: interface.probation.service.justice.gov.uk
+
+app_filesystems_domain_name_fqdn: azure.hmpp.root
+app_filesystems_mount:
+  - dir: /opt/data/interfaces/extract
+    uid: 10002
+    gid: 10002
+    fstype: cifs
+    opts: vers=3.0,_netdev,nofail,uid=10002,gid=10002,dir_mode=0755,file_mode=0755,credentials=/root/.filesystems/{{ filesystems_domain_name_fqdn }}.creds
+    src: //PDPDW00057.azure.hmpp.root/NOMS_Extracts_PD$
+    metric_dimension: NOMS_Extracts_PD
+
+filesystems_domains:
+  azure.hmpp.root:
+    secret_name: /ndh/pd/shared
+    mount_fs_username: svc_noms_ndh_pd

--- a/ansible/group_vars/server_type_ndh_app.yml
+++ b/ansible/group_vars/server_type_ndh_app.yml
@@ -8,13 +8,18 @@ server_type_roles_list:
   - ansible-script
   - epel
   - packages
+  - filesystems
   - ndh-app
   - collectd
   - amazon-cloudwatch-agent
   - amazon-cloudwatch-agent-collectd
   - collectd-service-metrics
+  - collectd-textfile-monitoring
 
 packages_yum_install:
   - jq
+
+filesystems_domain_name_fqdn: "{{ app_filesystems_domain_name_fqdn|default('') }}"
+filesystems_mount: "{{ app_filesystems_mount|default([]) }}"
 
 roles_list: "{{ (ami_roles_list | default([]) | difference(server_type_roles_list | default([]))) + (server_type_roles_list | default([])) }}"

--- a/ansible/group_vars/server_type_nomis_build.yml
+++ b/ansible/group_vars/server_type_nomis_build.yml
@@ -3,6 +3,7 @@ ansible_python_interpreter: /usr/local/bin/python3.9
 
 packages_yum_install:
   - libaio
+  - ksh
 
 disks_mount:
   - ebs_device_name: /dev/sdb

--- a/ansible/roles/filesystems/README.md
+++ b/ansible/roles/filesystems/README.md
@@ -1,5 +1,15 @@
 # Role for managing file shares
 
+This role will:
+- install relevant packages
+- optionally retrieve credentials from SecretsManager
+- mount the filesystem and add to fstab
+- optionally run a keepalive check with Cloudwatch monitoring
+
+For cloudwatch monitoring, ensure `collectd-textfile-monitoring` role is included.
+Metrics will appear in `CWAgent/InstanceId,type,type_instance` where the
+type_instance metric dimension is set to the value of `metric_dimension` variable.
+
 ## Mount EFS file shares
 
 In appropriate `group_vars`, define `filesystem_mount`
@@ -11,6 +21,7 @@ filesystems_mount:
     fstype: nfs
     opts: nfsvers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2,noresvport,nofail
     src: "{{ ansible_ec2_placement_availability_zone }}.fs-0a170471eea499c2c.efs.eu-west-2.amazonaws.com:/"
+    metric_dimension: fs-0a170471eea499c2c
 ```
 
 Single-AZ, e.g. in eu-west-2a
@@ -20,6 +31,7 @@ filesystems_mount:
     fstype: nfs
     opts: nfsvers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2,noresvport,nofail
     src: "eu-west-2a.fs-0a170471eea499c2c.efs.eu-west-2.amazonaws.com:/"
+    metric_dimension: fs-0a170471eea499c2c
 ```
 
 ## Mount FSX windows file shares
@@ -41,6 +53,28 @@ filesystems_mount:
     fstype: cifs
     opts: vers=3.1.1,rsize=130048,wsize=130048,cache=none,credentials=/root/.filesystems/{{ filesystems_domain_name_fqdn }}.creds
     src: //amznfsxgnktcz6b.azure.noms.root/share
+    metric_dimension: amznfsxgnktcz6b
+```
+
+## Mount EC2 windows file shares
+
+This is more or less the same as FSX. This example uses a secret configured in the same account
+rather than cross-account access.
+
+```
+filesystems_domain_name_fqdn: azure.hmpp.root
+filesystems_domains:
+  azure.hmpp.root:
+    secret_name: /ndh/pd/shared
+    mount_fs_username: svc_noms_ndh_pd
+filesystems_mount:
+  - dir: /opt/data/interfaces/extract
+    uid: 10002
+    gid: 10002
+    fstype: cifs
+    opts: vers=3.0,_netdev,nofail,uid=10002,gid=10002,dir_mode=0755,file_mode=0755,credentials=/root/.filesystems/{{ filesystems_domain_name_fqdn }}.creds
+    src: //PDPDW00057.azure.hmpp.root/NOMS_Extracts_PD$
+    metric_dimension: NOMS_Extracts_PD
 ```
 
 ## Running Ansible

--- a/ansible/roles/filesystems/defaults/main.yml
+++ b/ansible/roles/filesystems/defaults/main.yml
@@ -1,4 +1,7 @@
 ---
+# Run collectd-textfile-monitoring to enable cloudwatch monitoring
+filesystems_metric_dir: /opt/textfile_monitoring/filesystems_check
+
 # Define list of filesystems to mount using `filesystems_mount` list.
 #filesystems_mount: examples below
 
@@ -16,7 +19,7 @@ filesystems_domains:
     secret_account_name: hmpps-domain-services-production
     secret_role_name: EC2HmppsDomainSecretsRole
     secret_name: "/microsoft/AD/azure.hmpp.root/shared-passwords"
-    mount_fs_username: svc_join_domain
+    mount_fs_username: svc_noms_ndh_pd
 
 filesystems_domain: "{{ filesystems_domains[filesystems_domain_name_fqdn] }}"
 
@@ -27,8 +30,8 @@ filesystems_mount_user:
 
 filesystems_secretsmanager_passwords:
   filesystems_shared_passwords:
-    account_name: "{{ filesystems_domain.secret_account_name }}"
-    assume_role_name: "{{ filesystems_domain.secret_role_name }}"
+    account_name: "{{ filesystems_domain.secret_account_name|default('') }}"
+    assume_role_name: "{{ filesystems_domain.secret_role_name|default('') }}"
     secret: "{{ filesystems_domain.secret_name }}"
     users:
       - "{{ filesystems_mount_user | items2dict }}"

--- a/ansible/roles/filesystems/tasks/main.yml
+++ b/ansible/roles/filesystems/tasks/main.yml
@@ -5,7 +5,15 @@
     - ec2provision
     - ec2patch
     - filesystems_domain_creds
-  when: filesystems_domain_name_fqdn is defined
+  when: filesystems_domain_name_fqdn is defined and filesystems_domain_name_fqdn|length > 0
+
+- import_tasks: monitoring.yml
+  tags:
+    - amibuild
+    - ec2provision
+    - ec2patch
+    - filesystems_monitoring
+  when: filesystems_mount is defined
 
 - import_tasks: mount.yml
   tags:

--- a/ansible/roles/filesystems/tasks/monitoring.yml
+++ b/ansible/roles/filesystems/tasks/monitoring.yml
@@ -1,0 +1,15 @@
+---
+- name: Create monitoring directory
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: directory
+  loop:
+    - "{{ filesystems_metric_dir }}"
+
+- name: Copy monitoring script to /usr/local/bin
+  ansible.builtin.template:
+    src: "{{ item }}"
+    dest: "/usr/local/bin/{{ item }}"
+    mode: "0755"
+  loop:
+    - filesystem_keepalive.sh

--- a/ansible/roles/filesystems/tasks/mount.yml
+++ b/ansible/roles/filesystems/tasks/mount.yml
@@ -11,6 +11,8 @@
   ansible.builtin.file:
     path: "{{ item.dir }}"
     state: "directory"
+    owner: "{{ item.uid }}"
+    group: "{{ item.gid }}"
   loop_control:
     label: "{{ item.dir }}"
   loop: "{{ filesystems_mount }}"
@@ -22,6 +24,17 @@
     path: "{{ item.dir }}"
     src: "{{ item.src }}"
     state: "{{ item.state | default('mounted') }}"
+  loop_control:
+    label: "{{ item.dir }}"
+  loop: "{{ filesystems_mount }}"
+
+- name: Setup monitoring keepalive cron
+  ansible.builtin.cron:
+    name: "cleanup tmp for weblogic"
+    user: root
+    minute: "*/5"
+    job: "/usr/local/bin/filesystem_keepalive.sh '{{ item.src }}' '{{ item.metric_dimension }}' 2>&1 | logger -p local3.info -t filesystem_keepalive.sh"
+  when: item.metric_dimension is defined and item.metric_dimension|length > 0
   loop_control:
     label: "{{ item.dir }}"
   loop: "{{ filesystems_mount }}"

--- a/ansible/roles/filesystems/templates/filesystem_keepalive.sh
+++ b/ansible/roles/filesystems/templates/filesystem_keepalive.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# check mount is working by writing temporary file. Optionally update cloudwatch metric
+FILESHARE_SOURCE="$1"
+METRIC_NAME="$2"
+METRIC_DIR="{{ filesystems_metric_dir }}"
+
+if [[ -z $FILESHARE_SOURCE ]]; then
+  echo "Usage: $0 <source> [<metric_name>]" >&2
+  echo "Where" >&2
+  echo "  <source>: fileshare source, e.g. first entry in fstab"
+  echo "  <metric_name>: friendly name for file share for cloudwatch metric, no special chars or dashes"
+  exit 1
+fi
+
+old_exitcode=""
+if [[ -e "$METRIC_DIR/$METRIC_NAME.metric" ]]; then
+  metrics=($(grep -E "^[[:alnum:][:punct:]]+[[:space:]]+[[:digit:]]+" "$METRIC_DIR/$METRIC_NAME.metric" | grep -v ^#))
+  old_exitcode=${metrics[1]}
+fi
+
+mount_dir=$(mount | grep -Fw "$FILESHARE_SOURCE" | cut -d\  -f3)
+if [[ -z $mount_dir ]]; then
+  exitcode=1
+else
+  timeout 5 echo test > "$mount_dir/${HOSTNAME}_keepalive.txt"
+  exitcode=$?
+fi
+
+if [[ -n $METRIC_NAME ]]; then
+  echo "$METRIC_NAME $exitcode" > "$METRIC_DIR/$METRIC_NAME.metric"
+fi
+if [[ -z $old_exitcode || $exitcode -ne $old_exitcode ]]; then
+  if [[ $exitcode -eq 0 ]]; then
+    echo "$FILESHARE_SOURCE: mounted ok, updated ${HOSTNAME}_keepalive.txt"
+  else
+    echo "$FILESHARE_SOURCE: error writing keepalive $exitcode"
+  fi
+fi
+exit $exitcode

--- a/ansible/roles/secretsmanager-passwords/tasks/main.yml
+++ b/ansible/roles/secretsmanager-passwords/tasks/main.yml
@@ -43,13 +43,13 @@
     PATH=$PATH:/usr/local/bin
     set -e
     account_id=$(aws sts get-caller-identity --query Account --output text)
-    {% if item.value.account_name is defined %}
+    {% if item.value.account_name is defined and item.value.account_name|length > 0 %}
     secret_account_id="{{ account_ids[item.value.account_name] }}"
     secret_arn="arn:aws:secretsmanager:eu-west-2:${secret_account_id}:secret:{{ item.value.secret }}"
     {% else %}
     secret_arn="{{ item.value.secret }}"
     {% endif %}
-    {% if item.value.assume_role_name is defined %}
+    {% if item.value.assume_role_name is defined and item.value.assume_role_name|length > 0 %}
     role_arn="arn:aws:iam::${account_id}:role/{{ item.value.assume_role_name }}"
     session="{{ item.key }}-ansible"
     creds=$(aws sts assume-role --role-arn "${role_arn}" --role-session-name "${session}"  --output text --query "Credentials.[AccessKeyId,SecretAccessKey,SessionToken]")
@@ -171,7 +171,7 @@
   ansible.builtin.shell: |
     PATH=$PATH:/usr/local/bin
     set -e
-    {% if item.value.config.account_name is defined %}
+    {% if item.value.config.account_name is defined and item.value.account_name|length > 0 %}
     account_id=$(aws sts get-caller-identity --query Account --output text)
     secret_account_id="{{ account_ids[item.value.config.account_name] }}"
     if [[ $account_id != $secret_account_id ]]; then


### PR DESCRIPTION
Added Azure Windows fileshare to NDH prod app servers.  
- Tweak secretsmanager/filesystem role so creds can be retrieved from current aws account
- Added keepalive monitoring with cloudwatch integration
- Add ksh to nomis build server 
Tested on NDH prod and is working OK.