### PR TITLE
Issue/6709

### DIFF
--- a/.github/workflows/flexible-instance-stop-start.yml
+++ b/.github/workflows/flexible-instance-stop-start.yml
@@ -6,17 +6,10 @@ permissions:
 
 on:
   schedule:
-    - cron: ${{ env.EC2_START_CRON }}
-    - cron: ${{ env.RDS_START_CRON }}
-    - cron: ${{ env.RDS_STOP_CRON }}
-    - cron: ${{ env.EC2_STOP_CRON }}
-
-env:
-  EC2_STOP_CRON:  '00 17 * * *'
-  EC2_START_CRON: '30 7 * * *'
-  RDS_STOP_CRON:  '00 18 * * *'
-  RDS_START_CRON: '00 7 * * *'
-
+    - cron: '45 6 * * *' # RDS Start
+    - cron: '30 7 * * *' # ED2 Start
+    - cron: '25 17 * * *' # EC2 Stop
+    - cron: '25 18 * * *' # RDS Stop
 
 jobs:
 
@@ -49,25 +42,25 @@ jobs:
         role-to-assume: arn:aws:iam::${{ secrets.EXAMPLE_ACCOUNT_NUMBER }}:role/modernisation-platform-oidc-cicd
 
     - name: Stop EC2 instances with specific tags
-      if: ${{ github.event.schedule }} == $EC2_STOP_CRON
+      if: ${{ github.event.schedule }} == '25 17 * * *'
       run: |
        chmod +x scripts/flexistopstart.sh
        bash scripts/flexistopstart.sh 'stop_ec2' $EC2_TAG $EC2_TAG_VALUE $AWS_REGION
 
     - name: Start EC2 instances with specific tags
-      if: ${{ github.event.schedule }} == $EC2_START_CRON
+      if: ${{ github.event.schedule }} == '30 7 * * *'
       run: |
         chmod +x scripts/flexistopstart.sh
         bash scripts/flexistopstart.sh 'start_ec2' $EC2_TAG $EC2_TAG_VALUE $AWS_REGION
 
     - name: Stop RDS instances with specific tags
-      if: ${{ github.event.schedule }} == $RDS_STOP_CRON
+      if: ${{ github.event.schedule }} == '25 18 * * *'
       run: |
         chmod +x scripts/flexistopstart.sh
         bash scripts/flexistopstart.sh 'stop_rds' $RDS_TAG $RDS_TAG_VALUE $AWS_REGION
 
     - name: Start RDS instances with specific tags
-      if: ${{ github.event.schedule }} == $RDS_START_CRON
+      if: ${{ github.event.schedule }} == '45 6 * * *'
       run: |
         chmod +x scripts/flexistopstart.sh
         bash scripts/flexistopstart.sh 'start_rds' $RDS_TAG $RDS_TAG_VALUE $AWS_REGION

--- a/.github/workflows/flexible-instance-stop-start.yml
+++ b/.github/workflows/flexible-instance-stop-start.yml
@@ -5,11 +5,17 @@ permissions:
   contents: read
 
 on:
-    schedule:
-      - cron: '00 7 * * *'
-      - cron: '30 7 * * *'
-      - cron: '00 17 * * *'
-      - cron: '00 18 * * *'
+  schedule:
+    - cron: ${{ env.EC2_START_CRON }}
+    - cron: ${{ env.RDS_START_CRON }}
+    - cron: ${{ env.RDS_STOP_CRON }}
+    - cron: ${{ env.EC2_STOP_CRON }}
+
+env:
+  EC2_STOP_CRON:  '00 17 * * *'
+  EC2_START_CRON: '30 7 * * *'
+  RDS_STOP_CRON:  '00 18 * * *'
+  RDS_START_CRON: '00 7 * * *'
 
 
 jobs:
@@ -19,16 +25,11 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      EC2_STOP_CRON:  '00 17 * * *'
-      EC2_START_CRON: '30 7 * * *'
-      RDS_STOP_CRON:  '00 18 * * *'
-      RDS_START_CRON: '00 7 * * *'
       EC2_TAG: 'application'
       EC2_TAG_VALUE: 'example'
       RDS_TAG: 'application'
       RDS_TAG_VALUE: 'example'
       AWS_REGION: 'eu-west-2'
-
 
     steps:
   

