### PR TITLE
add hosting-migrations as codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @ministryofjustice/modernisation-platform @ministryofjustice/studio-webops @ministryofjustice/hmpps-dba @ministryofjustice/hmpps-migration
+* @ministryofjustice/modernisation-platform @ministryofjustice/hosting-migrations @ministryofjustice/studio-webops @ministryofjustice/hmpps-dba @ministryofjustice/hmpps-migration


### PR DESCRIPTION
DSO has been merged into the new Migrations Team. This PR allows the new team to codeown as DSO did.