### PR TITLE
fix working directory path length in NCR client PowerShell

### DIFF
--- a/powershell/Scripts/UserDataScripts/NcrClient.ps1
+++ b/powershell/Scripts/UserDataScripts/NcrClient.ps1
@@ -23,6 +23,7 @@ $GlobalConfig = @{
         }
     }   
  }
+$WorkingDirectory = "C:\Temp"
   
  function Get-Config {
    $Token = Invoke-RestMethod -TimeoutSec 10 -Headers @{"X-aws-ec2-metadata-token-ttl-seconds"=3600} -Method PUT -Uri http://169.254.169.254/latest/api/token
@@ -43,7 +44,6 @@ $GlobalConfig = @{
     param (
       [hashtable]$Config
     )
-    $WorkingDirectory = "C:\Temp"
     New-Item -ItemType Directory -Path $WorkingDirectory -Force
     Set-Location -Path $WorkingDirectory
     # Read-S3Object -BucketName $Config.WindowsClientS3Bucket -Key ($Config.WindowsClientS3Folder + "/" + $Config.WindowsClientS3File) -File (".\" + $Config.WindowsClientS3File) -Verbose | Out-Null

--- a/powershell/Scripts/UserDataScripts/NcrClient.ps1
+++ b/powershell/Scripts/UserDataScripts/NcrClient.ps1
@@ -58,11 +58,11 @@ $WorkingDirectory = "C:\Temp"
    )
  
    $ErrorActionPreference = "Stop"
-   if (Test-Path (([System.IO.Path]::GetTempPath()) + "\Client\setup.exe")) {
+   if (Test-Path ($WorkingDirectory + "\Client\setup.exe")) {
      Write-Output "Windows Client already installed"
    } else {
      Write-Output "Add Windows Client"
-     Set-Location -Path ([System.IO.Path]::GetTempPath())
+     Set-Location -Path $WorkingDirectory
      Read-S3Object -BucketName $Config.WindowsClientS3Bucket -Key ($Config.WindowsClientS3Folder + "/" + $Config.WindowsClientS3File) -File (".\" + $Config.WindowsClientS3File) -Verbose | Out-Null
  
 

--- a/powershell/Scripts/UserDataScripts/NcrClient.ps1
+++ b/powershell/Scripts/UserDataScripts/NcrClient.ps1
@@ -71,7 +71,7 @@ New-Item -ItemType Directory -Path $WorkingDirectory -Force
 
      # FIXME: Expand-Archive path is too long for Windows, use C:\Windows\Temp possible? or just C:\Temp even
      # Extract Client Installer - there is no installer for this application
-     # Expand-Archive -Path (".\" + $Config.WindowsClientS3File) -DestinationPath  ($WorkingDirectory + "\client") -force | out-null
+     # Expand-Archive -Path (".\" + $Config.WindowsClientS3File) -DestinationPath  ($WorkingDirectory + "\Client") -Force | Out-Null
 
      # Install Windows Client
     #  Start-Process -FilePath ($WorkingDirectory + "\Client\setup.exe") -ArgumentList "-r", "C:\Users\Administrator\AppData\Local\Temp\modernisation-platform-configuration-management\powershell\Configs\OnrClientResponse.ini" -Wait -NoNewWindow

--- a/powershell/Scripts/UserDataScripts/NcrClient.ps1
+++ b/powershell/Scripts/UserDataScripts/NcrClient.ps1
@@ -44,7 +44,7 @@ $GlobalConfig = @{
       [hashtable]$Config
     )
     $WorkingDirectory = "C:\Temp"
-    New-Item -ItemType Directory -Path $WorkingDirectory
+    New-Item -ItemType Directory -Path $WorkingDirectory -Force
     Set-Location -Path $WorkingDirectory
     # Read-S3Object -BucketName $Config.WindowsClientS3Bucket -Key ($Config.WindowsClientS3Folder + "/" + $Config.WindowsClientS3File) -File (".\" + $Config.WindowsClientS3File) -Verbose | Out-Null
     Read-S3Object -BucketName $Config.WindowsClientS3Bucket -Key ($Config.WindowsClientS3Folder + "/" + $Config.IPSS3File) -File (".\" + $Config.IPSS3File) -Verbose | Out-Null

--- a/powershell/Scripts/UserDataScripts/NcrClient.ps1
+++ b/powershell/Scripts/UserDataScripts/NcrClient.ps1
@@ -58,7 +58,10 @@ New-Item -ItemType Directory -Path $WorkingDirectory -Force
    )
  
    $ErrorActionPreference = "Stop"
-   if (Test-Path ($WorkingDirectory + "\Client\setup.exe")) {
+   # TODO the following may need a better path to test for installation
+   # the current path may be good enough though,
+   # as it's what's provided in the response file for installation
+   if (Test-Path "C:\Program Files (x86)\Business Objects\") {
      Write-Output "Windows Client already installed"
    } else {
      Write-Output "Add Windows Client"

--- a/powershell/Scripts/UserDataScripts/NcrClient.ps1
+++ b/powershell/Scripts/UserDataScripts/NcrClient.ps1
@@ -24,6 +24,7 @@ $GlobalConfig = @{
     }   
  }
 $WorkingDirectory = "C:\Temp"
+New-Item -ItemType Directory -Path $WorkingDirectory -Force
   
  function Get-Config {
    $Token = Invoke-RestMethod -TimeoutSec 10 -Headers @{"X-aws-ec2-metadata-token-ttl-seconds"=3600} -Method PUT -Uri http://169.254.169.254/latest/api/token
@@ -44,7 +45,6 @@ $WorkingDirectory = "C:\Temp"
     param (
       [hashtable]$Config
     )
-    New-Item -ItemType Directory -Path $WorkingDirectory -Force
     Set-Location -Path $WorkingDirectory
     # Read-S3Object -BucketName $Config.WindowsClientS3Bucket -Key ($Config.WindowsClientS3Folder + "/" + $Config.WindowsClientS3File) -File (".\" + $Config.WindowsClientS3File) -Verbose | Out-Null
     Read-S3Object -BucketName $Config.WindowsClientS3Bucket -Key ($Config.WindowsClientS3Folder + "/" + $Config.IPSS3File) -File (".\" + $Config.IPSS3File) -Verbose | Out-Null

--- a/powershell/Scripts/UserDataScripts/NcrClient.ps1
+++ b/powershell/Scripts/UserDataScripts/NcrClient.ps1
@@ -43,7 +43,9 @@ $GlobalConfig = @{
     param (
       [hashtable]$Config
     )
-    Set-Location -Path ([System.IO.Path]::GetTempPath())
+    $WorkingDirectory = "C:\Temp"
+    New-Item -ItemType Directory -Path $WorkingDirectory
+    Set-Location -Path $WorkingDirectory
     # Read-S3Object -BucketName $Config.WindowsClientS3Bucket -Key ($Config.WindowsClientS3Folder + "/" + $Config.WindowsClientS3File) -File (".\" + $Config.WindowsClientS3File) -Verbose | Out-Null
     Read-S3Object -BucketName $Config.WindowsClientS3Bucket -Key ($Config.WindowsClientS3Folder + "/" + $Config.IPSS3File) -File (".\" + $Config.IPSS3File) -Verbose | Out-Null
     Read-S3Object -BucketName $Config.WindowsClientS3Bucket -Key ($Config.WindowsClientS3Folder + "/" + $Config.DataServicesS3File) -File (".\" + $Config.DataServicesS3File) -Verbose | Out-Null

--- a/powershell/Scripts/UserDataScripts/NcrClient.ps1
+++ b/powershell/Scripts/UserDataScripts/NcrClient.ps1
@@ -68,10 +68,10 @@ New-Item -ItemType Directory -Path $WorkingDirectory -Force
 
      # FIXME: Expand-Archive path is too long for Windows, use C:\Windows\Temp possible? or just C:\Temp even
      # Extract Client Installer - there is no installer for this application
-     # Expand-Archive -Path (".\" + $Config.WindowsClientS3File) -DestinationPath  (([System.IO.Path]::GetTempPath()) + "\Client") -Force | Out-Null
+     # Expand-Archive -Path (".\" + $Config.WindowsClientS3File) -DestinationPath  ($WorkingDirectory + "\client") -force | out-null
 
      # Install Windows Client
-    #  Start-Process -FilePath (([System.IO.Path]::GetTempPath()) + "\Client\setup.exe") -ArgumentList "-r", "C:\Users\Administrator\AppData\Local\Temp\modernisation-platform-configuration-management\powershell\Configs\OnrClientResponse.ini" -Wait -NoNewWindow
+    #  Start-Process -FilePath ($WorkingDirectory + "\Client\setup.exe") -ArgumentList "-r", "C:\Users\Administrator\AppData\Local\Temp\modernisation-platform-configuration-management\powershell\Configs\OnrClientResponse.ini" -Wait -NoNewWindow
      
      # TODO: change the shortcut path and remove reference to BOE
      # Create a desktop shortcut for Client Tools

--- a/powershell/Scripts/UserDataScripts/NcrClient.ps1
+++ b/powershell/Scripts/UserDataScripts/NcrClient.ps1
@@ -114,3 +114,6 @@ $GlobalConfig = @{
  Add-WindowsClient $Config
  Get-Software $Config
  # Add-Shortcuts $Config
+ 
+ # clean up temporary working directory
+ Remove-Item -Path $WorkingDirectory -Recurse -Force


### PR DESCRIPTION
Using the system temp results in paths that are too looking for extracting `.zip` files into.

This PR:
- Creates a custom temporary working directory that is created and cleaned up on script start and end respectively.
- Replaces all references to the system temp directory with this custom temp.
- Replaces testing the temp path for whether the software is installed - we instead use the install dir specified in the response file