### PR TITLE
Onr/dsos 2858/boe instance metrics

### DIFF
--- a/ansible/group_vars/server_type_onr_boe.yml
+++ b/ansible/group_vars/server_type_onr_boe.yml
@@ -118,3 +118,6 @@ collectd_monitored_services_servertype:
   - metric_name: service_status_os
     metric_dimension: chronyd
     shell_cmd: "service chronyd status"
+  - metric_name: service_status_app
+    metric_dimension: onr-boe-cmsd
+    shell_cmd: "pgrep boe_cmsd"

--- a/ansible/group_vars/server_type_onr_boe.yml
+++ b/ansible/group_vars/server_type_onr_boe.yml
@@ -119,5 +119,5 @@ collectd_monitored_services_servertype:
     metric_dimension: chronyd
     shell_cmd: "service chronyd status"
   - metric_name: service_status_app
-    metric_dimension: onr-boe-cmsd
+    metric_dimension: cmsdatabase
     shell_cmd: "pgrep boe_cmsd"

--- a/ansible/group_vars/server_type_onr_web.yml
+++ b/ansible/group_vars/server_type_onr_web.yml
@@ -99,6 +99,9 @@ collectd_monitored_services_servertype:
   - metric_name: service_status_os
     metric_dimension: chronyd
     shell_cmd: "service chronyd status"
+  - metric_name: service_status_app
+    metric_dimension: tomcat
+    shell_cmd: "pgrep -f tomcat"
 
 collectd_monitored_metrics_additional:
   - metric_name: web_incoming


### PR DESCRIPTION
- add basic pgrep metric checking for boe_cmsd (cms process) on the boe instances
- add basic pgrep metric checking for tomcat on the web instances

The 'actual' service management comes down to running ccm.sh scripts on the host which, if we're going to automate them and turn them into services would be quite an extensive task. This way we get "is it up" without getting into the weeds