### PR TITLE
Onr/dsos 2726/set onr boe uids

### DIFF
--- a/ansible/group_vars/server_type_onr_boe.yml
+++ b/ansible/group_vars/server_type_onr_boe.yml
@@ -4,12 +4,12 @@ ansible_python_interpreter: /usr/local/bin/python3.6
 # NOTE: test environment uses different values from production and preproduction, defaults are 502 and 501 for group dba and user oracle. For some reason 'test' uses 503 and 502.
 users_and_groups_system:
   - group: dba
-    gid: "{{ ec2.tags['environment-name'] == 'oasys-national-reporting-test' | ternary(503, 502)"
+    gid: "{{ ec2.tags['environment-name'] == 'oasys-national-reporting-test' | ternary(503, 502) }}"
   - group: wheel
     gid: 10
   - name: oracle
     group: oinstall
-    uid: "{{ ec2.tags['environment-name'] == 'oasys-national-reporting-test' | ternary(502, 501)"
+    uid: "{{ ec2.tags['environment-name'] == 'oasys-national-reporting-test' | ternary(502, 501) }}"
     groups:
       - dba
       - wheel

--- a/ansible/group_vars/server_type_onr_boe.yml
+++ b/ansible/group_vars/server_type_onr_boe.yml
@@ -1,14 +1,21 @@
 ---
 ansible_python_interpreter: /usr/local/bin/python3.6
 
+# NOTE: test environment uses different values from production and preproduction, defaults are 502 and 501 for group dba and user oracle. For some reason 'test' uses 503 and 502.
 users_and_groups_system:
+  - group: dba
+    gid: "{{ ec2.tags['environment-name'] == 'oasys-national-reporting-test' | ternary(503, 502)"
+  - group: wheel
+    gid: 10
   - name: oracle
     group: oinstall
+    uid: "{{ ec2.tags['environment-name'] == 'oasys-national-reporting-test' | ternary(502, 501)"
     groups:
       - dba
       - wheel
   - name: bobj
     group: binstall
+    uid: 1201
     groups:
       - dba
       - sapsys


### PR DESCRIPTION
- set uids and gids for server_type_onr_boe instances
- match uid and gid values to servers in Azure
- cope with the fact that 't2' (test) environment uid and gid values for the same roles != production & preproduction 