### PR TITLE
TM-500: endpoint monitoring improvements

### DIFF
--- a/ansible/group_vars/environment_name_hmpps_oem_preproduction.yml
+++ b/ansible/group_vars/environment_name_hmpps_oem_preproduction.yml
@@ -121,5 +121,5 @@ collectd_endpoint_monitoring:
     url: https://hpa-preprod.service.hmpps.dsd.io/
     time_ranges: "1.0700-1.1800,2.0700-2.1800,3.0700-3.1800,4.0700-4.1800,5.0700-5.1800"
   - metric_dimension: rdgateway1.preproduction.hmpps-domain.service.justice.gov.uk
-    url:  https://rdgateway1.preproduction.hmpps-domain.service.justice.gov.uk/
+    url: https://rdgateway1.preproduction.hmpps-domain.service.justice.gov.uk/
     time_ranges: "1.0700-1.1800,2.0700-2.1800,3.0700-3.1800,4.0700-4.1800,5.0700-5.1800"

--- a/ansible/group_vars/environment_name_hmpps_oem_preproduction.yml
+++ b/ansible/group_vars/environment_name_hmpps_oem_preproduction.yml
@@ -76,27 +76,50 @@ emctl_agent: /u01/app/oracle/product/oem-agent/agent_inst/bin/emctl
 collectd_endpoint_monitoring:
   - metric_dimension: c.pp-nomis.az.justice.gov.uk
     url: https://c.pp-nomis.az.justice.gov.uk/forms/frmservlet?config=tag
+    time_ranges: "1.0700-1.1800,2.0700-2.1800,3.0700-3.1800,4.0700-4.1800,5.0700-5.1800"
+  - metric_dimension: reporting.pp-nomis.az.justice.gov.uk
+    url: https://reporting.pp-nomis.az.justice.gov.uk/keepalive.htm
+    time_ranges: "1.0700-1.1800,2.0700-2.1800,3.0700-3.1800,4.0700-4.1800,5.0700-5.1800"
   - metric_dimension: c.lsast-nomis.az.justice.gov.uk
     url: https://c.lsast-nomis.az.justice.gov.uk/forms/frmservlet?config=tag
+    time_ranges: "1.0700-1.1800,2.0700-2.1800,3.0700-3.1800,4.0700-4.1800,5.0700-5.1800"
   - metric_dimension: pp-oasys.az.justice.gov.uk
     url: https://pp-oasys.az.justice.gov.uk/eor/f?p=100
+    time_ranges: "1.0700-1.1800,2.0700-2.1800,3.0700-3.1800,4.0700-4.1800,5.0700-5.1800"
   - metric_dimension: onr.pp-oasys.az.justice.gov.uk
     url: https://onr.pp-oasys.az.justice.gov.uk/InfoViewApp
+    time_ranges: "1.0700-1.1800,2.0700-2.1800,3.0700-3.1800,4.0700-4.1800,5.0700-5.1800"
   - metric_dimension: r1.pp.csr.service.justice.gov.uk
     url: http://r1.pp.csr.service.justice.gov.uk:7770/isps/index.html?2057
+    time_ranges: "1.0700-1.1800,2.0700-2.1800,3.0700-3.1800,4.0700-4.1800,5.0700-5.1800"
   - metric_dimension: r2.pp.csr.service.justice.gov.uk
     url: http://r2.pp.csr.service.justice.gov.uk:7771/isps/index.html?2057
+    time_ranges: "1.0700-1.1800,2.0700-2.1800,3.0700-3.1800,4.0700-4.1800,5.0700-5.1800"
   - metric_dimension: r3.pp.csr.service.justice.gov.uk
     url: http://r3.pp.csr.service.justice.gov.uk:7770/isps/index.html?2057
+    time_ranges: "1.0700-1.1800,2.0700-2.1800,3.0700-3.1800,4.0700-4.1800,5.0700-5.1800"
   - metric_dimension: r4.pp.csr.service.justice.gov.uk
     url: http://r4.pp.csr.service.justice.gov.uk:7771/isps/index.html?2057
