### PR TITLE
nomis: DSOS-2823: improve cleanup frm script

### DIFF
--- a/ansible/roles/nomis-weblogic/tasks/cleanup-frmweb.yml
+++ b/ansible/roles/nomis-weblogic/tasks/cleanup-frmweb.yml
@@ -13,5 +13,5 @@
   ansible.builtin.cron:
     name: "cleanup tmp for weblogic"
     user: root
-    minute: "0"
+    minute: "*/5"
     job: "/home/oracle/admin/scripts/cleanup_frmweb.sh 2>&1 | logger -p local3.info -t nomis-weblogic-cleanup-frmweb"

--- a/ansible/roles/nomis-weblogic/tasks/main.yml
+++ b/ansible/roles/nomis-weblogic/tasks/main.yml
@@ -176,6 +176,7 @@
     - import_tasks: cleanup-frmweb.yml
       tags:
         - ec2provision
+        - ec2patch
         - weblogic_cleanup_frmweb
 
     - include_tasks:

--- a/ansible/roles/nomis-weblogic/templates/10.3/home/oracle/admin/scripts/cleanup_frmweb.sh
+++ b/ansible/roles/nomis-weblogic/templates/10.3/home/oracle/admin/scripts/cleanup_frmweb.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-echo "Checking for dead frmweb processes"
 PIDS=$(ps -C frmweb -o %p, -o %u, -o %t, -o %c, -o %C | tr -d " " | egrep ",[0-9]+-[0-9]+:[0-9]+:[0-9]+," | cut -d, -f1 | sort -ug | tr [:space:] " " | sed "s/ $//")
 if [[ -n $PIDS ]]; then
   echo "Killing frmweb processes older than 24 hours: ${PIDS// /,}"
@@ -16,4 +15,11 @@ if [[ -n $PIDS ]]; then
     ps -q ${PIDS2// /,} ux
     kill -9 $PIDS2
   fi
+fi
+
+PIDS=$(/usr/sbin/lsof | grep deleted | grep frmweb | gawk '{print $2,$7}'  | sort -ug | grep -E "^[0-9]+ [0-9]{10}" | cut -d\  -f1 | tr [:space:] " " | sed "s/ $//")
+if [[ -n $PIDS ]]; then
+  echo "Killing frmweb processes with deleted lsof files bigger than 1GB: ${PIDS// /,}"
+  ps -q ${PIDS// /,} ux
+  kill -9 $PIDS
 fi


### PR DESCRIPTION
There's been couple of occasions of a spurious process filling up /tmp.  
Kill any process with deleted tmp file bigger than 1GB.