### PR TITLE
fix conditionals, allow gids to be set from config

### DIFF
--- a/ansible/group_vars/server_type_onr_boe.yml
+++ b/ansible/group_vars/server_type_onr_boe.yml
@@ -4,7 +4,7 @@ ansible_python_interpreter: /usr/local/bin/python3.6
 # NOTE: test environment uses different values from production and preproduction, defaults are 502 and 501 for group dba and user oracle. For some reason 't2' uses 503 and 502.
 users_and_groups_system:
   - group: dba
-    gid: "{{ (ec2.tags['environment-name'] == 'oasys-national-reporting-test') | ternary('503', '502') }}" 
+    gid: "{{ (ec2.tags['environment-name'] == 'oasys-national-reporting-test') | ternary('503', '502') }}"
   - group: wheel
     gid: 10
   - group: oinstall

--- a/ansible/group_vars/server_type_onr_boe.yml
+++ b/ansible/group_vars/server_type_onr_boe.yml
@@ -1,15 +1,17 @@
 ---
 ansible_python_interpreter: /usr/local/bin/python3.6
 
-# NOTE: test environment uses different values from production and preproduction, defaults are 502 and 501 for group dba and user oracle. For some reason 'test' uses 503 and 502.
+# NOTE: test environment uses different values from production and preproduction, defaults are 502 and 501 for group dba and user oracle. For some reason 't2' uses 503 and 502.
 users_and_groups_system:
   - group: dba
-    gid: "{{ ec2.tags['environment-name'] == 'oasys-national-reporting-test' | ternary(503, 502) }}"
+    gid: "{{ (ec2.tags['environment-name'] == 'oasys-national-reporting-test') | ternary('503', '502') }}" 
   - group: wheel
     gid: 10
+  - group: oinstall
+    gid: "{{ (ec2.tags['environment-name'] == 'oasys-national-reporting-test') | ternary('502', '501') }}"
   - name: oracle
     group: oinstall
-    uid: "{{ ec2.tags['environment-name'] == 'oasys-national-reporting-test' | ternary(502, 501) }}"
+    uid: "{{ (ec2.tags['environment-name'] == 'oasys-national-reporting-test') | ternary('502', '501') }}"
     groups:
       - dba
       - wheel

--- a/ansible/roles/users-and-groups/tasks/add-system.yml
+++ b/ansible/roles/users-and-groups/tasks/add-system.yml
@@ -9,16 +9,22 @@
 
 - name: Calculate list of groups
   ansible.builtin.set_fact:
-    system_groups_1: "{{ users_and_groups_system | map(attribute='group') }}"
-    system_groups_2: "{{ users_and_groups_system | selectattr('groups', 'defined') | map(attribute='groups') | flatten }}"
+    all_system_groups: >- # Jinja 2 multi-line string
+      {{ 
+        (
+          users_and_groups_system | map(attribute='group') | list
+        ) + (
+          users_and_groups_system | selectattr('groups', 'defined') | map(attribute='groups') | flatten | list
+        ) | unique 
+      }}
 
 - name: Add system groups
   ansible.builtin.group:
     name: "{{ item }}"
     state: present
     system: yes
-    gid: "{{ system_gids[item]|default(omit) }}"
-  loop: "{{ (system_groups_1 + system_groups_2) | unique }}"
+    gid: "{{ (users_and_groups_system | selectattr('group', 'equalto', item) | map(attribute='gid') | first | default(system_gids[item] | default(omit))) }}"
+  loop: "{{ all_system_groups }}"
 
 - name: Add system users
   ansible.builtin.user:


### PR DESCRIPTION
Set ONR BOE user/group id values == what's in the equivalent Azure env

- FIX conditionals in J2 for uid, gid values for ONR BOE instances
- change `users-and-groups` role to allow setting gid values independently as well
- use jinja2 >- syntax to make multi-line logic easier to read 