+    time_ranges: "1.0700-1.1800,2.0700-2.1800,3.0700-3.1800,4.0700-4.1800,5.0700-5.1800"
   - metric_dimension: r5.pp.csr.service.justice.gov.uk
     url: http://r5.pp.csr.service.justice.gov.uk:7770/isps/index.html?2057
+    time_ranges: "1.0700-1.1800,2.0700-2.1800,3.0700-3.1800,4.0700-4.1800,5.0700-5.1800"
   - metric_dimension: r6.pp.csr.service.justice.gov.uk
     url: http://r6.pp.csr.service.justice.gov.uk:7771/isps/index.html?2057
+    time_ranges: "1.0700-1.1800,2.0700-2.1800,3.0700-3.1800,4.0700-4.1800,5.0700-5.1800"
   - metric_dimension: traina.csr.service.justice.gov.uk
     url: http://traina.csr.service.justice.gov.uk/isps/index.html?2057
+    time_ranges: "1.0700-1.1800,2.0700-2.1800,3.0700-3.1800,4.0700-4.1800,5.0700-5.1800"
+  - metric_dimension: cafmtx.pp.planetfm.service.justice.gov.uk
+    url: https://cafmtx.pp.planetfm.service.justice.gov.uk/RDWeb
+    time_ranges: "1.0700-1.1800,2.0700-2.1800,3.0700-3.1800,4.0700-4.1800,5.0700-5.1800"
   - metric_dimension: cafmwebx.pp.planetfm.service.justice.gov.uk
     url: https://cafmwebx.pp.planetfm.service.justice.gov.uk/PlanetPortal
+    follow_redirect: 0
+    time_ranges: "1.0700-1.1800,2.0700-2.1800,3.0700-3.1800,4.0700-4.1800,5.0700-5.1800"
   - metric_dimension: hpa-preprod.service.hmpps.dsd.io
     url: https://hpa-preprod.service.hmpps.dsd.io/
+    time_ranges: "1.0700-1.1800,2.0700-2.1800,3.0700-3.1800,4.0700-4.1800,5.0700-5.1800"
+  - metric_dimension: rdgateway1.preproduction.hmpps-domain.service.justice.gov.uk
+    url:  https://rdgateway1.preproduction.hmpps-domain.service.justice.gov.uk/
+    time_ranges: "1.0700-1.1800,2.0700-2.1800,3.0700-3.1800,4.0700-4.1800,5.0700-5.1800"

--- a/ansible/group_vars/environment_name_hmpps_oem_production.yml
+++ b/ansible/group_vars/environment_name_hmpps_oem_production.yml
@@ -95,7 +95,7 @@ collectd_endpoint_monitoring:
   - metric_dimension: c.nomis.az.justice.gov.uk
     url: https://c.nomis.az.justice.gov.uk/forms/frmservlet?config=tag
   - metric_dimension: reporting.nomis.az.justice.gov.uk
-    url: https://reporting.nomis.az.justice.gov.uk/BOE/BI
+    url: https://reporting.nomis.az.justice.gov.uk/keepalive.htm
   - metric_dimension: oasys.az.justice.gov.uk
     url: https://oasys.az.justice.gov.uk/eor/f?p=100
   - metric_dimension: training.oasys.az.justice.gov.uk
@@ -118,13 +118,20 @@ collectd_endpoint_monitoring:
     url: http://r5.csr.service.justice.gov.uk:7770/isps/index.html?2057
   - metric_dimension: r6.csr.service.justice.gov.uk
     url: http://r6.csr.service.justice.gov.uk:7771/isps/index.html?2057
+  - metric_dimension: cafmtx.planetfm.service.justice.gov.uk
+    url: https://cafmtx.planetfm.service.justice.gov.uk/RDWeb
   - metric_dimension: cafmwebx2.az.justice.gov.uk
     url: https://cafmwebx2.az.justice.gov.uk/PlanetPortal
+    follow_redirect: 0
   - metric_dimension: cafmtrainweb.az.justice.gov.uk
     url: https://cafmtrainweb.az.justice.gov.uk/PlanetPortal
