### PR TITLE
Nomis: DSOS-2660: sshd config

### DIFF
--- a/ansible/group_vars/server_type_base_ol85.yml
+++ b/ansible/group_vars/server_type_base_ol85.yml
@@ -4,6 +4,7 @@ ansible_python_interpreter: python3.9
 server_type_roles_list:
   - autoscale-group-hooks
   - get-ec2-facts
+  - sshd-config
   - users-and-groups
   - set-ec2-hostname
   - ssh-host-keys

--- a/ansible/group_vars/server_type_base_rhel610.yml
+++ b/ansible/group_vars/server_type_base_rhel610.yml
@@ -3,6 +3,7 @@ ansible_python_interpreter: /usr/local/bin/python3.6
 
 server_type_roles_list:
   - autoscale-group-hooks
+  - sshd-config
   - users-and-groups
   - set-ec2-hostname
   - domain-search

--- a/ansible/group_vars/server_type_base_rhel79.yml
+++ b/ansible/group_vars/server_type_base_rhel79.yml
@@ -3,6 +3,7 @@ ansible_python_interpreter: /usr/local/bin/python3.9
 
 server_type_roles_list:
   - autoscale-group-hooks
+  - sshd-config
   - users-and-groups
   - set-ec2-hostname
   - domain-search

--- a/ansible/group_vars/server_type_base_rhel85.yml
+++ b/ansible/group_vars/server_type_base_rhel85.yml
@@ -4,6 +4,7 @@ ansible_python_interpreter: python3.9
 server_type_roles_list:
   - autoscale-group-hooks
   - get-ec2-facts
+  - sshd-config
   - users-and-groups
   - set-ec2-hostname
   - domain-search

--- a/ansible/group_vars/server_type_csr_db.yml
+++ b/ansible/group_vars/server_type_csr_db.yml
@@ -43,6 +43,7 @@ disks_mount:
     fstype: swap
 
 server_type_roles_list:
+  - sshd-config
   - users-and-groups
   - sudoers
   - ssh-host-keys

--- a/ansible/group_vars/server_type_hmpps_oem.yml
+++ b/ansible/group_vars/server_type_hmpps_oem.yml
@@ -45,6 +45,7 @@ disks_mount:
     fstype: swap
 
 server_type_roles_list:
+  - sshd-config
   - users-and-groups
   - sudoers
   - ssh-host-keys

--- a/ansible/group_vars/server_type_ncr_bip.yml
+++ b/ansible/group_vars/server_type_ncr_bip.yml
@@ -14,6 +14,7 @@ users_and_groups_system:
       - sapsys
 
 server_type_roles_list:
+  - sshd-config
   - users-and-groups
   - sudoers
   - get-ec2-facts

--- a/ansible/group_vars/server_type_ncr_db.yml
+++ b/ansible/group_vars/server_type_ncr_db.yml
@@ -9,6 +9,7 @@ users_and_groups_system:
       - wheel
 
 roles_list:
+  - sshd-config
   - users-and-groups
   - sudoers
   - get-ec2-facts

--- a/ansible/group_vars/server_type_ncr_db.yml
+++ b/ansible/group_vars/server_type_ncr_db.yml
@@ -9,6 +9,7 @@ users_and_groups_system:
       - wheel
 
 roles_list:
+  - ssh-host-keys
   - sshd-config
   - users-and-groups
   - sudoers

--- a/ansible/group_vars/server_type_ncr_web.yml
+++ b/ansible/group_vars/server_type_ncr_web.yml
@@ -14,6 +14,7 @@ users_and_groups_system:
       - sapsys
 
 server_type_roles_list:
+  - sshd-config
   - users-and-groups
   - sudoers
   - get-ec2-facts

--- a/ansible/group_vars/server_type_nomis_build.yml
+++ b/ansible/group_vars/server_type_nomis_build.yml
@@ -23,6 +23,7 @@ users_and_groups_system:
 server_type_roles_list:
   - sudoers
   - selinux-config
