### PR TITLE
nomis: DSOS-2899: improvement to weblogic-all start

### DIFF
--- a/ansible/roles/nomis-weblogic/templates/10.3/etc/init.d/weblogic-all
+++ b/ansible/roles/nomis-weblogic/templates/10.3/etc/init.d/weblogic-all
@@ -189,6 +189,14 @@ case "$1" in
   start)
     start
     repair
+    unhealthy_services=$(get_unhealthy_services)
+    if [[ -n $unhealthy_services ]]; then
+      status
+      echo "Re-starting all services in attempt to fix $unhealthy_services"
+      stop
+      start
+      repair
+    fi
     ;;
   start_sequential)
     start_sequential


### PR DESCRIPTION
Last ditch attempt at rescuing a failed weblogic start. An attempt to make the out-of-hours environment stop/start more reliable.