+    follow_redirect: 0
+    time_ranges: "1.0700-1.1800,2.0700-2.1800,3.0700-3.1800,4.0700-4.1800,5.0700-5.1800"
   - metric_dimension: www.offloc.service.justice.gov.uk
     url: https://www.offloc.service.justice.gov.uk/health
   - metric_dimension: hpa.service.hmpps.dsd.io
     url: https://hpa.service.hmpps.dsd.io/
   - metric_dimension: hmpps-az-gw1.justice.gov.uk
     url: https://hmpps-az-gw1.justice.gov.uk/RDWeb
+  - metric_dimension: rdgateway1.hmpps-domain.service.justice.gov.uk
+    url:  https://rdgateway1.hmpps-domain.service.justice.gov.uk/

--- a/ansible/group_vars/environment_name_hmpps_oem_production.yml
+++ b/ansible/group_vars/environment_name_hmpps_oem_production.yml
@@ -134,4 +134,4 @@ collectd_endpoint_monitoring:
   - metric_dimension: hmpps-az-gw1.justice.gov.uk
     url: https://hmpps-az-gw1.justice.gov.uk/RDWeb
   - metric_dimension: rdgateway1.hmpps-domain.service.justice.gov.uk
-    url:  https://rdgateway1.hmpps-domain.service.justice.gov.uk/
+    url: https://rdgateway1.hmpps-domain.service.justice.gov.uk/

--- a/ansible/group_vars/environment_name_hmpps_oem_test.yml
+++ b/ansible/group_vars/environment_name_hmpps_oem_test.yml
@@ -81,9 +81,15 @@ collectd_endpoint_monitoring:
     url: https://c-t3.test.nomis.service.justice.gov.uk/forms/frmservlet?config=tag
   - metric_dimension: t1-int.oasys.service.justice.gov.uk
     url: https://t1-int.oasys.service.justice.gov.uk/
+    time_ranges: "1.0700-1.1800,2.0700-2.1800,3.0700-3.1800,4.0700-4.1800,5.0700-5.1800"
   - metric_dimension: t2-int.oasys.service.justice.gov.uk
     url: https://t2-int.oasys.service.justice.gov.uk/
+    time_ranges: "1.0700-1.1800,2.0700-2.1800,3.0700-3.1800,4.0700-4.1800,5.0700-5.1800"
   - metric_dimension: stage.offloc.service.justice.gov.uk
     url: https://stage.offloc.service.justice.gov.uk/health
+    time_ranges: "1.0700-1.1800,2.0700-2.1800,3.0700-3.1800,4.0700-4.1800,5.0700-5.1800"
   - metric_dimension: hmppgw1.justice.gov.uk
     url: https://hmppgw1.justice.gov.uk/RDWeb
+  - metric_dimension: rdgateway1.test.hmpps-domain.service.justice.gov.uk
+    url:  https://rdgateway1.test.hmpps-domain.service.justice.gov.uk/
+    time_ranges: "1.0700-1.1800,2.0700-2.1800,3.0700-3.1800,4.0700-4.1800,5.0700-5.1800"

--- a/ansible/group_vars/environment_name_hmpps_oem_test.yml
+++ b/ansible/group_vars/environment_name_hmpps_oem_test.yml
@@ -91,5 +91,5 @@ collectd_endpoint_monitoring:
   - metric_dimension: hmppgw1.justice.gov.uk
     url: https://hmppgw1.justice.gov.uk/RDWeb
   - metric_dimension: rdgateway1.test.hmpps-domain.service.justice.gov.uk
-    url:  https://rdgateway1.test.hmpps-domain.service.justice.gov.uk/
+    url: https://rdgateway1.test.hmpps-domain.service.justice.gov.uk/
     time_ranges: "1.0700-1.1800,2.0700-2.1800,3.0700-3.1800,4.0700-4.1800,5.0700-5.1800"

