### PR TITLE
Update combo_patch and version to 19.25

### DIFF
--- a/ansible/group_vars/environment_name_delius_core_development_dev_delius_primarydb.yml
+++ b/ansible/group_vars/environment_name_delius_core_development_dev_delius_primarydb.yml
@@ -78,12 +78,3 @@ required_patches:
     grid_patch: false
     database_patch: true
     datapatch_required: true
-  p36252161:
-    patch_files:
-      - target_version: "19.22"
-        filename: p36252161_1922000OCWRU_Linux-x86-64.zip
-    description: UNSUPPORTED CONFIGURATION DETECTED FOR REAL-TIME SCHEDULING REQUIREMENTS.
-    grid_patch: true
-    database_patch: false
-    datapatch_required: false
-    install_with_opatchauto: true

--- a/ansible/group_vars/environment_name_delius_core_development_dev_delius_primarydb.yml
+++ b/ansible/group_vars/environment_name_delius_core_development_dev_delius_primarydb.yml
@@ -21,8 +21,8 @@ delius_users:
   worr_sro:
   nhodgkinson_rw:
 oracle_software:
-  version: "19.24"
-  combo_patch: p36522439_190000_Linux-x86-64.zip
+  version: "19.25"
+  combo_patch: p36866740_190000_Linux-x86-64.zip
 # OFFENDER_DELTA and DOMAIN_EVENT are dynamic tables cleared down by Integration Services.
 # Prevent changing these to unrepresentative statistics.
 database_locked_statistics:


### PR DESCRIPTION

update file environment_name_delius_core_development_dev_delius_primarydb.yml 

the variable oracle_software:

from :
  version: "19.24"
  combo_patch: p36522439_190000_Linux-x86-64.zip

to : 
  version: "19.25"
  combo_patch: p36866740_190000_Linux-x86-64.zip

You do NOT need to update the standby variable files, as we assume that they will be on the same version of Oracle as the primary.

