### PR TITLE
TM-892: nomis: cleanup_frmweb timeout reduced to 2 hours

### DIFF
--- a/ansible/roles/nomis-weblogic/templates/10.3/home/oracle/admin/scripts/cleanup_frmweb.sh
+++ b/ansible/roles/nomis-weblogic/templates/10.3/home/oracle/admin/scripts/cleanup_frmweb.sh
@@ -9,9 +9,9 @@ fi
 PIDS=$(/usr/sbin/lsof | grep deleted | grep frmweb | gawk '{print $2}' | sort -ug | tr [:space:] " " | sed "s/ $//")
 if [[ -n $PIDS ]]; then
   echo "Checking frmweb processes with deleted lsof: ${PIDS// /,}"
-  PIDS2=$(ps -q ${PIDS// /,} -o %p, -o %u, -o %t, -o %c, -o %C | tr -d " " | egrep ",1[0-9]:[0-9]+:[0-9]+," | cut -d, -f1 | sort -ug | tr [:space:] " " | sed "s/ $//")
+  PIDS2=$(ps -q ${PIDS// /,} -o %p, -o %u, -o %t, -o %c, -o %C | tr -d " " | egrep ",1[0-9]:[0-9]+:[0-9]+,|0[2-9]:[0-9]+:[0-9]+," | cut -d, -f1 | sort -ug | tr [:space:] " " | sed "s/ $//")
   if [[ -n $PIDS2 ]]; then
-    echo "Killing frmweb processes with deleted lsof older than 10 hours: ${PIDS2// /,}"
+    echo "Killing frmweb processes with deleted lsof older than 2 hours: ${PIDS2// /,}"
     ps -q ${PIDS2// /,} ux
     kill -9 $PIDS2
   fi


### PR DESCRIPTION
As agreed in post-incident review, reduce timeout from 10 hours to 2 hours on all weblogic servers. Already applied + seems to be working fine.