### PR TITLE
DBA-838 - replace me$restore point metric extension

### DIFF
--- a/ansible/roles/oracle-oms-setup/files/metric_extensions/common/restore_point_age/collection/ME#24#RESTORE_POINT_AGE.xml
+++ b/ansible/roles/oracle-oms-setup/files/metric_extensions/common/restore_point_age/collection/ME#24#RESTORE_POINT_AGE.xml
@@ -1,9 +1,9 @@
-<TargetCollectionExt EXT_NAME="ME$RESTORE_POINT_AGE" EXT_VERSION="3" TARGET_TYPE="host"><CollectionItem NAME="ME$RESTORE_POINT_AGE" UPLOAD="YES">
+<TargetCollectionExt EXT_NAME="ME$RESTORE_POINT_AGE" EXT_VERSION="1" TARGET_TYPE="host"><CollectionItem NAME="ME$RESTORE_POINT_AGE" UPLOAD="YES">
 	<Schedule>
 		<IntervalSchedule INTERVAL="12" TIME_UNIT="Hr"/>
 	</Schedule>
 	<MetricColl NAME="ME$RESTORE_POINT_AGE">
-		<Condition COLUMN_NAME="max_restore_point_age" CRITICAL="21" WARNING="7" OPERATOR="GT" OCCURRENCES="1" MESSAGE="The value of %columnName% is %value%" MESSAGE_NLSID="EMAGENT_DEFAULT_MESSAGE" CLEAR_MESSAGE="Alert for %columnName% is cleared" CLEAR_MESSAGE_NLSID="EMAGENT_DEFAULT_NO_ROW_CLEAR_MESSAGE"/>
+		<Condition COLUMN_NAME="max_restore_point_age" CRITICAL="21" WARNING="7" OPERATOR="GT" OCCURRENCES="1" MESSAGE="The value of %columnName% for %keyValue% is %value%" MESSAGE_NLSID="EMAGENT_DEFAULT_MESSAGE_WITH_KEY" CLEAR_MESSAGE="Alert for %columnName% for %keyValue% is cleared" CLEAR_MESSAGE_NLSID="EMAGENT_DEFAULT_NO_ROW_CLEAR_MESSAGE_WITH_KEY"/>
 	</MetricColl>
 </CollectionItem>
 </TargetCollectionExt>

--- a/ansible/roles/oracle-oms-setup/files/metric_extensions/common/restore_point_age/mea.xml
+++ b/ansible/roles/oracle-oms-setup/files/metric_extensions/common/restore_point_age/mea.xml
@@ -1,5 +1,5 @@
 <MetricExtensionArchive name="MEAME$RESTORE_POINT_AGE">
-<MetricExtension name="ME$RESTORE_POINT_AGE" type="host" version="3" is_repos="FALSE" display_name="Restore Point Age" description="Maximum Restore Point Age" version_comment=" " metadata_digest="d3eda3a049551a2a0013d2946ea4f4f5" coll_digest="d4298bbf871432157b486ad49753ca73" attach_digest="420a1b78e41db13bce8a8b0a81534ad4">
+<MetricExtension name="ME$RESTORE_POINT_AGE" type="host" version="1" is_repos="FALSE" display_name="Restore Point Age" description="Maximum Restore Point Age" version_comment=" " metadata_digest="02aac4b9ec14d5789de98cb00ca5d25f" coll_digest="624a8453265a244c685da6beae5d9fb1" attach_digest="9bd71fba651612bc7582ae9fc699ca14">
 <scripts name="max_restore_point_age.sh">
 </scripts>
 </MetricExtension>

--- a/ansible/roles/oracle-oms-setup/files/metric_extensions/common/restore_point_age/mea.xml
+++ b/ansible/roles/oracle-oms-setup/files/metric_extensions/common/restore_point_age/mea.xml
@@ -1,5 +1,5 @@
 <MetricExtensionArchive name="MEAME$RESTORE_POINT_AGE">
-<MetricExtension name="ME$RESTORE_POINT_AGE" type="host" version="1" is_repos="FALSE" display_name="Restore Point Age" description="Maximum Restore Point Age" version_comment=" " metadata_digest="02aac4b9ec14d5789de98cb00ca5d25f" coll_digest="624a8453265a244c685da6beae5d9fb1" attach_digest="9bd71fba651612bc7582ae9fc699ca14">
+<MetricExtension name="ME$RESTORE_POINT_AGE" type="host" version="1" is_repos="FALSE" display_name="Restore Point Age" description="Maximum Restore Point Age" version_comment=" " metadata_digest="02aac4b9ec14d5789de98cb00ca5d25f" coll_digest="624a8453265a244c685da6beae5d9fb1" attach_digest="76d4bea352ac406e5e45fd462b623d58">
 <scripts name="max_restore_point_age.sh">
 </scripts>
 </MetricExtension>

--- a/ansible/roles/oracle-oms-setup/files/metric_extensions/common/restore_point_age/metadata/ME#24#RESTORE_POINT_AGE.xml
+++ b/ansible/roles/oracle-oms-setup/files/metric_extensions/common/restore_point_age/metadata/ME#24#RESTORE_POINT_AGE.xml
@@ -1,13 +1,18 @@
-<TargetMetadataExt EXT_NAME="ME$RESTORE_POINT_AGE" EXT_VERSION="3" TARGET_TYPE="host"><Metric NAME="ME$RESTORE_POINT_AGE" TYPE="TABLE">
+<TargetMetadataExt EXT_NAME="ME$RESTORE_POINT_AGE" EXT_VERSION="1" TARGET_TYPE="host"><Metric NAME="ME$RESTORE_POINT_AGE" TYPE="TABLE">
 <Display>
 <Label NLSID="NLS_METRIC_hostME$RESTORE_POINT_AGE">Restore Point Age</Label>
 <Description NLSID="NLS_DESCRIPTION_hostME$RESTORE_POINT_AGE">Maximum Restore Point Age</Description>
 </Display>
 <TableDescriptor>