+  - sshd-config
   - users-and-groups
   - set-ec2-hostname
   - domain-search

--- a/ansible/group_vars/server_type_oasys_bip.yml
+++ b/ansible/group_vars/server_type_oasys_bip.yml
@@ -1,6 +1,7 @@
 ---
 ansible_python_interpreter: /usr/local/bin/python3.9
 roles_list:
+  - sshd-config
   - users-and-groups
   - sudoers
   - get-ec2-facts

--- a/ansible/group_vars/server_type_oasys_db.yml
+++ b/ansible/group_vars/server_type_oasys_db.yml
@@ -9,6 +9,7 @@ users_and_groups_system:
       - wheel
 
 roles_list:
+  - sshd-config
   - users-and-groups
   - sudoers
   - get-ec2-facts

--- a/ansible/group_vars/server_type_oasys_web.yml
+++ b/ansible/group_vars/server_type_oasys_web.yml
@@ -1,6 +1,7 @@
 ---
 ansible_python_interpreter: /usr/bin/python3.9
 roles_list:
+  - sshd-config
   - users-and-groups
   - sudoers
   - get-ec2-facts

--- a/ansible/group_vars/server_type_onr_boe.yml
+++ b/ansible/group_vars/server_type_onr_boe.yml
@@ -23,6 +23,7 @@ users_and_groups_system:
       - sapsys
 
 server_type_roles_list:
+  - sshd-config
   - users-and-groups
   - sudoers
   - get-ec2-facts

--- a/ansible/group_vars/server_type_onr_db.yml
+++ b/ansible/group_vars/server_type_onr_db.yml
@@ -9,6 +9,7 @@ users_and_groups_system:
       - wheel
 
 roles_list:
+  - sshd-config
   - users-and-groups
   - sudoers
   - get-ec2-facts

--- a/ansible/group_vars/server_type_onr_web.yml
+++ b/ansible/group_vars/server_type_onr_web.yml
@@ -17,6 +17,7 @@ ansible_python_interpreter: /usr/bin/python3.9
 #       - sapsys
 
 server_type_roles_list:
+  #  - sshd-config
   #  - users-and-groups
   - sudoers
   - get-ec2-facts

