### PR TITLE
Onr/dsos 2726/onr silent installer response file

### DIFF
--- a/ansible/roles/onr-boe/defaults/main.yml
+++ b/ansible/roles/onr-boe/defaults/main.yml
@@ -5,7 +5,6 @@ artefact_dir: /u02
 app_dir: /u01/software/BOE_3_1_FP7_4_Linux
 onr_environment: "{{ ec2.tags['oasys-national-reporting-environment'] }}"
 
-boe_software: ENTERPRISE07P_4-10007478.TGZ
 boe_install_user: bobj
 boe_install_group: binstall
 
@@ -17,3 +16,12 @@ boe_secretsmanager_passwords:
     secret: "/ec2/onr-boe/{{ onr_environment }}/passwords"
     users:
       - boe: auto # just a random user so this role works
+  t2_oracle_sys:
+    secret: "/oracle/database/T2BOSYS/passwords"
+    users:
+      - cmspassword: auto # gets added into the response file for t2
+  t2_oracle_aud:
+    secret: "/oracle/database/T2BOAUD/passwords"
+    users:
+      - boe: auto # just a random user so this role works
+

--- a/ansible/roles/onr-boe/files/example_response.ini
+++ b/ansible/roles/onr-boe/files/example_response.ini
@@ -1,4 +1,4 @@
-# Installation Response File
+# Installation Response File - Example only! Do not use!
 # ----------------------------------------------------------------------
 #
 

--- a/ansible/roles/onr-boe/files/pp_response_file.ini
+++ b/ansible/roles/onr-boe/files/pp_response_file.ini
@@ -1,0 +1,4 @@
+# Installation Response File for preproduction environment
+# ----------------------------------------------------------------------
+#
+# Included to show how this should work. Preproduction is not yet implemented but there should be an EC2 Instance tag of say oasys-national-reporing-environment = "pp" which would then allow this (filled in) response file to be used.

