### PR TITLE
T2 ONR BODS redundancy and shared drive

### DIFF
--- a/powershell/Scripts/UserDataScripts/OnrBods.ps1
+++ b/powershell/Scripts/UserDataScripts/OnrBods.ps1
@@ -25,7 +25,7 @@ $GlobalConfig = @{
         # "cmsPrimaryNode"     = "t2-tst-bods-asg" # Use this value when testing
         "cmsSecondaryNode"       = "t2-onr-bods-2"
         # "cmsSecondaryNode" = "t2-tst-bods-asg" # Use this value when testing
-        "cmsPrimaryNodeHostname" = "EC2AMAZ-JM52FS3" # ADD MANUALLY AFTER cmsPrimaryNode DEPLOYED
+        "cmsPrimaryNodeHostname" = "EC2AMAZ-7VGMSLH" # ADDED MANUALLY AFTER cmsPrimaryNode DEPLOYED
         "serviceUser"            = "svc_nart"
         "serviceUserPath"        = "OU=Service,OU=Users,OU=NOMS RBAC,DC=AZURE,DC=NOMS,DC=ROOT"
         "nartComputersOU"        = "OU=Nart,OU=MODERNISATION_PLATFORM_SERVERS,DC=AZURE,DC=NOMS,DC=ROOT"
@@ -943,3 +943,4 @@ Install-IPS -Config $Config
 Install-DataServices -Config $Config
 Set-LoginText -Config $Config
 New-SharedDriveShortcut -Config $Config
+# }}}

--- a/powershell/Scripts/UserDataScripts/OnrBods.ps1
+++ b/powershell/Scripts/UserDataScripts/OnrBods.ps1
@@ -31,6 +31,7 @@ $GlobalConfig = @{
         "nartComputersOU"        = "OU=Nart,OU=MODERNISATION_PLATFORM_SERVERS,DC=AZURE,DC=NOMS,DC=ROOT"
         "serviceUserDescription" = "Onr BODS service user for AWS in AZURE domain"
         "domain"                 = "AZURE"
+        "sharedDrive"            = "amznfsx7aojksot.azure.noms.root"
     }
     "oasys-national-reporting-preproduction" = @{
         "sysDbName"              = "PPBOSYS"
@@ -44,6 +45,7 @@ $GlobalConfig = @{
         "nartComputersOU"        = "OU=Nart,OU=MODERNISATION_PLATFORM_SERVERS,DC=AZURE,DC=HMPP,DC=ROOT"
         "serviceUserDescription" = "Onr BODS service user for AWS in HMPP domain"
         "domain"                 = "HMPP"
+        "sharedDrive"            = ""
     }
     "oasys-national-reporting-production"    = @{
         "domain" = "HMPP"
@@ -284,6 +286,22 @@ function New-TnsOraFile {
 
     Copy-Item -Path $tnsOraFilePath -Destination $tnsOraFileDestination -Force
 
+}
+
+function New-SharedDrive {
+    param (
+        [Parameter(Mandatory)]
+        [hashtable]$Config
+    )
+
+    # Check if shared drive is already mounted
+    if (Test-Path "G:\") {
+        Write-Host "Shared drive already mounted at G:\"
+        return
+    } else {
+        Write-Host "Shared drive not mounted at G:\ - mounting now"
+        New-PSDrive -Name "G" -PSProvider "FileSystem" -Root "\\$($Config.sharedDrive)\share" -Persist -Scope Global
+    }   
 }
 
 function Install-Oracle19cClient {
@@ -897,3 +915,4 @@ Test-DbCredentials -Config $Config
 Install-IPS -Config $Config
 Install-DataServices -Config $Config
 Set-LoginText -Config $Config
+New-SharedDrive -Config $Config


### PR DESCRIPTION
- add config values
- add cmsPrimaryNodeHostname after deployment
- add shared drive address to t2 config
- add function to create a shortcut to the shared drive

Deployment of ONR Bods is now documented [here in Confluence](https://dsdmoj.atlassian.net/wiki/spaces/DSTT/pages/5132419101/ONR+BODS+Infrastructure+Deployment#4.-Automated-Deployment)