### PR TITLE
Tm/tm 584/fix path

### DIFF
--- a/powershell/Scripts/UserDataScripts/OnrBods.ps1
+++ b/powershell/Scripts/UserDataScripts/OnrBods.ps1
@@ -530,17 +530,16 @@ $ipsInstallParams = @{
 }
 
 # debugging
-$ipsInstallParams | Out-File -FilePath "$WorkingDirectory\IPS\DATA_UNITS\IPS_win\ips_install_params.txt" -Force
+# $ipsInstallParams | Out-File -FilePath "$WorkingDirectory\IPS\DATA_UNITS\IPS_win\ips_install_params.txt" -Force
 
 Clear-PendingFileRenameOperations
 
-if (-NOT(Test-Path $ipsInstallParams.FilePath)) {
-    Write-Output "IPS setup.exe not found at $($ipsInstallParams.FilePath)"
-    exit 1
-}
+# if (-NOT(Test-Path $ipsInstallParams.FilePath)) {
+#     Write-Output "IPS setup.exe not found at $($ipsInstallParams.FilePath)"
+#     exit 1
+# }
 
-Start-Process @ipsInstallParams -ErrorAction Stop
-
+& "$WorkingDirectory\IPS\DATA_UNITS\IPS_win\setup.exe" -r "$WorkingDirectory\IPS\DATA_UNITS\IPS_win\ips_install.rsp" | Out-Null
 # }}} end install IPS
 
 # {{{ install Data Services
@@ -622,7 +621,9 @@ $dataServicesInstallParams = @{
 }
 
 # DISABLE FOR TESTING
-Start-Process @dataServicesInstallParams
+# Start-Process @dataServicesInstallParams
+& "$WorkingDirectory\$($Config.DataServicesS3File)" -r "$WorkingDirectory\ds_install.rsp" | Out-Null
+
 # }}} End install Data Services
 
 # {{{ Post install steps for Data Services, configure JDBC driver

--- a/powershell/Scripts/UserDataScripts/OnrBods.ps1
+++ b/powershell/Scripts/UserDataScripts/OnrBods.ps1
@@ -433,21 +433,24 @@ Enable-PSRemoting -Force
 # Use admin credentials to add the service user to the Remote Desktop Users group
 $ADAdminCredential = Get-ModPlatformADAdminCredential -ModPlatformADConfig $ADConfig -ModPlatformADSecret $ADSecret
 
-$serviceUser = "$($Config.domain)\$($Config.serviceUser)"
-Write-Host "Adding $serviceUser to Remote Desktop Users group on $ComputerName"
+# $serviceUser = "$($Config.domain)\$($Config.serviceUser)"
+# TODO: Remove this as it's being done by Group Policy by moving the EC2 instance to the Nart OU
+# Write-Host "Adding $serviceUser to Remote Desktop Users group on $ComputerName"
 
-Invoke-Command -ComputerName $ComputerName -Credential $ADAdminCredential -ScriptBlock {
-   param($serviceUser)
-   #Add the service user to the Remote Desktop Users group locally, if this isn't enough change to -Group Administrators
-   Add-LocalGroupMember -Group "Remote Desktop Users" -Member $serviceUser
-   Add-LocalGroupMember -Group "Administrators" -Member $serviceUser
-} -ArgumentList $serviceUser
+# Invoke-Command -ComputerName $ComputerName -Credential $ADAdminCredential -ScriptBlock {
+#    param($serviceUser)
+#    #Add the service user to the Remote Desktop Users group locally, if this isn't enough change to -Group Administrators
+#    Add-LocalGroupMember -Group "Remote Desktop Users" -Member $serviceUser
+#    Add-LocalGroupMember -Group "Administrators" -Member $serviceUser
+# } -ArgumentList $serviceUser
 
 # Move the computer to the correct OU
 Move-ModPlatformADComputer -ModPlatformADCredential $ADAdminCredential -NewOU $($Config.nartComputersOU)
 
-# ensure computer is in the correct OU
+# ensure computer is in the correct OU TODO: need to check this is actually applied
 gpupdate /force
+
+
 # }}}
 
 # {{{ prepare assets

--- a/powershell/Scripts/UserDataScripts/OnrBods.ps1
+++ b/powershell/Scripts/UserDataScripts/OnrBods.ps1
@@ -547,15 +547,18 @@ if (-NOT(Test-Path "$WorkingDirectory\IPS\DATA_UNITS\IPS_win\ips_install.rsp")) 
     exit 1
 }
 
-try {
-    Write-Host "IPS install started"
-    Start-Process @ipsInstallParams -ErrorAction Stop
-} catch {
-    Write-Output "Output, Failed to start process $_"
-    Write-Error "Error, Failed to start process: $_"
-    Write-Host  "Host, Failed to start process: $_"
-    exit 1
-}
+# try {
+#     Write-Host "IPS install started"
+#     Start-Process @ipsInstallParams -ErrorAction Stop
+# } catch {
+#     Write-Output "Output, Failed to start process $_"
+#     Write-Error "Error, Failed to start process: $_"
+#     Write-Host  "Host, Failed to start process: $_"
+#     exit 1
+# }
+
+start /wait "$WorkingDirectory\IPS\DATA_UNITS\IPS_win\setup.exe" -r "$WorkingDirectory\IPS\DATA_UNITS\IPS_win\ips_install.rsp"
+
 # & "$WorkingDirectory\IPS\DATA_UNITS\IPS_win\setup.exe" -r "$WorkingDirectory\IPS\DATA_UNITS\IPS_win\ips_install.rsp" | Out-Null
 # }}} end install IPS
 