--- a/ansible/roles/onr-boe/files/t2_response_file.ini
+++ b/ansible/roles/onr-boe/files/t2_response_file.ini
@@ -1,0 +1,218 @@
+# Installation Response File for T2 environment
+# ----------------------------------------------------------------------
+#
+
+[Manual Settings]
+# The name of the local server. This feature overrides the local server name
+# to the machine name specified. It must be manually set within the response file
+# or it will be defaulted to the local machine name.
+MACHINENAME=
+
+
+[Paths]
+# The path of the bobje directory. This feature is automically set by
+# the installation directory specified as a command line argument followed
+# by /bobje/.
+BOBJEDIR="/u01/app/boe/bobje/"
+
+# The path of the DISK_1 directory on the CD. This path defaults to the cd directory
+# pertaining to the install which has created the response file. It may be overwritten
+# by specifying the cd directory as an argument on the command line.
+CDDIR=/u02/temp/DISK_1
+
+# The path of the license directory.
+LICENSEDIR=
+
+
+[Product Information]
+# The current language with the following exceptions:
+#       1) "jp"         if the current language is "ja"         (Japanese)
+#       2) "chs"        if the current language is "zh_CN"      (Chinese - China)
+#       3) "cht"        if the current language is "zh_TW"      (Chinese - Taiwan)
+BOBJELANG="en"
+
+# The name of the product being installed.
+PRODUCTID_NAME="BusinessObjects"
+
+# The version of Business Objects Enterprise.
+BOBJEVERSION="12.0"
+
+# The version of the product being installed.
+PRODUCTID_VER="12.7"
+
+# The license key to install Business Objects Enterprise.
+BOBJELICENSEKEY=
+
+# The product id key. ( The product id is usually the same as the BOBJELICENSEKEY )
+PIDKEY=
+
+
+[Installation Information]
+# The installation function to perform. (i.e. install)
+FUNCTION=install
+
+# The type of installation. (i.e. new / custom / webtier )
+INSTALLTYPE="custom"
+
+# A comma-delimited list of flags that describe the operating mode of the Installer
+# The following flags are supported:
+# install     - running a new install of the product
+# modify      - running a modify install on a previously installed product
+# remove      - running a uninstall of on a previously installed product
+# integrated  - the current install is running from within another installed (ie. integrated langpacks)
+# interactive - UI is enabled and can prompt for user response
+INSTALLMODE=install
+
+# The name of the local server.
+LOCALNAMESERVER=
+
+# Whether to perform a user or system install.
+BOBJEINSTALLLOCAL="system"
+
+# The language packs to install.
+# Each language is specified using the short format and is seperated by a space.
+# Example: LANGPACKS_TO_INSTALL=en fr
+LANGPACKS_TO_INSTALL=
+
+# List of all languages included in the product.
+# Each language is specified using the short format and is seperated by a comma.
+# Example: LANGUAGES_TO_INSTALL=en,fr
+LANGUAGES_TO_INSTALL=cs,da,de,en,es,fi,fr,hu,it,ja,ko,nb,nl,pl,pt,ru,sk,sl,sv,th,zh_CN,zh_TW
+
+# The Business Objects Enterprise username.
+BOBJEUSERNAME="bobj"
+
+# Specified servers to add.
+EXPANDSERVERS=
+
+
+[Tomcat]
+# Whether or not to install Tomcat.
+INSTALLTOMCAT=no
+
+# The connection port.
+CONNECTORPORT="8080"
+
+# The redirection port.
+REDIRECTPORT="8443"
+
+# The shutdown port.
+SHUTDOWNPORT="8005"
+
+
+[Application Server]
+# The path of the Application Server directory (If an Application Server
+# is being installed). This path is automatically set using the installation
+# directory.
+AS_DIR=
+
+# The Application Server name.
+# Defaults to tomcat55 if Tomcat is to be installed.
+#AS_SERVER=tomcat55
+AS_SERVER=tomcat7
+
+# The instance of the Application Server. (e.g. localhost)
+# Defaults to localhost if Tomcat is to be installed.
+AS_INSTANCE=localhost
+
+# The Application Server port.
+AS_ADMIN_PORT=
+
+# The Application Server deployment action. (i.e. deploy or predeploy)
+WDEPLOYACTION=predeploy
+
+
+[CMS Cluster]
+# Whether or not to cluster the CMS.
+CMSCLUSTER="no"
+
+# The CMS name to cluster to.
+CLUSTER_NAMESERVER=""
+
+# The CMS port number to cluster to.
+CLUSTERPORTNUMBER="6400"
+
+
+[CMS]
+# The type of database. (e.g. MySQL, DB2, Oracle,SQL Anywhere)
+DBTYPE="Oracle"
+
+# The service name of the CMS.
+SERVICENAME="T2BOSYS"
+
+# The username to connect to the database.
+DATABASEUID="onr_system_owner"
+
+# The password to connect to the database.
+DATABASEPWD=
+
+# The name of the CMS server.
+CMSNAMESERVER=
+
+# The port number used to communicate with the CMS.
+CMSPORTNUMBER="6400"
+
+# The password used to connect to the CMS.
+CMSPASSWORD=
+
+# The server intelligence agent node name.
+SIANODENAME="t2onr1"
+
+# The port used to communicate with the server intelligence agent.
+SIAPORTNUMBER="6410"
+
+# Whether or not to reinitialize the database.
+REINIT="yes"
+
+
+[SQLANYWHERE]
+# Whether or not to install SQL Anywhere
+INSTALLSQLANYWHERE=
+
+# The port number used to communicate with the SQL Anywhere database.
+SERVICEPORT="2638"
+
+# The name of the server hosting the SQL Anywhere database.
+SQLANYWHEREHOSTNAME=
+
+# The root password for the SQL Anywhere database.
+SQLANYWHEREROOTPWD=
+
+
+[Audit]
+# Whether or not auditing is enabled.
+AUDITINGENABLED=yes
+
+# The service audit name of the CMS.
+SERVICENAME_AUDIT="T2BOAUD"
+
+# The port number used to communicate with the SQL Anywhere database.
+SERVICEPORT_AUDIT="2638"
+
+# The name of the server hosting the SQL Anywhere database.
+SQLANYWHEREHOSTNAME_AUDIT=
+
+# The audit username to connect to the database.
+DATABASEUID_AUDIT=onr_audit_owner
+
+# The audit password to connect to the database.
+DATABASEPWD_AUDIT=
+
+
+[Marketing Products]
+# This feature manually enables specified marketing products. Each marketing product
+# specified must be seperated by a comma.
+# For a custom install this field is used to enable those products which are different from a default new installation.
+# Example: ENABLEMP=BusinessObjects.MySQL,BusinessObjects.WebTierComponents
+ENABLEMP=BusinessObjects.Redbrick
+
+# This feature manually disables specified marketing products. Each marketing product
+# specified must be seperated by a comma.
+# For a custom install this field is used to disable those products which are different from a default new installation.
+# Example: DISABLEMP=BusinessObjects.MySQL,BusinessObjects.WebTierComponents
+DISABLEMP=BusinessObjects.HPNeoview,BusinessObjects.MySQL,BusinessObjects.MySQL_DataAccess,BusinessObjects.NCRTeradata,BusinessObjects.NETEZZA,BusinessObjects.NeverInstall,BusinessObjects.Progress.OpenEdge,BusinessObjects.SFORCE,BusinessObjects.Sybase,BusinessObjects.SybaseASE,BusinessObjects.SybaseAnywhere,BusinessObjects.SybaseIQ,BusinessObjects.Tomcat
+
+
+[New Settings]
+# All uncommented settings are added here.
+DBTYPE_AUDIT="Oracle"

