### PR TITLE
DSOS-2917: add config for new T2 SAN environment

### DIFF
--- a/ansible/group_vars/environment_name_oasys_test.yml
+++ b/ansible/group_vars/environment_name_oasys_test.yml
@@ -15,7 +15,7 @@ oracle_ru_patch: JUL2024
 
 ords_trusted_origins:
   test: "https://t2.oasys.service.justice.gov.uk/eor,https://t2-int.oasys.service.justice.gov.uk/eor,http://localhost:8080/eor"
-  t2: "https://t2.oasys.service.justice.gov.uk/eor,https://t2-int.oasys.service.justice.gov.uk/eor,http://localhost:8080/eor"
+  t2: "https://t2.oasys.service.justice.gov.uk/eor,https://t2-int.oasys.service.justice.gov.uk/eor,http://localhost:8080/eor,https://t2-int-a.oasys.service.justice.gov.uk/eor,https://t2-a.oasys.service.justice.gov.uk/eor,https://t2-int-b.oasys.service.justice.gov.uk/eor,https://t2-b.oasys.service.justice.gov.uk/eor"
   t1: "https://t1.oasys.service.justice.gov.uk/eor,https://t1-int.oasys.service.justice.gov.uk/eor,http://localhost:8080/eor"
 
 # OEM server


### PR DESCRIPTION
Just update T2 trusted origins so both the -a and -b T2 URLs can be used directly from a Mac. Already tested and it works.