### PR TITLE
ncr: TM-534: bip fixes v2

### DIFF
--- a/ansible/group_vars/server_type_base_rhel85.yml
+++ b/ansible/group_vars/server_type_base_rhel85.yml
@@ -4,6 +4,7 @@ ansible_python_interpreter: python3.9
 server_type_roles_list:
   - autoscale-group-hooks
   - get-ec2-facts
+  - packages
   - sshd-config
   - users-and-groups
   - set-ec2-hostname
@@ -12,6 +13,8 @@ server_type_roles_list:
   - time
   - python-ssm-configure
   - autoscale-group-hooks-state
+
+packages_yum_update: []
 
 collectd_monitored_services_servertype:
   - metric_name: service_status_os

--- a/ansible/group_vars/server_type_base_rhel85.yml
+++ b/ansible/group_vars/server_type_base_rhel85.yml
@@ -14,7 +14,7 @@ server_type_roles_list:
   - python-ssm-configure
   - autoscale-group-hooks-state
 
-packages_yum_update: []
+packages_yum_update_on_build: []
 
 collectd_monitored_services_servertype:
   - metric_name: service_status_os

--- a/ansible/group_vars/server_type_base_rhel85.yml
+++ b/ansible/group_vars/server_type_base_rhel85.yml
@@ -7,8 +7,8 @@ server_type_roles_list:
   - packages
   - sshd-config
   - users-and-groups
-  - set-ec2-hostname
-  - domain-search
+# - set-ec2-hostname
+# - domain-search
   - ansible-script
   - time
   - python-ssm-configure

--- a/ansible/group_vars/server_type_base_rhel85.yml
+++ b/ansible/group_vars/server_type_base_rhel85.yml
@@ -7,8 +7,8 @@ server_type_roles_list:
   - packages
   - sshd-config
   - users-and-groups
-# - set-ec2-hostname
-# - domain-search
+  # - set-ec2-hostname
+  # - domain-search
   - ansible-script
   - time
   - python-ssm-configure

--- a/ansible/group_vars/server_type_ncr_bip_app.yml
+++ b/ansible/group_vars/server_type_ncr_bip_app.yml
@@ -13,7 +13,7 @@ users_and_groups_system:
       - dba
       - sapsys
 
-set_ec2_hostname_mode: "short"  # don't rename to tags.Name
+set_ec2_hostname_mode: "short" # don't rename to tags.Name
 
 server_type_roles_list:
   - ansible-requirements

--- a/ansible/group_vars/server_type_ncr_bip_app.yml
+++ b/ansible/group_vars/server_type_ncr_bip_app.yml
@@ -13,6 +13,8 @@ users_and_groups_system:
       - dba
       - sapsys
 
+set_ec2_hostname_mode: "short"  # don't rename to tags.Name
+
 server_type_roles_list:
   - ansible-requirements
   - sshd-config

--- a/ansible/group_vars/server_type_ncr_bip_app.yml
+++ b/ansible/group_vars/server_type_ncr_bip_app.yml
@@ -42,6 +42,7 @@ server_type_roles_list:
 
 roles_list: "{{ (ami_roles_list | default([]) | difference(server_type_roles_list | default([]))) + (server_type_roles_list | default([])) }}"
 
+packages_yum_update_on_build: []
 packages_yum_install:
   - bind-utils
   - nano

--- a/ansible/group_vars/server_type_ncr_bip_cms.yml
+++ b/ansible/group_vars/server_type_ncr_bip_cms.yml
@@ -13,7 +13,7 @@ users_and_groups_system:
       - dba
       - sapsys
 
-set_ec2_hostname_mode: "short"  # don't rename to tags.Name
+set_ec2_hostname_mode: "short" # don't rename to tags.Name
 
 server_type_roles_list:
   - ansible-requirements

--- a/ansible/group_vars/server_type_ncr_bip_cms.yml
+++ b/ansible/group_vars/server_type_ncr_bip_cms.yml
@@ -13,6 +13,8 @@ users_and_groups_system:
       - dba
       - sapsys
 
+set_ec2_hostname_mode: "short"  # don't rename to tags.Name
+
 server_type_roles_list:
   - ansible-requirements
   - sshd-config