--- a/.github/workflows/flexible-instance-stop-start.yml
+++ b/.github/workflows/flexible-instance-stop-start.yml
@@ -1,0 +1,72 @@
+name: Flexible Shutdown & Startup of EC2 & RDS Instances
+
+permissions:
+  id-token: write
+  contents: read
+
+on:
+    schedule:
+      - cron: '00 7 * * *'
+      - cron: '30 7 * * *'
+      - cron: '00 17 * * *'
+      - cron: '00 18 * * *'
+
+
+jobs:
+
+  stop-start-instances:
+ 
+    runs-on: ubuntu-latest
+
+    env:
+      EC2_STOP_CRON:  '00 17 * * *'
+      EC2_START_CRON: '30 7 * * *'
+      RDS_STOP_CRON:  '00 18 * * *'
+      RDS_START_CRON: '00 7 * * *'
+      EC2_TAG: 'application'
+      EC2_TAG_VALUE: 'example'
+      RDS_TAG: 'application'
+      RDS_TAG_VALUE: 'example'
+      AWS_REGION: 'eu-west-2'
+
+
+    steps:
+  
+    - name: Checkout Repository
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      with:
+        sparse-checkout: |
+         scripts
+
+    - name: Configure AWS credentials
+      id: set-credentials
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        audience: sts.amazonaws.com
+        aws-region: eu-west-2
+        mask-aws-account-id: true
+        role-to-assume: arn:aws:iam::${{ secrets.EXAMPLE_ACCOUNT_NUMBER }}:role/modernisation-platform-oidc-cicd
+
+    - name: Stop EC2 instances with specific tags
+      if: ${{ github.event.schedule }} == $EC2_STOP_CRON
+      run: |
+       chmod +x scripts/flexistopstart.sh
+       bash scripts/flexistopstart.sh 'stop_ec2' $EC2_TAG $EC2_TAG_VALUE $AWS_REGION
+
+    - name: Start EC2 instances with specific tags
+      if: ${{ github.event.schedule }} == $EC2_START_CRON
+      run: |
+        chmod +x scripts/flexistopstart.sh
+        bash scripts/flexistopstart.sh 'start_ec2' $EC2_TAG $EC2_TAG_VALUE $AWS_REGION
+
+    - name: Stop RDS instances with specific tags
+      if: ${{ github.event.schedule }} == $RDS_STOP_CRON
+      run: |
+        chmod +x scripts/flexistopstart.sh
+        bash scripts/flexistopstart.sh 'stop_rds' $RDS_TAG $RDS_TAG_VALUE $AWS_REGION
+
+    - name: Start RDS instances with specific tags
+      if: ${{ github.event.schedule }} == $RDS_START_CRON
+      run: |
+        chmod +x scripts/flexistopstart.sh
+        bash scripts/flexistopstart.sh 'start_rds' $RDS_TAG $RDS_TAG_VALUE $AWS_REGION

--- a/.github/workflows/flexible-instance-stop-start.yml
+++ b/.github/workflows/flexible-instance-stop-start.yml
@@ -7,7 +7,7 @@ permissions:
 on:
   schedule:
     - cron: '45 6 * * *' # RDS Start
-    - cron: '30 7 * * *' # ED2 Start
+    - cron: '25 7 * * *' # ED2 Start
     - cron: '25 17 * * *' # EC2 Stop
     - cron: '25 18 * * *' # RDS Stop
 
@@ -48,7 +48,7 @@ jobs:
        bash scripts/flexistopstart.sh 'stop_ec2' $EC2_TAG $EC2_TAG_VALUE $AWS_REGION
 
     - name: Start EC2 instances with specific tags
-      if: ${{ github.event.schedule }} == '30 7 * * *'
+      if: ${{ github.event.schedule }} == '25 7 * * *'
       run: |
         chmod +x scripts/flexistopstart.sh
         bash scripts/flexistopstart.sh 'start_ec2' $EC2_TAG $EC2_TAG_VALUE $AWS_REGION