--- a/ansible/roles/onr-boe/files/t2_response_file.ini
+++ b/ansible/roles/onr-boe/files/t2_response_file.ini
@@ -13,7 +13,7 @@ MACHINENAME=
 # The path of the bobje directory. This feature is automically set by
 # the installation directory specified as a command line argument followed
 # by /bobje/.
-BOBJEDIR="/u01/app/boe/bobje/"
+BOBJEDIR="/u01/app/bobj/boe/bobje/"
 
 # The path of the DISK_1 directory on the CD. This path defaults to the cd directory
 # pertaining to the install which has created the response file. It may be overwritten

--- a/ansible/roles/onr-boe/tasks/get-facts.yml
+++ b/ansible/roles/onr-boe/tasks/get-facts.yml
@@ -8,12 +8,18 @@
 - name: Set secretsmanager password facts
   set_fact:
     bobje_license_key: "{{ secretsmanager_passwords_dict['boe'].passwords['bobje_license_key'] }}"
+    databasepwd: "{{ secretsmanager_passwords_dict['t2_oracle_sys'].passwords['onr_system_owner'] }}"
+    databasepwd_audit: "{{ secretsmanager_passwords_dict['t2_oracle_aud'].passwords['onr_audit_owner'] }}"
+    cmspassword: "{{ secretsmanager_passwords_dict['t2_oracle_sys'].passwords['cmspassword'] }}"
 
 - name: Check all SSM parameters and tags are set
   set_fact:
     boe_all_variables_set: true
   when:
     - bobje_license_key|length > 0
+    - databasepwd|length > 0
+    - databasepwd_audit|length > 0
+    - cmspassword|length > 0
 
 - name: Fail if missing SSM parameters or tags
   fail:

--- a/ansible/roles/onr-boe/tasks/get-facts.yml
+++ b/ansible/roles/onr-boe/tasks/get-facts.yml
@@ -5,6 +5,9 @@
   vars:
     secretsmanager_passwords: "{{ boe_secretsmanager_passwords }}"
 
+# NOTE: see DSOS-2817 item to get databasepwd and databasepwd_audit from the oasys-test env, not locally
+# This requires allowing the instance to get passwords from a different environment so deferring this for now
+
 - name: Set secretsmanager password facts
   set_fact:
     bobje_license_key: "{{ secretsmanager_passwords_dict['boe'].passwords['bobje_license_key'] }}"

--- a/ansible/roles/onr-boe/tasks/install-boe.yml
+++ b/ansible/roles/onr-boe/tasks/install-boe.yml
@@ -6,16 +6,15 @@
     owner: "{{ boe_install_user }}"
     group: "{{ boe_install_group }}"
     mode: "0755"
-
 # IMPORTANT: The following task is commented out because it fails when run by Ansible for reasons unknown.
 
 # - name: Run Silent Installation
 #   become_user: bobj
 #   ansible.builtin.shell: |
-#     . ~/.bash_profile 
+#     . ~/.bash_profile
 #     {{ stage }}/DISK_1/install.sh -r {{ app_dir }}/{{ onr_environment }}_response_file.ini
 
 # - name: Run post install script command
 #   become_user: root