+<ColumnDescriptor NAME="database" TYPE="STRING" IS_KEY="TRUE">
+<Display>
+<Label NLSID="NLS_COLUMN_hostME$RESTORE_POINT_AGEdatabase">Database</Label>
+</Display>
+</ColumnDescriptor>
 <ColumnDescriptor NAME="max_restore_point_age" TYPE="NUMBER">
 <Display>
 <Label NLSID="NLS_COLUMN_hostME$RESTORE_POINT_AGEmax_restore_point_age">Maximum Restore Point Age</Label>
-<Unit NLSID="mext_unit_nlsid_DAYS">DAYS</Unit>
+<Unit NLSID="EM_SYS_STANDARD_TIME_DAYS">DAYS</Unit>
 <UnitCategory>TIME</UnitCategory>
 </Display>
 <CategoryValue CLASS="Default" CATEGORY_NAME="Capacity">

--- a/ansible/roles/oracle-oms-setup/files/metric_extensions/common/restore_point_age/scripts/max_restore_point_age.sh
+++ b/ansible/roles/oracle-oms-setup/files/metric_extensions/common/restore_point_age/scripts/max_restore_point_age.sh
@@ -2,17 +2,79 @@
 
 . ~/.bash_profile
 
+# Function to identify all ORACLE_SID values on the host
+get_oracle_sids() {
+  #ps -ef | grep "[o]ra_pmon" | awk -F'_' '{print $NF}'
+  grep -E '^[^+#]' /etc/oratab | awk -F: 'NF && $1 ~ /^[^ ]/ {print $1}'
+}
 
-# Exit without failure if database is not up
-srvctl status database -d $ORACLE_SID >/dev/null || exit 0
+# Function to determine if the TIME column exists in V$RESTORE_POINT as it was only introduced in 12.2
+check_time_column() {
+  sqlplus -s / as sysdba <<EOF
+SET HEADING OFF
+SET FEEDBACK OFF
+SET PAGESIZE 0
+WHENEVER SQLERROR EXIT SQL.SQLCODE
+SELECT TIME FROM V\$RESTORE_POINT WHERE ROWNUM = 1;
+EXIT;
+EOF
+}
 
-sqlplus -s / as sysdba <<EOSQL
+# Function to calculate the maximum restore point age for a specific ORACLE_SID
+get_max_restore_point_age() {
+  local ORACLE_SID=$1
+  export ORACLE_SID
+  export ORAENV_ASK=NO
+  . oraenv >/dev/null 2>&1
+  if [ $? -ne 0 ]; then
+    echo "$ORACLE_SID|"
+    return
+  fi
+
+  # Exit without failure if database is not up
+  srvctl status database -d $ORACLE_SID >/dev/null 2>&1
+  if [ $? -ne 0 ]; then
+    echo "$ORACLE_SID|"
+    return
+  fi
+
+  # Check if the TIME column exists as it was only introduced in 12.2
+  if check_time_column >/dev/null 2>&1; then
+    # Use TIME column
+    sqlplus -s / as sysdba <<EOF
 SET ECHO OFF
 SET FEEDBACK OFF
 SET HEAD OFF
 SET PAGES 0
-COL max_restore_point_age FORMAT 99990
-SELECT COALESCE(MAX(TRUNC(SYSDATE)-TRUNC(TIME)),0) max_restore_point_age
-FROM   v\$restore_point;
-EXIT
-EOSQL
+SELECT SYS_CONTEXT('USERENV', 'DB_NAME') || '|' || TRIM(TO_CHAR(COALESCE(MAX(TRUNC(SYSDATE)-TRUNC(TIME)),0))) AS OUTPUT
+FROM V\$RESTORE_POINT;
+EXIT;
+EOF
+  else
+    # Fallback to SCN_TO_TIMESTAMP
+    sqlplus -s / as sysdba <<EOF
+SET ECHO OFF
+SET FEEDBACK OFF
+SET HEAD OFF
+SET PAGES 0
+SELECT SYS_CONTEXT('USERENV', 'DB_NAME') || '|' || TRIM(TO_CHAR(NVL(MAX(SYSDATE - SCN_TO_TIMESTAMP(SCN)), 0))) AS OUTPUT
+FROM V\$RESTORE_POINT;
+EXIT;
+EOF
+  fi
+}
+
+# Main script execution
+sids=$(get_oracle_sids)
+if [ -z "$sids" ]; then
+  # if no sids on this instance just exit
+  exit 0
+fi
+
+for sid in $sids; do
+  export ORACLE_SID=$sid
+  max_age=$(get_max_restore_point_age "$sid")
+  # Format output with pipe delimiter
+  echo "$max_age"
+done
+


### PR DESCRIPTION
Bash script updated to handle multiple databases running on a host as well as different Oracle versions (as the v$restore_point view changed from 12c onwards).

New key column added to store the sid.

As new key column has been added, ME$RESTORE_POINT_AGE has to be deleted manually from each EM (which has been done) and recreated from scratch.

me$restore_point doesn't exist in the repo so no changes required to remove it other than manually deleting it from the EM instances through the console.

Once ME$RESTORE_POINT_AGE has been imported into an EM instance, it has to be deployed to targets manually as emcli doesn't yet support deployments of ME's to targets.