### PR TITLE
fix oracle19c defaults

### DIFF
--- a/ansible/roles/oracle-19c/defaults/main.yml
+++ b/ansible/roles/oracle-19c/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
-artefacts_s3_bucket_name: devtest-oasys-20230411143832198800000001
-artefacts_s3_bucket_path: licence
+artefacts_s3_bucket_name: mod-platform-image-artefact-bucket20230203091453221500000001
+artefacts_s3_bucket_path: hmpps/oracle-19c-software
 artefact_dir: /u02
 app_dir: /u01/app
 oracle_install_user: oracle


### PR DESCRIPTION
Revert defaults back to what they were - files now copied to artefacts S3 buckets