### PR TITLE
nomis: check the keepalive file is present

### DIFF
--- a/ansible/group_vars/server_type_nomis_web.yml
+++ b/ansible/group_vars/server_type_nomis_web.yml
@@ -23,8 +23,11 @@ collectd_monitored_services_servertype:
     metric_dimension: chronyd
     shell_cmd: "service chronyd status"
   - metric_name: service_status_app
-    metric_dimension: weblogic-healthcheck
+    metric_dimension: weblogic-healthcheck-service
     shell_cmd: "service weblogic-healthcheck status"
   - metric_name: service_status_app
     metric_dimension: WLS_TAGSAR
     shell_cmd: "service WLS_TAGSAR status"
+  - metric_name: service_status_app
+    metric_dimension: weblogic-keepalive-file
+    shell_cmd: "service weblogic-healthcheck keepalive"


### PR DESCRIPTION
Add an additional check for the keepalive file.  This makes it a little easier to identify if a weblogic server is down