### PR TITLE
ncr: add nart users to binstall group

### DIFF
--- a/ansible/roles/users-and-groups/vars/hmpps-regular-groups.yml
+++ b/ansible/roles/users-and-groups/vars/hmpps-regular-groups.yml
@@ -8,7 +8,7 @@ regular_gids:
   studio-webops: 2001
   syscon-nomis: 2051
   csr-application-support: 2081
-  nart: 2101  # national-applications-reporting-team
+  nart: 2101 # national-applications-reporting-team
 
 # define any additional groups that team members should be added to
 regular_groups_additional_groups:

--- a/ansible/roles/users-and-groups/vars/hmpps-regular-groups.yml
+++ b/ansible/roles/users-and-groups/vars/hmpps-regular-groups.yml
@@ -22,6 +22,7 @@ regular_groups_additional_groups:
     - tibco
   nart:
     - nart
+    - binstall
     - wheel
 
 # define members of each group


### PR DESCRIPTION
Add nart users to binstall group so they can write files to certain directories on the BIP EC2s. For Vamshi.