### PR TITLE
bump major version of amazon.aws ansible module

### DIFF
--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -7,7 +7,7 @@ collections:
     version: 6.3.0
   - name: amazon.aws
     source: https://galaxy.ansible.com
-    version: 3.2.0
+    version: 9.2.0
   - name: community.aws
     source: https://galaxy.ansible.com
     version: 3.2.1


### PR DESCRIPTION
Some playbook runs fail due to the module returning non-UTF-8 data. This was previously a warning but was changed to fail playbook runs in Ansible 2.18. Upgrading the amazon.aws module fixes this error.