### PR TITLE
TM-988: vss-backups-for-dc-and-rdl

### DIFF
--- a/powershell/Scripts/ModPlatformAD/Install-ModPlatformADDomainController.ps1
+++ b/powershell/Scripts/ModPlatformAD/Install-ModPlatformADDomainController.ps1
@@ -38,7 +38,7 @@ if (Add-ModPlatformADComputer -ModPlatformADConfig $ADConfig -ModPlatformADCrede
 }
 
 $DFSReplicationStatus = Get-Service "DFS Replication" -ErrorAction SilentlyContinue
-if ($DFSReplicationStatus -eq $null) {
+if ($null -eq $DFSReplicationStatus) {
   $ADAdminCredential = Get-ModPlatformADAdminCredential -ModPlatformADConfig $ADConfig -ModPlatformADSecret $ADSecret
   $ADSafeModeAdministratorPassword = Get-ModPlatformADSafeModeAdministratorPassword -ModPlatformADConfig $ADConfig -ModPlatformADSecret $ADSecret
   Install-WindowsFeature -Name AD-Domain-Services -IncludeAllSubFeature -IncludeManagementTools

--- a/powershell/Scripts/UserDataScripts/DomainController.ps1
+++ b/powershell/Scripts/UserDataScripts/DomainController.ps1
@@ -2,3 +2,18 @@
 if ($LASTEXITCODE -ne 0) {
    Exit $LASTEXITCODE
 }
+
+# Get the InstanceId
+$Token = Invoke-RestMethod -TimeoutSec 10 -Headers @{"X-aws-ec2-metadata-token-ttl-seconds"=3600} -Method PUT -Uri http://169.254.169.254/latest/api/token
+$InstanceId = Invoke-RestMethod -TimeoutSec 10 -Headers @{"X-aws-ec2-metadata-token" = $Token} -Method GET -Uri http://169.254.169.254/latest/meta-data/instance-id
+
+# Install the AWS VSS Components via SSM
+$documentName = "AWS-ConfigureAWSPackage"
+$parameters = @{
+    "action" = "Install"
+    "name" = "AwsVssComponents"
+}
+Send-SSMCommand -InstanceId $instanceId -DocumentName $documentName -Parameters $parameters
+
+# Install the Cloudwatch Agent with out baseline config
+. ../AmazonCloudWatchAgent/Install-AmazonCloudWatchAgent.ps1

--- a/powershell/Scripts/UserDataScripts/RDLicensing.ps1
+++ b/powershell/Scripts/UserDataScripts/RDLicensing.ps1
@@ -10,3 +10,18 @@ Install-WindowsFeature RDS-Licensing -IncludeAllSubFeature -IncludeManagementToo
 Import-Module ModPlatformRemoteDesktop -Force
 $CompanyInformation = Get-ModPlatformRDLicensingCompanyInformation
 Add-ModPlatformRDLicensingActivation $CompanyInformation
+
+# Get the InstanceId
+$Token = Invoke-RestMethod -TimeoutSec 10 -Headers @{"X-aws-ec2-metadata-token-ttl-seconds"=3600} -Method PUT -Uri http://169.254.169.254/latest/api/token
+$InstanceId = Invoke-RestMethod -TimeoutSec 10 -Headers @{"X-aws-ec2-metadata-token" = $Token} -Method GET -Uri http://169.254.169.254/latest/meta-data/instance-id
+
+# Install the AWS VSS Components via SSM
+$documentName = "AWS-ConfigureAWSPackage"
+$parameters = @{
+    "action" = "Install"
+    "name" = "AwsVssComponents"
+}
+Send-SSMCommand -InstanceId $instanceId -DocumentName $documentName -Parameters $parameters
+
+# Install the Cloudwatch Agent with out baseline config
+. ../AmazonCloudWatchAgent/Install-AmazonCloudWatchAgent.ps1


### PR DESCRIPTION
Enabling installation of the VSS agent and installation and configuration of the cloudwatch agent for domain controller and RD licensing role automation scripts.