--- a/powershell/Scripts/UserDataScripts/OnrBods.ps1
+++ b/powershell/Scripts/UserDataScripts/OnrBods.ps1
@@ -699,6 +699,9 @@ if (-NOT(Test-Path $ipsInstallIni)) {
 $logFile = "$WorkingDirectory\IPS\DATA_UNITS\IPS_win\install_ips_sp.log"
 New-Item -Type File -Path $logFile -Force | Out-Null
 
+# add Oracle client path to the powershell session
+$env:Path += ";E:\app\oracle\product\19.0.0\client_1\bin"
+
 try {
     "Starting IPS installer at $(Get-Date)" | Out-File -FilePath $logFile -Append
     $process = Start-Process -FilePath "D:\Software\IPS\DATA_UNITS\IPS_win\setup.exe" -ArgumentList '/wait -r D:\Software\IPS\DATA_UNITS\IPS_win\ips_install.ini' -Wait -NoNewWindow -Verbose -PassThru

--- a/powershell/Scripts/UserDataScripts/OnrBods.ps1
+++ b/powershell/Scripts/UserDataScripts/OnrBods.ps1
@@ -527,6 +527,7 @@ $ipsInstallParams = @{
     ArgumentList = '/wait -r D:\Software\IPS\DATA_UNITS\IPS_win\ips_install.ini'
     Verb = 'RunAs'
     Wait = $true
+    Verb = "RunAs"
 }
 
 # debugging
@@ -544,7 +545,14 @@ if (-NOT(Test-Path "$WorkingDirectory\IPS\DATA_UNITS\IPS_win\ips_install.rsp")) 
     exit 1
 }
 
-Start-Process @ipsInstallParams
+try {
+    Write-Host "IPS install started"
+    Start-Process @ipsInstallParams -ErrorAction Stop -ErrorVariable StartProcessError
+} catch {
+    Write-Error "Failed to start process: $StartProcessError"
+    Write-Host  "Failed to start process: $StartProcessError"
+    exit 1
+}
 # & "$WorkingDirectory\IPS\DATA_UNITS\IPS_win\setup.exe" -r "$WorkingDirectory\IPS\DATA_UNITS\IPS_win\ips_install.rsp" | Out-Null
 # }}} end install IPS
 

--- a/powershell/Scripts/UserDataScripts/OnrBods.ps1
+++ b/powershell/Scripts/UserDataScripts/OnrBods.ps1
@@ -547,7 +547,7 @@ New-Item -Type File -Path $logFile -Force | Out-Null
 
 try {
     "Starting IPS installer at $(Get-Date)" | Out-File -FilePath $logFile -Append
-    Start-Process -FilePath "D:\Software\IPS\DATA_UNITS\IPS_win\setup.exe" -ArgumentList '-r D:\Software\IPS\DATA_UNITS\IPS_win\ips_install.ini' -Wait -NoNewWindow
+    Start-Process -FilePath "D:\Software\IPS\DATA_UNITS\IPS_win\setup.exe" -ArgumentList '/wait -r D:\Software\IPS\DATA_UNITS\IPS_win\ips_install.ini' -Wait -NoNewWindow
 } catch {
     $exception = $_.Exception
     "Failed to start installer at $(Get-Date)" | Out-File -FilePath $logFile -Append

--- a/powershell/Scripts/UserDataScripts/OnrBods.ps1
+++ b/powershell/Scripts/UserDataScripts/OnrBods.ps1
@@ -702,6 +702,12 @@ New-Item -Type File -Path $logFile -Force | Out-Null
 # add Oracle client path to the powershell session
 $env:Path += ";E:\app\oracle\product\19.0.0\client_1\bin"
 
+$env:Path -split ";" | ForEach-Object {
+    Write-Host $_
+}
+
+Write-Host "Starting IPS installer at $(Get-Date)"
+
 try {
     "Starting IPS installer at $(Get-Date)" | Out-File -FilePath $logFile -Append
     $process = Start-Process -FilePath "D:\Software\IPS\DATA_UNITS\IPS_win\setup.exe" -ArgumentList '/wait -r D:\Software\IPS\DATA_UNITS\IPS_win\ips_install.ini' -Wait -NoNewWindow -Verbose -PassThru

--- a/powershell/Scripts/UserDataScripts/OnrBods.ps1
+++ b/powershell/Scripts/UserDataScripts/OnrBods.ps1
@@ -615,8 +615,10 @@ $dataServicesInstallParams = @{
     WorkingDirectory = $WorkingDirectory
     ArgumentList = '-q -r D:\Software\ds_install.ini'
     Wait = $true
-    # NoNewWindow = $true
-    Verb = "Open"
+    Verb = "RunAs"
+    WindowStyle = "Hidden"
+    RedirectStandardOutput = "$WorkingDirectory\std_out_ds_install.log"
+    RedirectStandardError = "$WorkingDirectory\std_err_ds_install.log"
 }
 
 # DISABLE FOR TESTING

--- a/powershell/Scripts/UserDataScripts/OnrBods.ps1
+++ b/powershell/Scripts/UserDataScripts/OnrBods.ps1
@@ -21,7 +21,7 @@ $GlobalConfig = @{
         "sysDbName"       = "T2BOSYS"
         "audDbName"       = "T2BOAUD"
         "tnsorafile"      = "tnsnames_T2_BODS.ora"
-        "cmsMainNode"     = "t2-tst-bods-asg" #TODO: change this BACK
+        "cmsMainNode"     = "t2-tst-bods-1"
         "cmsExtendedNode" = "t2-onr-bods-2"
         "serviceUser"     = "svc_nart"
         "serviceUserPath" = "OU=Service,OU=Users,OU=NOMS RBAC,DC=AZURE,DC=NOMS,DC=ROOT"
@@ -397,11 +397,6 @@ Set-MpPreference -DisableBehaviorMonitoring $true
 
 Write-Host "Windows Security antivirus has been disabled. Please re-enable it as soon as possible for security reasons."
 
-# Label the drives just to add some convienience
-# Set-DriveLabel -DriveLetter "D" -NewLabel "Temp"
-# Set-DriveLabel -DriveLetter "E" -NewLabel "App"
-# Set-DriveLabel -DriveLetter "F" -NewLabel "Storage"
-
 # Set local time zone to UK although this should now be set by Group Policy objects
 Set-TimeZone -Name "GMT Standard Time"
 
@@ -448,23 +443,11 @@ Enable-PSRemoting -Force
 # Use admin credentials to add the service user to the Remote Desktop Users group
 $ADAdminCredential = Get-ModPlatformADAdminCredential -ModPlatformADConfig $ADConfig -ModPlatformADSecret $ADSecret
 
-# $serviceUser = "$($Config.domain)\$($Config.serviceUser)"
-# TODO: Remove this as it's being done by Group Policy by moving the EC2 instance to the Nart OU
-# Write-Host "Adding $serviceUser to Remote Desktop Users group on $ComputerName"
-
-# Invoke-Command -ComputerName $ComputerName -Credential $ADAdminCredential -ScriptBlock {
-#    param($serviceUser)
-#    #Add the service user to the Remote Desktop Users group locally, if this isn't enough change to -Group Administrators
-#    Add-LocalGroupMember -Group "Remote Desktop Users" -Member $serviceUser
-#    Add-LocalGroupMember -Group "Administrators" -Member $serviceUser
-# } -ArgumentList $serviceUser
-
 # Move the computer to the correct OU
 Move-ModPlatformADComputer -ModPlatformADCredential $ADAdminCredential -NewOU $($Config.nartComputersOU)
 
-# ensure computer is in the correct OU TODO: need to check this is actually applied
+# ensure computer is in the correct OU
 gpupdate /force
-
 
 # }}}
 
@@ -593,17 +576,17 @@ choosesmdintegration=nointegrate
 ### CMS cluster key
 clusterkey=$bods_cluster_key
 ### CMS administrator password
-# cmspassword=$bods_admin_password
+# cmspassword=**** bods_admin_password value supplied directly via silent install params
 ### CMS connection port
 cmsport=6400
 ### Existing auditing DB password
-# existingauditingdbpassword=$bods_ips_audit_owner
+# existingauditingdbpassword=**** bods_ips_audit_owner value supplied directly via silent install params
 ### Existing auditing DB server
 existingauditingdbserver=$($Config.audDbName)
 ### Existing auditing DB user name
 existingauditingdbuser=bods_ips_audit_owner
 ### Existing CMS DB password
-# existingcmsdbpassword=$bods_ips_system_owner
+# existingcmsdbpassword=**** bods_ips_system_owner value supplied directly via silent install params
 ### Existing CMS DB reset flag: 0 or 1 where 1 means don't reset <<<<<<-- check this
 existingcmsdbreset=1
 ### Existing CMS DB server
@@ -617,7 +600,7 @@ installtype=custom
 ### LCM server name
 lcmname=LCM_repository
 ### LCM password
-# lcmpassword=$bods_subversion_password
+# lcmpassword=**** bods_subversion_password value supplied directly via silent install params
 ### LCM port
 lcmport=3690
 ### LCM user name
@@ -778,7 +761,7 @@ $dataServicesResponsePrimary = @"
 ### #property.CMSAUTHENTICATION.description#
 cmsauthentication=secEnterprise
 ### CMS administrator password
-# cmspassword=$bods_admin_password
+# cmspassword=**** bods_admin_password value supplied directly via silent install params
 ### #property.CMSUSERNAME.description#
 cmsusername=Administrator
 ### #property.CMSAuthMode.description#
@@ -786,7 +769,7 @@ dscmsauth=secEnterprise
 ### #property.CMSEnabledSSL.description#
 dscmsenablessl=0
 ### CMS administrator password
-# dscmspassword=$bods_admin_password
+# dscmspassword=**** bods_admin_password value supplied directly via silent install params
 ### #property.CMSServerPort.description#
 dscmsport=6400
 ### #property.CMSServerName.description#
@@ -810,7 +793,7 @@ dslogininfoaccountselection=this
 ### #property.DSLoginInfoThisUser.description#
 dslogininfothisuser=$($Config.Domain)\$($Config.serviceUser)
 ### #property.DSLoginInfoThisPassword.description#
-# dslogininfothispassword=$service_user_password
+# dslogininfothispassword=**** service_user_password value supplied directly via silent install params
 ### Installation folder for SAP products
 installdir=E:\SAP BusinessObjects\
 ### #property.IsCommonDirChanged.description#

--- a/powershell/Scripts/UserDataScripts/OnrBods.ps1
+++ b/powershell/Scripts/UserDataScripts/OnrBods.ps1
@@ -525,12 +525,12 @@ Clear-PendingFileRenameOperations
 $setupExe = "$WorkingDirectory\IPS\DATA_UNITS\IPS_win\setup.exe"
 
 # Build the command to pass to cmd.exe
-$command = 'start "" /wait "' + $setupExe + '" -r "' + $ipsInstallIni + '"'
+# $command = 'start "" /wait "' + $setupExe + '" -r "' + $ipsInstallIni + '"'
 
 # Build the ArgumentList as an array of strings
-$cmdArgs = @('/c', $command)
+# $cmdArgs = @('/c', $command)
 
-$command | Out-File -FilePath "$WorkingDirectory\IPS\DATA_UNITS\IPS_win\command.txt" -Force
+# $command | Out-File -FilePath "$WorkingDirectory\IPS\DATA_UNITS\IPS_win\command.txt" -Force
 
 if (-NOT(Test-Path $setupExe)) {
     Write-Host "IPS setup.exe not found at $($setupExe)"
@@ -542,16 +542,18 @@ if (-NOT(Test-Path $ipsInstallIni)) {
     exit 1
 }
 
-# IMPORTANT: because the installer only has access to /wait via cmd.exe we can't use Start-Process to run the installer directly via PowerShell
+$logFile = "$WorkingDirectory\IPS\DATA_UNITS\IPS_win\install_ips_sp.log"
+New-Item -Type File -Path $logFile -Force | Out-Null
+
 try {
-    # & cmd.exe /c $command
-    Start-Process -FilePath cmd.exe -ArgumentList $cmdArgs -Wait -NoNewWindow
+    "Starting IPS installer at $(Get-Date)" | Out-File -FilePath $logFile -Append
+    Start-Process -FilePath "D:\Software\IPS\DATA_UNITS\IPS_win\setup.exe" -ArgumentList '-r D:\Software\IPS\DATA_UNITS\IPS_win\ips_install.ini' -Wait -NoNewWindow
 } catch {
     $exception = $_.Exception
-    Write-Error "Failed to start installer:"
-    Write-Error "Exception Message: $($exception.Message)"
+    "Failed to start installer at $(Get-Date)" | Out-File -FilePath $logFile -Append
+    "Exception Message: $($exception.Message)" | OUt-File -FilePath $logFile -Append
     if ($exception.InnerException) {
-        Write-Error "Inner Exception Message: $($exception.InnerException.Message)"
+        "Inner Exception Message: $($exception.InnerException.Message)" | Out-File -FilePath $logFile -Append
     }
 }
 

--- a/powershell/Scripts/UserDataScripts/OnrBods.ps1
+++ b/powershell/Scripts/UserDataScripts/OnrBods.ps1
@@ -483,9 +483,6 @@ $oracleClientResponseFileContent | Out-File -FilePath "$WorkingDirectory\OracleC
 # Service user will have been added by Group Policy to the Administrators User Group, makes sure this is applied
 gpupdate /force
 
-# convert the service user password and domain to a credential object
-$serviceUserCredentialObject = New-Object System.Management.Automation.PSCredential -ArgumentList "$($Config.domain)\$($Config.serviceUser)", $serviceUserPassword 
-
 # Install Oracle Client silent install
 $OracleClientInstallParams = @{
     FilePath         = "$WorkingDirectory\OracleClient\client\setup.exe"
@@ -780,7 +777,7 @@ dscmspassword=$bods_admin_password
 ### #property.CMSServerPort.description#
 dscmsport=6400
 ### #property.CMSServerName.description#
-dscmssystem=$($Config.cmsMainNode)
+dscmssystem=$env:COMPUTERNAME
 ### #property.CMSUser.description#
 dscmsuser=Administrator
 ### #property.DSCommonDir.description#
@@ -806,7 +803,7 @@ installdir=E:\SAP BusinessObjects\
 ### #property.IsCommonDirChanged.description#
 iscommondirchanged=1
 ### #property.MasterCmsName.description#
-mastercmsname=$($Config.cmsMainNode)
+mastercmsname=$env:COMPUTERNAME
 ### #property.MasterCmsPort.description#
 mastercmsport=6400
 ### Keycode for the product.

--- a/powershell/Scripts/UserDataScripts/OnrBods.ps1
+++ b/powershell/Scripts/UserDataScripts/OnrBods.ps1
@@ -255,9 +255,9 @@ Set-MpPreference -DisableBehaviorMonitoring $true
 Write-Host "Windows Security antivirus has been disabled. Please re-enable it as soon as possible for security reasons."
 
 # Label the drives just to add some convienience
-Set-DriveLabel -DriveLetter "D" -NewLabel "Storage"
+Set-DriveLabel -DriveLetter "D" -NewLabel "Temp"
 Set-DriveLabel -DriveLetter "E" -NewLabel "App"
-Set-DriveLabel -DriveLetter "F" -NewLabel "Temp"
+Set-DriveLabel -DriveLetter "F" -NewLabel "Storage"
 
 # Set local time zone to UK
 Set-TimeZone -Name "GMT Standard Time"

--- a/powershell/Scripts/UserDataScripts/OnrBods.ps1
+++ b/powershell/Scripts/UserDataScripts/OnrBods.ps1
@@ -530,16 +530,17 @@ $ipsInstallParams = @{
 }
 
 # debugging
-# $ipsInstallParams | Out-File -FilePath "$WorkingDirectory\IPS\DATA_UNITS\IPS_win\ips_install_params.txt" -Force
+$ipsInstallParams | Out-File -FilePath "$WorkingDirectory\IPS\DATA_UNITS\IPS_win\ips_install_params.txt" -Force
 
 Clear-PendingFileRenameOperations
 
-# if (-NOT(Test-Path $ipsInstallParams.FilePath)) {
-#     Write-Output "IPS setup.exe not found at $($ipsInstallParams.FilePath)"
-#     exit 1
-# }
+if (-NOT(Test-Path $ipsInstallParams.FilePath)) {
+    Write-Output "IPS setup.exe not found at $($ipsInstallParams.FilePath)"
+    exit 1
+}
 
-& "$WorkingDirectory\IPS\DATA_UNITS\IPS_win\setup.exe" -r "$WorkingDirectory\IPS\DATA_UNITS\IPS_win\ips_install.rsp" | Out-Null
+Start-Process @ipsInstallParams
+# & "$WorkingDirectory\IPS\DATA_UNITS\IPS_win\setup.exe" -r "$WorkingDirectory\IPS\DATA_UNITS\IPS_win\ips_install.rsp" | Out-Null
 # }}} end install IPS
 
 # {{{ install Data Services
@@ -621,8 +622,8 @@ $dataServicesInstallParams = @{
 }
 
 # DISABLE FOR TESTING
-# Start-Process @dataServicesInstallParams
-& "$WorkingDirectory\$($Config.DataServicesS3File)" -r "$WorkingDirectory\ds_install.rsp" | Out-Null
+Start-Process @dataServicesInstallParams
+# & "$WorkingDirectory\$($Config.DataServicesS3File)" -r "$WorkingDirectory\ds_install.rsp" | Out-Null
 
 # }}} End install Data Services
 

--- a/powershell/Scripts/UserDataScripts/OnrBods.ps1
+++ b/powershell/Scripts/UserDataScripts/OnrBods.ps1
@@ -26,7 +26,7 @@ $GlobalConfig = @{
         "serviceUser"     = "svc_nart"
         "serviceUserPath" = "OU=Service,OU=Users,OU=NOMS RBAC,DC=AZURE,DC=NOMS,DC=ROOT"
         "nartComputersOU" = "OU=Nart,OU=MODERNISATION_PLATFORM_SERVERS,DC=AZURE,DC=NOMS,DC=ROOT"
-        "serviceUserDescription" = "Onr BODS T2 service user for AWS"
+        "serviceUserDescription" = "Onr BODS service user for AWS in AZURE domain"
         "domain"    = "AZURE"
     }
     "oasys-national-reporting-preproduction" = @{
@@ -38,7 +38,7 @@ $GlobalConfig = @{
         "serviceUser"     = "svc_nart"
         "serviceUserPath" = "OU=SERVICE_ACCOUNTS,OU=RBAC,DC=AZURE,DC=HMPP,DC=ROOT"
         "nartComputersOU" = "OU=Nart,OU=MODERNISATION_PLATFORM_SERVERS,DC=AZURE,DC=HMPP,DC=ROOT"
-        "serviceUserDescription" = "Onr BODS preprod service user for AWS"
+        "serviceUserDescription" = "Onr BODS service user for AWS in HMPP domain"
         "domain" = "HMPP"
     }
     "oasys-national-reporting-production"    = @{

--- a/powershell/Scripts/UserDataScripts/OnrBods.ps1
+++ b/powershell/Scripts/UserDataScripts/OnrBods.ps1
@@ -50,7 +50,7 @@ $tempPath = ([System.IO.Path]::GetTempPath())
 
 $ConfigurationManagementRepo = "$tempPath\modernisation-platform-configuration-management"
 $ErrorActionPreference = "Stop"
-$WorkingDirectory = "D:\Software"
+$WorkingDirectory = "E:\Software"
 $AppDirectory = "E:\App"
 
 # # Path to ebsnvme-id.exe
@@ -707,7 +707,7 @@ Write-Host "Starting IPS installer at $(Get-Date)"
 
 try {
     "Starting IPS installer at $(Get-Date)" | Out-File -FilePath $logFile -Append
-    $process = Start-Process -FilePath "D:\Software\IPS\DATA_UNITS\IPS_win\setup.exe" -ArgumentList '/wait -r D:\Software\IPS\DATA_UNITS\IPS_win\ips_install.ini' -Wait -NoNewWindow -Verbose -PassThru
+    $process = Start-Process -FilePath "E:\Software\IPS\DATA_UNITS\IPS_win\setup.exe" -ArgumentList '/wait -r E:\Software\IPS\DATA_UNITS\IPS_win\ips_install.ini' -Wait -NoNewWindow -Verbose -PassThru
     $installProcessId = $process.Id
     "Initial process is $installProcessId at $(Get-Date)" | Out-File -FilePath $logFile -Append
     # get all process IDs to monitor

--- a/powershell/Scripts/UserDataScripts/OnrBods.ps1
+++ b/powershell/Scripts/UserDataScripts/OnrBods.ps1
@@ -593,7 +593,7 @@ choosesmdintegration=nointegrate
 ### CMS cluster key
 clusterkey=$bods_cluster_key
 ### CMS administrator password
-cmspassword=$bods_admin_password
+# cmspassword=$bods_admin_password
 ### CMS connection port
 cmsport=6400
 ### Existing auditing DB password
@@ -657,7 +657,7 @@ neworexistinglcm=expand
 ### CMS cluster key
 clusterkey=$bods_cluster_key
 ### CMS administrator password
-cmspassword=$bods_admin_password
+# cmspassword=$bods_admin_password
 ### CMS connection port
 cmsport=6400
 ### Existing main cms node name
@@ -732,7 +732,7 @@ Write-Host "Starting IPS installer at $(Get-Date)"
 
 try {
     "Starting IPS installer at $(Get-Date)" | Out-File -FilePath $logFile -Append
-    $process = Start-Process -FilePath "E:\Software\IPS\DATA_UNITS\IPS_win\setup.exe" -ArgumentList '/wait -r E:\Software\IPS\DATA_UNITS\IPS_win\ips_install.ini' -Wait -NoNewWindow -Verbose -PassThru
+    $process = Start-Process -FilePath "E:\Software\IPS\DATA_UNITS\IPS_win\setup.exe" -ArgumentList '/wait','-r E:\Software\IPS\DATA_UNITS\IPS_win\ips_install.ini',"cmspassword=$bods_admin_password" -Wait -NoNewWindow -Verbose -PassThru
     $installProcessId = $process.Id
     "Initial process is $installProcessId at $(Get-Date)" | Out-File -FilePath $logFile -Append
     # get all process IDs to monitor
@@ -865,7 +865,7 @@ if (Test-Path $jdbcDriverPath) {
     foreach ($destination in $destinations) {
         if (Test-Path $destination) {
             Write-Output "Copying JDBC driver to $destination"
-            Copy-Item -Path $jdbcDriverPath -Destination $destination -NoClobber
+            Copy-Item -Path $jdbcDriverPath -Destination $destination
         } else {
             Write-Output "Destination $destination does not exist, skipping"
         }

--- a/powershell/Scripts/UserDataScripts/OnrBods.ps1
+++ b/powershell/Scripts/UserDataScripts/OnrBods.ps1
@@ -759,6 +759,7 @@ if (-NOT(Test-Path "F:\BODS_COMMON_DIR")) {
 [Environment]::SetEnvironmentVariable("DS_COMMON_DIR", "F:\BODS_COMMON_DIR", [System.EnvironmentVariableTarget]::Machine)
 #
 $data_services_product_key = Get-SecretValue -SecretId $bodsSecretName -SecretKey "data_services_product_key" -ErrorAction SilentlyContinue
+$service_user_password = Get-SecretValue -SecretId $bodsSecretName -SecretKey "svc_nart" -ErrorAction SilentlyContinue
 
 $dataServicesResponsePrimary = @"
 ### #property.CMSAUTHENTICATION.description#

--- a/powershell/Scripts/UserDataScripts/OnrBods.ps1
+++ b/powershell/Scripts/UserDataScripts/OnrBods.ps1
@@ -535,7 +535,12 @@ $ipsInstallParams | Out-File -FilePath "$WorkingDirectory\IPS\DATA_UNITS\IPS_win
 Clear-PendingFileRenameOperations
 
 if (-NOT(Test-Path $ipsInstallParams.FilePath)) {
-    Write-Output "IPS setup.exe not found at $($ipsInstallParams.FilePath)"
+    Write-Host "IPS setup.exe not found at $($ipsInstallParams.FilePath)"
+    exit 1
+}
+
+if (-NOT(Test-Path "$WorkingDirectory\IPS\DATA_UNITS\IPS_win\ips_install.rsp") {
+    Write-Host "IPS response file not found at $WorkingDirectory\IPS\DATA_UNITS\IPS_win\ips_install.rsp"
     exit 1
 }
 

--- a/powershell/Scripts/UserDataScripts/OnrBods.ps1
+++ b/powershell/Scripts/UserDataScripts/OnrBods.ps1
@@ -25,7 +25,7 @@ $GlobalConfig = @{
         "cmsExtendedNode" = "t2-onr-bods-2"
         "serviceUser"     = "svc_nart"
         "serviceUserPath" = "OU=Service,OU=Users,OU=NOMS RBAC,DC=AZURE,DC=NOMS,DC=ROOT"
-        "nartComputersOU" = "OU=Nart,OU=MODERNISATION_PLATFORM_COMPUTERS,DC=AZURE,DC=NOMS,DC=ROOT"
+        "nartComputersOU" = "OU=Nart,OU=MODERNISATION_PLATFORM_SERVERS,DC=AZURE,DC=NOMS,DC=ROOT"
         "serviceUserDescription" = "Onr BODS T2 service user for AWS"
         "domain"    = "AZURE"
     }
@@ -36,8 +36,8 @@ $GlobalConfig = @{
         "cmsMainNode"     = "pp-onr-bods-1"
         "cmsExtendedNode" = "pp-onr-bods-2"
         "serviceUser"     = "svc_nart"
-        "serviceUserPath" = "OU=SERVICE_ACCOUNTS,OU=RBAC,DC=azure,DC=hmpp,DC=root"
-        "nartComputersOU" = "OU=Nart,OU=MODERNISATION_PLATFORM_COMPUTERS,DC=AZURE,DC=NOMS,DC=ROOT"
+        "serviceUserPath" = "OU=SERVICE_ACCOUNTS,OU=RBAC,DC=AZURE,DC=HMPP,DC=ROOT"
+        "nartComputersOU" = "OU=Nart,OU=MODERNISATION_PLATFORM_SERVERS,DC=AZURE,DC=HMPP,DC=ROOT"
         "serviceUserDescription" = "Onr BODS preprod service user for AWS"
         "domain" = "HMPP"
     }

--- a/powershell/Scripts/UserDataScripts/OnrBods.ps1
+++ b/powershell/Scripts/UserDataScripts/OnrBods.ps1
@@ -760,7 +760,6 @@ if (-NOT(Test-Path "F:\BODS_COMMON_DIR")) {
 #
 $data_services_product_key = Get-SecretValue -SecretId $bodsSecretName -SecretKey "data_services_product_key" -ErrorAction SilentlyContinue
 
-
 $dataServicesResponsePrimary = @"
 ### #property.CMSAUTHENTICATION.description#
 cmsauthentication=secEnterprise
@@ -777,7 +776,7 @@ dscmspassword=$bods_admin_password
 ### #property.CMSServerPort.description#
 dscmsport=6400
 ### #property.CMSServerName.description#
-dscmssystem=$env:COMPUTERNAME
+dscmssystem=$($env:COMPUTERNAME)
 ### #property.CMSUser.description#
 dscmsuser=Administrator
 ### #property.DSCommonDir.description#
@@ -803,7 +802,7 @@ installdir=E:\SAP BusinessObjects\
 ### #property.IsCommonDirChanged.description#
 iscommondirchanged=1
 ### #property.MasterCmsName.description#
-mastercmsname=$env:COMPUTERNAME
+mastercmsname=$($env:COMPUTERNAME)
 ### #property.MasterCmsPort.description#
 mastercmsport=6400
 ### Keycode for the product.

--- a/powershell/Scripts/UserDataScripts/OnrBods.ps1
+++ b/powershell/Scripts/UserDataScripts/OnrBods.ps1
@@ -528,7 +528,7 @@ $setupExe = "$WorkingDirectory\IPS\DATA_UNITS\IPS_win\setup.exe"
 $command = 'start "" /wait "' + $setupExe + '" -r "' + $ipsInstallIni + '"'
 
 # Build the ArgumentList as an array of strings
-# $cmdArgs = @('/c', $command)
+$cmdArgs = @('/c', $command)
 
 $command | Out-File -FilePath "$WorkingDirectory\IPS\DATA_UNITS\IPS_win\command.txt" -Force
 
@@ -544,7 +544,8 @@ if (-NOT(Test-Path $ipsInstallIni)) {
 
 # IMPORTANT: because the installer only has access to /wait via cmd.exe we can't use Start-Process to run the installer directly via PowerShell
 try {
-    & cmd.exe /c $command
+    # & cmd.exe /c $command
+    Start-Process -FilePath cmd.exe -ArgumentList $cmdArgs -Wait -NoNewWindow
 } catch {
     $exception = $_.Exception
     Write-Error "Failed to start installer:"

--- a/powershell/Scripts/UserDataScripts/OnrBods.ps1
+++ b/powershell/Scripts/UserDataScripts/OnrBods.ps1
@@ -527,7 +527,9 @@ $ipsInstallParams = @{
     ArgumentList = '/wait -r D:\Software\IPS\DATA_UNITS\IPS_win\ips_install.ini'
     Verb = 'RunAs'
     Wait = $true
-    Verb = "RunAs"
+    RedirectStandardOutput = "$WorkingDirectory\IPS\DATA_UNITS\IPS_win\ips_out_install.log"
+    RedirectStandardError = "$WorkingDirectory\IPS\DATA_UNITS\IPS_win\ips_err_install.log"
+    NoNewWindow = $true
 }
 
 # debugging
@@ -547,10 +549,11 @@ if (-NOT(Test-Path "$WorkingDirectory\IPS\DATA_UNITS\IPS_win\ips_install.rsp")) 
 
 try {
     Write-Host "IPS install started"
-    Start-Process @ipsInstallParams -ErrorAction Stop -ErrorVariable StartProcessError
+    Start-Process @ipsInstallParams -ErrorAction Stop
 } catch {
-    Write-Error "Failed to start process: $StartProcessError"
-    Write-Host  "Failed to start process: $StartProcessError"
+    Write-Output "Output, Failed to start process $_"
+    Write-Error "Error, Failed to start process: $_"
+    Write-Host  "Host, Failed to start process: $_"
     exit 1
 }
 # & "$WorkingDirectory\IPS\DATA_UNITS\IPS_win\setup.exe" -r "$WorkingDirectory\IPS\DATA_UNITS\IPS_win\ips_install.rsp" | Out-Null

--- a/powershell/Scripts/UserDataScripts/OnrBods.ps1
+++ b/powershell/Scripts/UserDataScripts/OnrBods.ps1
@@ -617,8 +617,8 @@ $dataServicesInstallParams = @{
     Wait = $true
     Verb = "RunAs"
     WindowStyle = "Hidden"
-    RedirectStandardOutput = "$WorkingDirectory\std_out_ds_install.log"
-    RedirectStandardError = "$WorkingDirectory\std_err_ds_install.log"
+    # RedirectStandardOutput = "$WorkingDirectory\std_out_ds_install.log"
+    # RedirectStandardError = "$WorkingDirectory\std_err_ds_install.log"
 }
 
 # DISABLE FOR TESTING

--- a/powershell/Scripts/UserDataScripts/OnrBods.ps1
+++ b/powershell/Scripts/UserDataScripts/OnrBods.ps1
@@ -545,7 +545,6 @@ if (-NOT(Test-Path $ipsInstallIni)) {
 # IMPORTANT: because the installer only has access to /wait via cmd.exe we can't use Start-Process to run the installer directly via PowerShell
 try {
     & cmd.exe /c $command
-    # Start-Process -FilePath "cmd.exe" -ArgumentList $cmdArgs -Wait -ErrorAction Stop
 } catch {
     $exception = $_.Exception
     Write-Error "Failed to start installer:"

--- a/powershell/Scripts/UserDataScripts/OnrBods.ps1
+++ b/powershell/Scripts/UserDataScripts/OnrBods.ps1
@@ -509,8 +509,17 @@ $OracleClientInstallParams = @{
 
 Start-Process @OracleClientInstallParams
 
-# Copy tnsnames.ora file to correct location
-Copy-Item -Path "$ConfigurationManagementRepo\powershell\Configs\$($Config.tnsorafile)" -Destination "$($Config.ORACLE_HOME)\network\admin\tnsnames.ora" -Force
+# Copy tnsnames.ora file to correct location, may not be in the usual place, check both
+if (Test-Path "$ConfigurationManagementRepo\powershell\Configs\$($Config.tnsorafile)") {
+    Copy-Item -Path "$ConfigurationManagementRepo\powershell\Configs\$($Config.tnsorafile)" -Destination "$($Config.ORACLE_HOME)\network\admin\tnsnames.ora" -Force
+    Write-Output "Copied tnsnames.ora file to $($Config.ORACLE_HOME)\network\admin\tnsnames.ora"
+} elseif (Test-Path "C:\Users\Administrator\AppData\Local\Temp\modernisation-platform-configuration-management\powershell\Configs\$($Config.tnsorafile)") {
+    Copy-Item -Path "C:\Users\Administrator\AppData\Local\Temp\modernisation-platform-configuration-management\powershell\Configs\$($Config.tnsorafile)" -Destination "$($Config.ORACLE_HOME)\network\admin\tnsnames.ora" -Force
+    Write-Output "Copied tnsnames.ora file to $($Config.ORACLE_HOME)\network\admin\tnsnames.ora"
+} else {
+    Write-Error "Could not find tnsnames.ora file in $ConfigurationManagementRepo\powershell\Configs\$($Config.tnsorafile)"
+    Write-Error "Could not find tnsnames.ora file in C:\Users\Administrator\AppData\Local\Temp\modernisation-platform-configuration-management\powershell\Configs\$($Config.tnsorafile)"
+}
 
 # Install Oracle configuration tools
 $oracleConfigToolsParams = @{

--- a/powershell/Scripts/UserDataScripts/OnrBods.ps1
+++ b/powershell/Scripts/UserDataScripts/OnrBods.ps1
@@ -562,7 +562,7 @@ New-Item -Type File -Path $logFile -Force | Out-Null
 
 try {
     "Starting IPS installer at $(Get-Date)" | Out-File -FilePath $logFile -Append
-    $installProcess = Start-Process -FilePath "D:\Software\IPS\DATA_UNITS\IPS_win\setup.exe" -ArgumentList '-r D:\Software\IPS\DATA_UNITS\IPS_win\ips_install.ini' -Wait -NoNewWindow -Credential $serviceUserPSCredential -Verbose -PassThru
+    $installProcess = Start-Process -FilePath "D:\Software\IPS\DATA_UNITS\IPS_win\setup.exe" -ArgumentList '-r D:\Software\IPS\DATA_UNITS\IPS_win\ips_install.ini' -Wait -NoNewWindow -Verb runas -Verbose -PassThru
     $installProcessId = $installProcess.Id
     "Process is $installProcessId at $(Get-Date)" | Out-File -FilePath $logFile -Append
     # get all process IDs to monitor

--- a/powershell/Scripts/UserDataScripts/OnrBods.ps1
+++ b/powershell/Scripts/UserDataScripts/OnrBods.ps1
@@ -493,7 +493,6 @@ $OracleClientInstallParams = @{
     ArgumentList     = "-silent -noconfig -nowait -responseFile $WorkingDirectory\OracleClient\client\client_install.rsp"
     Wait             = $true
     NoNewWindow      = $true
-    Credential       = $serviceUserCredentialObject
 }
 
 Start-Process @OracleClientInstallParams
@@ -508,7 +507,6 @@ $oracleConfigToolsParams = @{
     ArgumentList     = "-executeConfigTools -silent -nowait -responseFile $WorkingDirectory\OracleClient\client\client_install.rsp"
     Wait             = $true
     NoNewWindow      = $true
-    Credential       = $serviceUserCredentialObject
 }
 
 Start-Process @oracleConfigToolsParams
@@ -703,7 +701,7 @@ New-Item -Type File -Path $logFile -Force | Out-Null
 
 try {
     "Starting IPS installer at $(Get-Date)" | Out-File -FilePath $logFile -Append
-    $process = Start-Process -FilePath "D:\Software\IPS\DATA_UNITS\IPS_win\setup.exe" -ArgumentList '/wait -r D:\Software\IPS\DATA_UNITS\IPS_win\ips_install.ini' -Wait -NoNewWindow -Credential $serviceUserCredentialObject -Verbose -PassThru
+    $process = Start-Process -FilePath "D:\Software\IPS\DATA_UNITS\IPS_win\setup.exe" -ArgumentList '/wait -r D:\Software\IPS\DATA_UNITS\IPS_win\ips_install.ini' -Wait -NoNewWindow -Verbose -PassThru
     $installProcessId = $process.Id
     "Initial process is $installProcessId at $(Get-Date)" | Out-File -FilePath $logFile -Append
     # get all process IDs to monitor
@@ -813,11 +811,10 @@ features=DataServicesJobServer,DataServicesAccessServer,DataServicesServer,DataS
 $dataServicesResponsePrimary | Out-File -FilePath "$WorkingDirectory\ds_install.ini" -Force -Encoding ascii
 
 $dataServicesInstallParams = @{
-    FilePath = "$WorkingDirectory\$($Config.DataServicesS3File)"
+    FilePath     = "$WorkingDirectory\$($Config.DataServicesS3File)"
     ArgumentList = "-q","-r","$WorkingDirectory\ds_install.ini"
-    Wait = $true
-    NoNewWindow = $true
-    Credential = $serviceUserCredentialObject
+    Wait         = $true
+    NoNewWindow  = $true
 }
 
 # Install Data Services

--- a/powershell/Scripts/UserDataScripts/OnrBods.ps1
+++ b/powershell/Scripts/UserDataScripts/OnrBods.ps1
@@ -539,7 +539,7 @@ if (-NOT(Test-Path $ipsInstallParams.FilePath)) {
     exit 1
 }
 
-if (-NOT(Test-Path "$WorkingDirectory\IPS\DATA_UNITS\IPS_win\ips_install.rsp") {
+if (-NOT(Test-Path "$WorkingDirectory\IPS\DATA_UNITS\IPS_win\ips_install.rsp")) {
     Write-Host "IPS response file not found at $WorkingDirectory\IPS\DATA_UNITS\IPS_win\ips_install.rsp"
     exit 1
 }

--- a/powershell/Scripts/UserDataScripts/OnrBods.ps1
+++ b/powershell/Scripts/UserDataScripts/OnrBods.ps1
@@ -21,7 +21,7 @@ $GlobalConfig = @{
         "sysDbName"       = "T2BOSYS"
         "audDbName"       = "T2BOAUD"
         "tnsorafile"      = "tnsnames_T2_BODS.ora"
-        "cmsMainNode"     = "t2-onr-bods-1"
+        "cmsMainNode"     = "t2-tst-bods-asg" #TODO: change this BACK
         "cmsExtendedNode" = "t2-onr-bods-2"
         "serviceUser"     = "svc_t2_onr_bods"
         "serviceUserPath" = "OU=Service,OU=Users,OU=NOMS RBAC,DC=AZURE,DC=NOMS,DC=ROOT"

--- a/powershell/Scripts/UserDataScripts/OnrBods.ps1
+++ b/powershell/Scripts/UserDataScripts/OnrBods.ps1
@@ -562,7 +562,7 @@ New-Item -Type File -Path $logFile -Force | Out-Null
 
 try {
     "Starting IPS installer at $(Get-Date)" | Out-File -FilePath $logFile -Append
-    $installProcess = Start-Process -FilePath "D:\Software\IPS\DATA_UNITS\IPS_win\setup.exe" -ArgumentList '-r D:\Software\IPS\DATA_UNITS\IPS_win\ips_install.ini' -Wait -NoNewWindow -Verb runas -Verbose -PassThru
+    $installProcess = Start-Process -FilePath "D:\Software\IPS\DATA_UNITS\IPS_win\setup.exe" -ArgumentList '-r D:\Software\IPS\DATA_UNITS\IPS_win\ips_install.ini' -Wait -Verb runas -Verbose -PassThru
     $installProcessId = $installProcess.Id
     "Process is $installProcessId at $(Get-Date)" | Out-File -FilePath $logFile -Append
     # get all process IDs to monitor

--- a/powershell/Scripts/UserDataScripts/OnrBods.ps1
+++ b/powershell/Scripts/UserDataScripts/OnrBods.ps1
@@ -523,8 +523,14 @@ if ($instanceName -eq $($Config.cmsMainNode)) {
 Clear-PendingFileRenameOperations
 
 $setupExe = "$WorkingDirectory\IPS\DATA_UNITS\IPS_win\setup.exe"
-$installArgs = '-r "' + $ipsInstallIni + '"'
-$cmdArgs = '/c start "" /wait "' + $setupExe + '" ' + $installArgs
+
+# Build the command to pass to cmd.exe
+$command = 'start "" /wait "' + $setupExe + '" -r "' + $ipsInstallIni + '"'
+
+# Build the ArgumentList as an array of strings
+# $cmdArgs = @('/c', $command)
+
+$command | Out-File -FilePath "$WorkingDirectory\IPS\DATA_UNITS\IPS_win\command.txt" -Force
 
 if (-NOT(Test-Path $setupExe)) {
     Write-Host "IPS setup.exe not found at $($setupExe)"
@@ -538,7 +544,8 @@ if (-NOT(Test-Path $ipsInstallIni)) {
 
 # IMPORTANT: because the installer only has access to /wait via cmd.exe we can't use Start-Process to run the installer directly via PowerShell
 try {
-    Start-Process -FilePath "cmd.exe" -ArgumentList $cmdArgs -Wait -ErrorAction Stop
+    & cmd.exe /c $command
+    # Start-Process -FilePath "cmd.exe" -ArgumentList $cmdArgs -Wait -ErrorAction Stop
 } catch {
     $exception = $_.Exception
     Write-Error "Failed to start installer:"

--- a/powershell/Scripts/UserDataScripts/OnrBods.ps1
+++ b/powershell/Scripts/UserDataScripts/OnrBods.ps1
@@ -534,8 +534,12 @@ $ipsInstallParams | Out-File -FilePath "$WorkingDirectory\IPS\DATA_UNITS\IPS_win
 
 Clear-PendingFileRenameOperations
 
-# DISABLE FOR TESTING
-Start-Process @ipsInstallParams
+if (-NOT(Test-Path $ipsInstallParams.FilePath)) {
+    Write-Output "IPS setup.exe not found at $($ipsInstallParams.FilePath)"
+    exit 1
+}
+
+Start-Process @ipsInstallParams -ErrorAction Stop
 
 # }}} end install IPS
 
@@ -611,7 +615,8 @@ $dataServicesInstallParams = @{
     WorkingDirectory = $WorkingDirectory
     ArgumentList = '-q -r D:\Software\ds_install.ini'
     Wait = $true
-    NoNewWindow = $true
+    # NoNewWindow = $true
+    Verb = "Open"
 }
 
 # DISABLE FOR TESTING

--- a/powershell/Scripts/UserDataScripts/OnrBods.ps1
+++ b/powershell/Scripts/UserDataScripts/OnrBods.ps1
@@ -568,7 +568,7 @@ try {
     # get all process IDs to monitor
     $allProcessIds = @($installProcessId)
     do {
-        Start-Sleep -Seconds 5
+
         # Refresh the list of child process IDs
         $allProcessIds = @($installProcessId) + (Get-ChildProcessIds -ParentId $installProcessId)
 
@@ -581,6 +581,8 @@ try {
 
         # Check if the parent process is still running
         $parentStillRunning = Get-Process -Id $installProcessId -ErrorAction SilentlyContinue
+
+        Start-Sleep -Seconds 1
 
     } while ($runningProcesses -and $parentStillRunning)
     "All monitored processes have completed at $(Get-Date)" | Out-File -FilePath $logFile -Append

--- a/powershell/Scripts/UserDataScripts/OnrBods.ps1
+++ b/powershell/Scripts/UserDataScripts/OnrBods.ps1
@@ -555,7 +555,7 @@ try {
     }
 }
 
-start /wait "$WorkingDirectory\IPS\DATA_UNITS\IPS_win\setup.exe" -r "$WorkingDirectory\IPS\DATA_UNITS\IPS_win\ips_install.ini"
+# start /wait "$WorkingDirectory\IPS\DATA_UNITS\IPS_win\setup.exe" -r "$WorkingDirectory\IPS\DATA_UNITS\IPS_win\ips_install.ini"
 
 # TODO: supply password values to argument list OR remove the reponse file after it's been used
 # }}} end install IPS

--- a/powershell/Scripts/UserDataScripts/OnrBods.ps1
+++ b/powershell/Scripts/UserDataScripts/OnrBods.ps1
@@ -21,7 +21,7 @@ $GlobalConfig = @{
         "sysDbName"       = "T2BOSYS"
         "audDbName"       = "T2BOAUD"
         "tnsorafile"      = "tnsnames_T2_BODS.ora"
-        "cmsMainNode"     = "t2-tst-bods-1"
+        "cmsMainNode"     = "t2-onr-bods-1"
         "cmsExtendedNode" = "t2-onr-bods-2"
         "serviceUser"     = "svc_nart"
         "serviceUserPath" = "OU=Service,OU=Users,OU=NOMS RBAC,DC=AZURE,DC=NOMS,DC=ROOT"


### PR DESCRIPTION
Silently installs Oracle, IPS and Data Services 

- adds instance to the relevant Domain
- moves the instance into the Nart OU on the domain controller & updates group policy 
- configures Oracle 19c client
- adds tnsnames.ora file depending on environment
- adds Oracle/client/bin to env so subsequent installer db connection checks will work
- tests database connection parameters BEFORE the installer runs
- creates a silent installer file for IPS
- creates a silent installer file for Data Services
- password secrets are passed directly to the installer Start-Process so they don't land in the response file(s)
- add JDBC copy to relevant folders post install