--- a/ansible/roles/ad-domain-join/README.md
+++ b/ansible/roles/ad-domain-join/README.md
@@ -30,6 +30,11 @@ ad_domains:
     domain_join_username: svc_join_domain
 ```
 
+# sshd-config
+
+Ensure `sshd-config` role is run with `sshd_config_mode: domain_joined` to enable
+relevant settings in sshd.
+
 # SSH with SSM
 
 You can use SSM to ssh to the server with your domain credentials.

--- a/ansible/roles/ad-domain-join/defaults/main.yml
+++ b/ansible/roles/ad-domain-join/defaults/main.yml
@@ -1,7 +1,6 @@
 ---
 # define ad_domain_name_fqdn in appropriate group_vars to enable role
 #ad_domain_name_fqdn: azure.noms.root
-sshd_disable_pubkey_authentication: true
 
 ad_domains:
   azure.noms.root:

--- a/ansible/roles/ad-domain-join/handlers/main.yml
+++ b/ansible/roles/ad-domain-join/handlers/main.yml
@@ -1,6 +1,0 @@
----
-- name: Restart SSSD service
-  service:
-    name: sssd
-    state: restarted
-    enabled: yes

--- a/ansible/roles/ad-domain-join/tasks/join_domain_rhel.yml
+++ b/ansible/roles/ad-domain-join/tasks/join_domain_rhel.yml
@@ -1,19 +1,4 @@
 ---
-- name: Configure sshd_config enable password authentication
-  ansible.builtin.lineinfile:
-    path: /etc/ssh/sshd_config
-    regexp: "^PasswordAuthentication.*no"
-    line: "PasswordAuthentication=yes"
-  notify: Restart SSSD service
-
-- name: Configure sshd_config disable public key authentication
-  ansible.builtin.lineinfile:
-    path: /etc/ssh/sshd_config
-    regexp: "PubkeyAuthentication.*yes"
-    line: "PubkeyAuthentication=no"
-  notify: Restart SSSD service
-  when: sshd_disable_pubkey_authentication
-
 - name: Install pexpect for injecting secrets
   ansible.builtin.pip:
     name: pexpect

--- a/ansible/roles/sshd-config/README.md
+++ b/ansible/roles/sshd-config/README.md
@@ -1,0 +1,21 @@
+# sshd-config role
+
+Update SSHD config with given settings defined in defaults.
+
+Set `sshd_config_mode` to control which settings are applied.
+
+## SSH over SSM
+
+This is the default. KeyPair auth only
+
+```
+sshd_config_mode: default
+```
+
+## Domain Joined
+
+Set following for password auth
+
+```
+sshd_config_mode: domain_joined
+```

--- a/ansible/roles/sshd-config/defaults/main.yml
+++ b/ansible/roles/sshd-config/defaults/main.yml
@@ -1,0 +1,16 @@
+---
+sshd_config_mode: default
+
+sshd_config_settings:
+  domain_joined:
+    X11Forwarding: "no"
+    PermitRootLogin: "no"
+    PasswordAuthentication: "yes"
+    PubkeyAuthentication: "no"
+    UsePAM: "yes"
+  default:
+    X11Forwarding: "no"
+    PermitRootLogin: "no"
+    PasswordAuthentication: "no"
+    PubkeyAuthentication: "yes"
+    UsePAM: "no"

--- a/ansible/roles/sshd-config/handlers/main.yml
+++ b/ansible/roles/sshd-config/handlers/main.yml
@@ -1,0 +1,6 @@
+---
+- name: Restart SSHD service
+  service:
+    name: sshd
+    state: restarted
+    enabled: yes

--- a/ansible/roles/sshd-config/handlers/main.yml
+++ b/ansible/roles/sshd-config/handlers/main.yml
@@ -1,6 +1,7 @@
 ---
 - name: Restart SSHD service
-  service:
+  ansible.builtin.service:
     name: sshd
     state: restarted
     enabled: yes
+  ignore_errors: yes

--- a/ansible/roles/sshd-config/tasks/main.yml
+++ b/ansible/roles/sshd-config/tasks/main.yml
@@ -1,0 +1,12 @@
+---
+- import_tasks: update-sshd-config.yml
+  tags:
+    - amibuild
+    - ec2provision
+    - ec2patch
+
+# Ensure handlers run before the next role
+- name: Flush handlers
+  meta: flush_handlers
+  tags:
+    - always

--- a/ansible/roles/sshd-config/tasks/update-sshd-config.yml
+++ b/ansible/roles/sshd-config/tasks/update-sshd-config.yml
@@ -1,0 +1,11 @@
+---
+- name: Configure sshd_config disable public key authentication
+  ansible.builtin.lineinfile:
+    path: /etc/ssh/sshd_config
+    regex: "^(#)?{{ item.key }}"
+    line: "{{ item.key }} {{ item.value }}"
+    state: present
+  notify: Restart SSHD service
+  loop_control:
+    label: "{{ item.key }}"
+  loop: "{{ sshd_config_settings[sshd_config_mode]|dict2items }}"

--- a/ansible/roles/users-and-groups/tasks/add-regular.yml
+++ b/ansible/roles/users-and-groups/tasks/add-regular.yml
@@ -90,6 +90,7 @@
     uid: "{{ item.uid|default(omit) }}"
     create_home: "{{ item.create_home }}"
     home: "{{ item.home }}"
+    password: "{{ item.password|default('*') }}"
     state: "{{ item.state }}"
     system: no
   loop_control:


### PR DESCRIPTION
Move sshd-config stuff into its own role.
Update sshd-config so it works with SSH over SSM. Syscon are getting issues with password resets and this fixes it.