### PR TITLE
put entire fqdn for tns entries

### DIFF
--- a/ansible/group_vars/server_type_onr_boe.yml
+++ b/ansible/group_vars/server_type_onr_boe.yml
@@ -102,10 +102,10 @@ tns_entries:
     - name: T2BOSYS
       port: 1521
       host_list:
-        - t2-onr-db-a.oasys.hmpps-test.modernisation-platform.internal
+        - t2-onr-db-a.oasys.hmpps-test.modernisation-platform.service.justice.gov.uk
       service_name: BOSYS_TAF
     - name: T2BOAUD
       port: 1521
       host_list:
-        - t2-onr-db-a.oasys.hmpps-test.modernisation-platform.internal
+        - t2-onr-db-a.oasys.hmpps-test.modernisation-platform.service.justice.gov.uk
       service_name: BOAUD_TAF


### PR DESCRIPTION
- these are cross account so 'internal' is unlikely to work