### PR TITLE
DSO: reflect ndh proxy changes

### DIFF
--- a/ansible/roles/ndh-app/tasks/configure_proxy.yml
+++ b/ansible/roles/ndh-app/tasks/configure_proxy.yml
@@ -18,6 +18,14 @@
     enabled: yes
     state: stopped
 
+- name: Get the IP address of the local resolver
+  ansible.builtin.command: grep '^nameserver' /etc/resolv.conf | awk '{print $2}'
+  register: local_resolver
+
+- name: Set a fact to contain the IP address of the local resolver
+  ansible.builtin.set_fact:
+    ndh_dns_resolver: "{{ local_resolver.stdout }}"
+
 - name: Add nginx proxy config
   ansible.builtin.template:
     src: etc/nginx/nginx.conf.j2

--- a/ansible/roles/ndh-app/templates/etc/nginx/nginx.conf.j2
+++ b/ansible/roles/ndh-app/templates/etc/nginx/nginx.conf.j2
@@ -12,6 +12,7 @@ events {
 
 http {
     include       /etc/nginx/mime.types;
+    resolver ${{ ndh_dns_resolver }};
     default_type  application/octet-stream;
 
     log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
@@ -39,7 +40,8 @@ http {
         location / {
                 proxy_set_header Host $host;
                 proxy_redirect https://{{ ndh_proxy_host }}:443/ https://{{ ndh_proxy_host }}/;
-                proxy_pass https://{{ ndelius_proxy_pass }}/;
+                set $ndelius "https://{{ ndelius_proxy_pass }}:443$request_uri";
+                proxy_pass $ndelius;
                 proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         }
 {% endif %}


### PR DESCRIPTION
- force nginx to refresh the proxy DNS by explicitly setting a resolution mechanism. this stops us trying to forward requests on to a dead endpoint in AWS