### PR TITLE
Restrict metric extensions to those on hosts

### DIFF
--- a/ansible/roles/oracle-oms-setup/files/metric_extensions_versions.sql
+++ b/ansible/roles/oracle-oms-setup/files/metric_extensions_versions.sql
@@ -1,3 +1,5 @@
+-- We only look at host metric extensions
 SELECT 'EXTENSION='||name||'|'||MAX(version)
 FROM   sysman.em_mext_versions_e
+WHERE  target_type = 'host'
 GROUP  BY name;


### PR DESCRIPTION
The coded metric extensions are all expected to have host targets.