--- a/ansible/roles/collectd-endpoint-monitoring/templates/collectd_endpoint_monitoring.sh.j2
+++ b/ansible/roles/collectd-endpoint-monitoring/templates/collectd_endpoint_monitoring.sh.j2
@@ -29,7 +29,7 @@ check_within_timeranges() {
   local timeranges
   local times
   now=$1
-  timeranges=$2  
+  timeranges=$2
   for timerange in ${timeranges//,/ }; do
     times=(${timerange/-/ })
     if [[ ($now == "${times[0]}" || $now > "${times[0]}") && $now < "${times[1]}" ]]; then
@@ -61,7 +61,7 @@ check_endpoint() {
     optional_curl_args="-L"
   fi
   if ! output=$(curl -sSv -m "$timeout_secs" -o /dev/null -w "http_code=%{http_code}" $optional_curl_args "$url" 2>&1); then
-    grep -v "^\*" <<<"$output" | grep -v ^http_code= | grep -v "^>" | grep -v "^<" | grep -v "^{" | grep -v "^}" >&2
+    grep -v "^\*" <<<"$output" | grep -v ^http_code= | grep -v CApath | grep -v "^>" | grep -v "^<" | grep -v "^{" | grep -v "^}" >&2
     return 1
   fi
   http_code=$(grep "^http_code=" <<< "$output" | cut -d= -f2)
@@ -76,7 +76,7 @@ check_endpoint() {
     fi
   fi
   if [[ $url =~ https: ]]; then
-    expiry=$(grep -F "*  expire date:" <<< "$output" | cut -d: -f2-)
+    expiry=$(grep -F "*  expire date:" <<< "$output" | head -1 | cut -d: -f2-)
     if [[ -z $expiry ]]; then
       echo "could not find expiry date in curl output" >&2
       return 1
@@ -122,6 +122,16 @@ while true; do
     fi
     output=$(check_endpoint "${args[0]}" "${args[1]}" "${args[2]}" 2>&1)
     exitcode=$?
+    if [[ $exitcode -ne 0 ]]; then
+      if [[ $LOGGER_INTERVAL_FOR_ERRORS -eq 0 ]]; then
+        echo "${args[3]}: $output [retrying once]"
+      elif [[ $((now_epoch_secs - last_error_log_timestamp[i])) -gt $LOGGER_INTERVAL_FOR_ERRORS ]]; then
+        echo "${args[3]}: $output [retrying once]" | logger -p local3.info -t collectd_endpoint_monitoring
+      fi
+      # retry immediately to avoid alarming on transient errors
+      output=$(check_endpoint "${args[0]}" "${args[1]}" "${args[2]}" 2>&1)
+      exitcode=$?
+    fi
     days_to_expiry=$(grep "^days_to_expiry=" <<< "$output" | cut -d= -f2)
     echo "PUTVAL $HOSTNAME/endpoint_status/exitcode-${args[3]} interval=$INTERVAL N:$exitcode"
     if [[ -n $days_to_expiry ]]; then
@@ -134,9 +144,19 @@ while true; do
     if [[ $exitcode -ne 0 ]]; then
       if [[ $LOGGER_INTERVAL_FOR_ERRORS -eq 0 ]]; then
         echo "${args[3]}: $output"
+        last_error_log_timestamp[i]="$now_epoch_secs"
       elif [[ $((now_epoch_secs - last_error_log_timestamp[i])) -gt $LOGGER_INTERVAL_FOR_ERRORS ]]; then
         echo "${args[3]}: $output" | logger -p local3.info -t collectd_endpoint_monitoring
         last_error_log_timestamp[i]="$now_epoch_secs"
+      fi
+    else
+      if [[ $((last_error_log_timestamp[i])) -ne 0 ]]; then
+        if [[ $LOGGER_INTERVAL_FOR_ERRORS -eq 0 ]]; then
+          echo "${args[3]}: endpoint now ok"
+        else
+          echo "${args[3]}: endpoint now ok" | logger -p local3.info -t collectd_endpoint_monitoring
+        fi
+        last_error_log_timestamp[i]=0
       fi
     fi
   done


### PR DESCRIPTION
Minor improvements, already applied:
- only check preprod URLs during working hours
- added RDWeb endpoints and fixed reporting endpoint
- don't follow redirect on PlanetFM as this leads to an error
- check cert expiry on the first certificate (if redirects followed)
- immediately retry on a curl error to avoid logging transient errors 
- log when an endpoint recovers