-#   ansible.builtin.shell: | 
+#   ansible.builtin.shell: |
 #     ./u01/app/bobj/boe/bobje/init/setupinit.sh

--- a/ansible/roles/onr-boe/tasks/install-boe.yml
+++ b/ansible/roles/onr-boe/tasks/install-boe.yml
@@ -1,17 +1,7 @@
 ---
-- name: Create BOE Disk mount point
-  ansible.builtin.file:
-    path: /mnt/DATA_1
-    state: directory
-    mode: "0755"
+- name: Run Silent Installation
+  become_user: bobj
+  ansible.builtin.shell: |
+    . ~/.bash_profile 
+    {{ stage }}/DISK_1/install.sh -r {{ app_dir }}/{{ onr_environment }}_response_file.ini
 
-- name: Mount DATA_1 volume
-  ansible.builtin.mount:
-    src: "{{ app_dir }}/DATA_1"
-    path: /mnt/DATA_1
-    fstype: none
-    opts: bind
-    state: mounted
-# TODO: interactive installer command /install.sh -InstallDir /u01/app/bobj/BOE31
-
-# TODO: interactive installer command write response file /install.sh -r /u01/app/bobj/BOE31 -w /u01/app/bobj/BOE31/response.ini

--- a/ansible/roles/onr-boe/tasks/install-boe.yml
+++ b/ansible/roles/onr-boe/tasks/install-boe.yml
@@ -1,7 +1,21 @@
 ---
-- name: Run Silent Installation
-  become_user: bobj
-  ansible.builtin.shell: |
-    . ~/.bash_profile 
-    {{ stage }}/DISK_1/install.sh -r {{ app_dir }}/{{ onr_environment }}_response_file.ini
+- name: create install target dir
+  ansible.builtin.file:
+    path: "/u01/app/bobj/boe"
+    state: directory
+    owner: "{{ boe_install_user }}"
+    group: "{{ boe_install_group }}"
+    mode: "0755"
 
+# IMPORTANT: The following task is commented out because it fails when run by Ansible for reasons unknown.
+
+# - name: Run Silent Installation
+#   become_user: bobj
+#   ansible.builtin.shell: |
+#     . ~/.bash_profile 
+#     {{ stage }}/DISK_1/install.sh -r {{ app_dir }}/{{ onr_environment }}_response_file.ini
+
+# - name: Run post install script command
+#   become_user: root
+#   ansible.builtin.shell: | 
+#     ./u01/app/bobj/boe/bobje/init/setupinit.sh

--- a/ansible/roles/onr-boe/tasks/main.yml
+++ b/ansible/roles/onr-boe/tasks/main.yml
@@ -32,8 +32,8 @@
   tags:
     - amibuild
     - ec2provision
-    - template_response_file
-# - import_tasks: install-boe.yml
-#   tags:
-#     - amibuild
-#     - ec2provision
+
+- import_tasks: install-boe.yml
+  tags:
+    - amibuild
+    - ec2provision

--- a/ansible/roles/onr-boe/tasks/main.yml
+++ b/ansible/roles/onr-boe/tasks/main.yml
@@ -32,6 +32,7 @@
   tags:
     - amibuild
     - ec2provision
+    - template_response_file
 # - import_tasks: install-boe.yml
 #   tags:
 #     - amibuild

--- a/ansible/roles/onr-boe/tasks/template-response-file.yml
+++ b/ansible/roles/onr-boe/tasks/template-response-file.yml
@@ -1,20 +1,50 @@
 ---
 - name: copy response ini file
   ansible.builtin.copy:
-    src: response.ini
-    dest: "{{ app_dir }}/response.ini"
+    src: "{{ onr_environment }}_response_file.ini"
+    dest: "{{ app_dir }}/{{ onr_environment }}_response_file.ini"
     owner: "{{ boe_install_user }}"
     group: "{{ boe_install_group }}"
     mode: "0755"
 
 - name: Ensure bobje license key is set in response file
   ansible.builtin.lineinfile:
-    path: "{{ app_dir }}/response.ini"
+    path: "{{ app_dir }}/{{ onr_environment }}_response_file.ini"
     regexp: "^BOBJELICENSEKEY="
     line: "BOBJELICENSEKEY={{ bobje_license_key }}"
 
 - name: Ensure bobje license is also set as the Product ID key
   ansible.builtin.lineinfile:
-    path: "{{ app_dir }}/response.ini"
+    path: "{{ app_dir }}/{{ onr_environment }}_response_file.ini"
     regexp: "^PIDKEY="
     line: "PIDKEY={{ bobje_license_key }}"
+
+- name: Set local name server value in response file
+  ansible.builtin.lineinfile:
+    path: "{{ app_dir }}/{{ onr_environment }}_response_file.ini"
+    regexp: "^LOCALNAMESERVER="
+    line: "LOCALNAMESERVER={{ ec2.tags['Name'] }}" # TODO: check whether or not {{ ansible_facts.hostname }} is better
+
+- name: Set database password value in response file
+  ansible.builtin.lineinfile:
+    path: "{{ app_dir }}/{{ onr_environment }}_response_file.ini"
+    regexp: "^DATABASEPWD="
+    line: "DATABASEPWD={{ databasepwd }}"
+
+- name: Set cms name server value in response file
+  ansible.builtin.lineinfile:
+    path: "{{ app_dir }}/{{ onr_environment }}_response_file.ini"
+    regexp: "^CMSNAMESERVER="
+    line: "CMSNAMESERVER={{ ec2.tags['Name'] }}" # TODO: check whether or not {{ ansible_facts.hostname }} is better
+
+- name: Set cms password value in response file
+  ansible.builtin.lineinfile:
+    path: "{{ app_dir }}/{{ onr_environment }}_response_file.ini"
+    regexp: "^CMSPASSWORD="
+    line: "CMSPASSWORD={{ cmspassword }}"
+
+- name: Set database_audit password value in response file
+  ansible.builtin.lineinfile:
+    path: "{{ app_dir }}/{{ onr_environment }}_response_file.ini"
+    regexp: "^DATABASEPWD_AUDIT="
+    line: "DATABASEPWD_AUDIT={{ databasepwd_audit }}"

--- a/ansible/roles/onr-get/defaults/main.yml
+++ b/ansible/roles/onr-get/defaults/main.yml
@@ -4,7 +4,9 @@ artefacts_s3_bucket_path: hmpps/onr
 artefact_dir: /u02
 app_dir: /u01/software/BOE_3_1_FP7_4_Linux
 
-boe_software: 51048118.ZIP # SBOP ENTERPRISE (SERVER) XI 3.1 SP7 LINUX (32B)
+boe_software: 51048118.ZIP # SBOP ENTERPRISE (SERVER) XI 3.1 SP7 LINUX (32B) FULL INSTALLER
+boe_patch: ENTERPRISE07P_4-10007478.TGZ # SBOP ENTERPRISE XI 3.1 SP7 PATCH 4 TODO: check 32bit or 64bit version
+
 boe_install_user: bobj
 boe_install_group: binstall
 

--- a/ansible/roles/onr-get/tasks/download-software.yml
+++ b/ansible/roles/onr-get/tasks/download-software.yml
@@ -22,3 +22,4 @@
     overwrite: latest
   loop:
     - "{{ boe_software }}"
+    - "{{ boe_patch }}"

--- a/ansible/roles/onr-get/tasks/extract-software.yml
+++ b/ansible/roles/onr-get/tasks/extract-software.yml
@@ -4,3 +4,5 @@
     src: "{{ stage }}/{{ boe_software }}"
     dest: "{{ temp }}"
     remote_src: yes
+
+# - name: Unpack the BOE patch - not yet implemented/required

--- a/ansible/roles/onr-get/tasks/extract-software.yml
+++ b/ansible/roles/onr-get/tasks/extract-software.yml
@@ -4,5 +4,4 @@
     src: "{{ stage }}/{{ boe_software }}"
     dest: "{{ temp }}"
     remote_src: yes
-
 # - name: Unpack the BOE patch - not yet implemented/required


### PR DESCRIPTION
- add response file for t2 environment
  - t2_response_file.ini for t2
  - included example file for pp == preproduction and how to reference it
- pull passwords from secrets in oasys-national-reporting-test env

Additional Jira items created: 

- DSOS-2818 fix hardcoded value in get-facts.yml in role, references t2 when it shouldn't (1 story point, fix next week)
- DSOS-2817 to get oasys password values from different env (deferred)