--- a/ansible/group_vars/server_type_ncr_bip_cms.yml
+++ b/ansible/group_vars/server_type_ncr_bip_cms.yml
@@ -42,6 +42,7 @@ server_type_roles_list:
 
 roles_list: "{{ (ami_roles_list | default([]) | difference(server_type_roles_list | default([]))) + (server_type_roles_list | default([])) }}"
 
+packages_yum_update_on_build: []
 packages_yum_install:
   - bind-utils
   - nano

--- a/ansible/group_vars/server_type_ncr_web.yml
+++ b/ansible/group_vars/server_type_ncr_web.yml
@@ -13,7 +13,7 @@ users_and_groups_system:
       - dba
       - sapsys
 
-set_ec2_hostname_mode: "short"  # don't rename to tags.Name
+set_ec2_hostname_mode: "short" # don't rename to tags.Name
 
 server_type_roles_list:
   - ansible-requirements

--- a/ansible/group_vars/server_type_ncr_web.yml
+++ b/ansible/group_vars/server_type_ncr_web.yml
@@ -40,6 +40,7 @@ server_type_roles_list:
 
 roles_list: "{{ (ami_roles_list | default([]) | difference(server_type_roles_list | default([]))) + (server_type_roles_list | default([])) }}"
 
+packages_yum_update_on_build: []
 packages_yum_install:
   - bind-utils
   - nano

--- a/ansible/group_vars/server_type_ncr_web.yml
+++ b/ansible/group_vars/server_type_ncr_web.yml
@@ -13,6 +13,8 @@ users_and_groups_system:
       - dba
       - sapsys
 
+set_ec2_hostname_mode: "short"  # don't rename to tags.Name
+
 server_type_roles_list:
   - ansible-requirements
   - sshd-config

--- a/ansible/group_vars/server_type_ncr_webadmin.yml
+++ b/ansible/group_vars/server_type_ncr_webadmin.yml
@@ -13,7 +13,7 @@ users_and_groups_system:
       - dba
       - sapsys
 
-set_ec2_hostname_mode: "short"  # don't rename to tags.Name
+set_ec2_hostname_mode: "short" # don't rename to tags.Name
 
 server_type_roles_list:
   - ansible-requirements

--- a/ansible/group_vars/server_type_ncr_webadmin.yml
+++ b/ansible/group_vars/server_type_ncr_webadmin.yml
@@ -40,6 +40,7 @@ server_type_roles_list:
 
 roles_list: "{{ (ami_roles_list | default([]) | difference(server_type_roles_list | default([]))) + (server_type_roles_list | default([])) }}"
 
+packages_yum_update_on_build: []
 packages_yum_install:
   - bind-utils
   - nano

--- a/ansible/group_vars/server_type_ncr_webadmin.yml
+++ b/ansible/group_vars/server_type_ncr_webadmin.yml
@@ -13,6 +13,8 @@ users_and_groups_system:
       - dba
       - sapsys
 
+set_ec2_hostname_mode: "short"  # don't rename to tags.Name
+
 server_type_roles_list:
   - ansible-requirements
   - sshd-config

--- a/ansible/roles/ncr-bip/defaults/main.yml
+++ b/ansible/roles/ncr-bip/defaults/main.yml
@@ -28,8 +28,8 @@ sap_bip_auditing_db_user: "{{ sap_bip_db_conf.auditing_db_user }}"
 sap_bip_cms_db_server: "{{ sap_bip_db_conf.cms_db_server }}"
 sap_bip_cms_db_user: "{{ sap_bip_db_conf.cms_db_user }}"
 sap_bip_cms_db_reset: 1
-sap_bip_sia_name_cms: "{{ ansible_ec2_hostname.split('.')[0] | replace('-','') }}"
-sap_bip_sia_name_app: "{{ ansible_ec2_hostname.split('.')[0] | replace('-','') }}"
+sap_bip_sia_name_cms: "{{ ec2.tags.Name | replace('-','') }}"
+sap_bip_sia_name_app: "{{ ec2.tags.Name | replace('-','') }}"
 
 # set in group vars, otherwise response.cms.ini or response.app.ini is used depending on whether first install
 # sap_bip_responsefile:

--- a/ansible/roles/ncr-bip/tasks/update_secrets.yml
+++ b/ansible/roles/ncr-bip/tasks/update_secrets.yml
@@ -5,7 +5,7 @@
   vars:
     secretsmanager_passwords:
       config:
-        secret: "/ec2/ncr-bip/{{ ncr_environment }}/config"
+        secret: "{{ sap_bip_secretsmanager_passwords.config.secret }}"
         users:
           - cms_primary_hostname: "{{ sap_bip_cms_primary_hostname }}"
           - cms_hosts: "{{ sap_bip_cms_hosts }}"

--- a/ansible/roles/ncr-bip/templates/home/bobj/.bash_profile
+++ b/ansible/roles/ncr-bip/templates/home/bobj/.bash_profile
@@ -8,7 +8,7 @@ fi
 # User specific environment and startup programs
 
 export EDITOR=vi
-export PS1="[\u@\h {{ ec2.tags['Name'] }} \W]\$"
+export PS1="[\u@\h {{ ec2.tags['Name'] }} \W]\$ "
 
 # Oracle setup
 export ORACLE_HOME={{ oracle_home }}

--- a/ansible/roles/ncr-bip/templates/home/bobj/.bash_profile
+++ b/ansible/roles/ncr-bip/templates/home/bobj/.bash_profile
@@ -8,6 +8,7 @@ fi
 # User specific environment and startup programs
 
 export EDITOR=vi
+export PS1="[\u@\h {{ ec2.tags['Name'] }} \W]\$"
 
 # Oracle setup
 export ORACLE_HOME={{ oracle_home }}

--- a/ansible/roles/set-ec2-hostname/defaults/main.yml
+++ b/ansible/roles/set-ec2-hostname/defaults/main.yml
@@ -1,3 +1,3 @@
 ---
 # dns_zone_internal: set in environment specific group_vars
-set_ec2_hostname_mode: "auto"  # or tags.Name or short
+set_ec2_hostname_mode: "auto" # or tags.Name or short

--- a/ansible/roles/set-ec2-hostname/defaults/main.yml
+++ b/ansible/roles/set-ec2-hostname/defaults/main.yml
@@ -1,2 +1,3 @@
 ---
 # dns_zone_internal: set in environment specific group_vars
+set_ec2_hostname_mode: "auto"  # or tags.Name or short

--- a/ansible/roles/set-ec2-hostname/tasks/set-ec2-hostname.yml
+++ b/ansible/roles/set-ec2-hostname/tasks/set-ec2-hostname.yml
@@ -18,13 +18,15 @@
   set_fact:
     ec2_hostname_fqdn: "{{ ec2.tags.Name }}.{{ dns_zone_internal }}"
     ec2_hostname_short: "{{ ec2.tags.Name }}"
-  when: ansible_ec2_autoscaling_target_lifecycle_state is not defined
+  when:
+    - set_ec2_hostname_mode == "tags.Name" or (set_ec2_hostname_mode == "auto" and ansible_ec2_autoscaling_target_lifecycle_state is not defined)
 
 - name: Set hostname to the dns name
   set_fact:
     ec2_hostname_fqdn: "{{ ansible_ec2_hostname }}"
     ec2_hostname_short: "{{ ansible_ec2_hostname.split('.')[0] }}"
-  when: ansible_ec2_autoscaling_target_lifecycle_state is defined
+  when:
+    - set_ec2_hostname_mode == "short" or (set_ec2_hostname_mode == "auto" and ansible_ec2_autoscaling_target_lifecycle_state is defined)
 
 - name: Configure /etc/hosts
   ansible.builtin.template:
@@ -45,7 +47,7 @@
 - name: Get hostname RHEL6
   ansible.builtin.shell: |
     hostname
-  check_mode: no
+  check_mode: false
   changed_when: false
   register: rhel6_hostname
   when: ansible_distribution_major_version == '6'


### PR DESCRIPTION
Minor fixes for bip running as standalone EC2 rather than ASG:
- don't rename EC2 hostname to tags.Name, instead just use short hostname
- update bobj prompt to include tags.Name
- don't run packages yum update as it will update rhel minor release to unsupported version
- base SIA name of tags.Name rather than hostname