--- a/scripts/flexistopstart.sh
+++ b/scripts/flexistopstart.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+
+# This script contains functions to stop and start ec2s and RDS instances based on the provided tag criteria.
+
+# Function to stop EC2 instances with a specific tag
+stop_ec2_instances() {
+  TAG_KEY=$1
+  TAG_VALUE=$2
+  REGION=$3
+  aws ec2 describe-instances \
+    --filters "Name=tag:${TAG_KEY},Values=${TAG_VALUE}" "Name=instance-state-name,Values=running" \
+    --query "Reservations[*].Instances[*].InstanceId" \
+    --output text --region $REGION > output.txt 2>&1
+  INSTANCE_IDS=$(cat output.txt)
+  if [ -n "$INSTANCE_IDS" ]; then
+    aws ec2 stop-instances --instance-ids $INSTANCE_IDS --region $REGION > /dev/null 2>&1
+    echo "Stopped EC2 instances: $INSTANCE_IDS"
+  else
+    echo "No running EC2 instances found with tag ${TAG_KEY}=${TAG_VALUE}"
+  fi
+}
+
+# Function to start EC2 instances with a specific tag
+start_ec2_instances() {
+  TAG_KEY=$1
+  TAG_VALUE=$2
+  REGION=$3
+  aws ec2 describe-instances \
+    --filters "Name=tag:${TAG_KEY},Values=${TAG_VALUE}" "Name=instance-state-name,Values=stopped" \
+    --query "Reservations[*].Instances[*].InstanceId" \
+    --output text --region $REGION > output.txt 2>&1
+  INSTANCE_IDS=$(cat output.txt)
+  if [ -n "$INSTANCE_IDS" ]; then
+    aws ec2 start-instances --instance-ids $INSTANCE_IDS --region $REGION > /dev/null 2>&1
+    echo "Started EC2 instances: $INSTANCE_IDS"
+  else
+    echo "No stopped EC2 instances found with tag ${TAG_KEY}=${TAG_VALUE}"
+  fi
+}
+
+# Function to stop RDS instances with a specific tag
+stop_rds_instances() {
+  TAG_KEY=$1
+  TAG_VALUE=$2
+  REGION=$3
+  aws rds describe-db-instances \
+    --query "DBInstances[?DBInstanceStatus == 'available' && contains(TagList[?Key=='${TAG_KEY}'].Value, '${TAG_VALUE}')].DBInstanceIdentifier" \
+    --output text --region $REGION > output.txt 2>&1
+  DB_INSTANCE_IDENTIFIERS=$(cat output.txt)
+  if [ -n "$DB_INSTANCE_IDENTIFIERS" ]; then
+    for DB_INSTANCE_IDENTIFIER in $DB_INSTANCE_IDENTIFIERS; do
+      aws rds stop-db-instance --db-instance-identifier $DB_INSTANCE_IDENTIFIER --region $REGION > /dev/null 2>&1
+      echo "Stopped RDS instance: $DB_INSTANCE_IDENTIFIER"
+    done
+  else
+    echo "No available RDS instances found with tag ${TAG_KEY}=${TAG_VALUE}"
+  fi
+}
+
+# Function to start RDS instances with a specific tag
+start_rds_instances() {
+  TAG_KEY=$1
+  TAG_VALUE=$2
+  REGION=$3
+  aws rds describe-db-instances \
+    --query "DBInstances[?DBInstanceStatus == 'stopped' && contains(TagList[?Key=='${TAG_KEY}'].Value, '${TAG_VALUE}')].DBInstanceIdentifier" \
+    --output text --region $REGION > output.txt 2>&1
+  DB_INSTANCE_IDENTIFIERS=$(cat output.txt)
+  if [ -n "$DB_INSTANCE_IDENTIFIERS" ]; then
+    for DB_INSTANCE_IDENTIFIER in $DB_INSTANCE_IDENTIFIERS; do
+      aws rds start-db-instance --db-instance-identifier $DB_INSTANCE_IDENTIFIER --region $REGION > /dev/null 2>&1
+      echo "Started RDS instance: $DB_INSTANCE_IDENTIFIER"
+    done
+  else
+    echo "No stopped RDS instances found with tag ${TAG_KEY}=${TAG_VALUE}"
+  fi
+}
+
+# Main script actions
+ACTION=$1
+TAG_KEY=$2
+TAG_VALUE=$3
+REGION=$4
+
+case $ACTION in
+  stop_ec2)
+    stop_ec2_instances $TAG_KEY $TAG_VALUE $REGION
+    ;;
+  stop_rds)
+    stop_rds_instances $TAG_KEY $TAG_VALUE $REGION
+    ;;
+  start_ec2)
+    start_ec2_instances $TAG_KEY $TAG_VALUE $REGION
+    ;;
+  start_rds) 
+    start_rds_instances $TAG_KEY $TAG_VALUE $REGION
+    ;;
+  *)
+    echo "Usage: $0 {stop_ec2|stop_rds|start_ec2|start_rds} tag_key tag_value aws_region"
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
This adds a new workflow and bash script that runs shutdown & startup of ec2 and rds instances using various user-defined cron schedules. Note that testing the use of env variables to substitute the cron strings isn't supported and so the cron strings need to be declared twice - once for the scheule and the other for the if test.

Note that the times chosen here are deliberately set to avoid the busy on-the-hour and half-hour slots as workflows can be cancelled if the back-end servers are too busy. This is a known issue with github cron schedules and the only solution is to use a local runner.