### PR TITLE
TM: ncr: fix timezone

### DIFF
--- a/ansible/group_vars/environment_name_nomis_combined_reporting_development.yml
+++ b/ansible/group_vars/environment_name_nomis_combined_reporting_development.yml
@@ -5,6 +5,5 @@ dns_zone_internal: nomis-combined-reporting.hmpps-development.modernisation-plat
 dns_search_domains:
   - hmpps-oem.hmpps-development.modernisation-platform.internal
   - azure.noms.root
-timezone: "Europe/London"
 ncr_environment: "{{ ec2.tags['nomis-combined-reporting-environment'] }}"
 sap_environment: "{{ ncr_environment }}"

--- a/ansible/group_vars/environment_name_nomis_combined_reporting_preproduction.yml
+++ b/ansible/group_vars/environment_name_nomis_combined_reporting_preproduction.yml
@@ -8,7 +8,6 @@ dns_search_domains:
   - azure.hmpp.root
   - lsast.reporting.nomis.service.justice.gov.uk
   - preproduction.reporting.nomis.service.justice.gov.uk
-timezone: "Europe/London"
 ncr_environment: "{{ ec2.tags['nomis-combined-reporting-environment'] }}"
 sap_environment: "{{ ncr_environment }}"
 

--- a/ansible/group_vars/environment_name_nomis_combined_reporting_test.yml
+++ b/ansible/group_vars/environment_name_nomis_combined_reporting_test.yml
@@ -7,7 +7,6 @@ dns_search_domains:
   - hmpps-oem.hmpps-test.modernisation-platform.internal
   - azure.noms.root
   - test.reporting.nomis.service.justice.gov.uk
-timezone: "Europe/London"
 ncr_environment: "{{ ec2.tags['nomis-combined-reporting-environment'] }}"
 sap_environment: "{{ ncr_environment }}"
 

--- a/ansible/group_vars/server_type_ncr_bip_app.yml
+++ b/ansible/group_vars/server_type_ncr_bip_app.yml
@@ -101,6 +101,7 @@ disks_mount:
     dir: swap
     fstype: swap
 
+timezone: "Europe/London"
 filesystems_mount: "{{ bip_filesystems_mount|default([]) }}"
 oracle_client_conf: "{{ sap_bip_oracle_client_conf }}"
 sap_bip_responsefile: response.app.ini

--- a/ansible/group_vars/server_type_ncr_bip_cms.yml
+++ b/ansible/group_vars/server_type_ncr_bip_cms.yml
@@ -101,6 +101,7 @@ disks_mount:
     dir: swap
     fstype: swap
 
+timezone: "Europe/London"
 filesystems_mount: "{{ bip_filesystems_mount|default([]) }}"
 oracle_client_conf: "{{ sap_bip_oracle_client_conf }}"
 sap_bip_is_cms: true

--- a/ansible/group_vars/server_type_ncr_web.yml
+++ b/ansible/group_vars/server_type_ncr_web.yml
@@ -99,6 +99,8 @@ disks_mount:
     dir: swap
     fstype: swap
 
+timezone: "Europe/London"
+
 sap_bip_responsefile: response.web.ini
 
 sap_web_disable_infoview: "false"

--- a/ansible/group_vars/server_type_ncr_webadmin.yml
+++ b/ansible/group_vars/server_type_ncr_webadmin.yml
@@ -99,6 +99,8 @@ disks_mount:
     dir: swap
     fstype: swap
 
+timezone: "Europe/London"
+
 sap_bip_responsefile: response.webadmin.ini
 sap_web_disable_infoview: "false"
 sap_web_disable_cmcapp: "false"

--- a/ansible/group_vars/server_type_onr_bip_cms.yml
+++ b/ansible/group_vars/server_type_onr_bip_cms.yml
@@ -100,6 +100,7 @@ disks_mount:
     dir: swap
     fstype: swap
 
+timezone: "Europe/London"
 filesystems_mount: "{{ bip_filesystems_mount|default([]) }}"
 oracle_client_conf: "{{ sap_bip_oracle_client_conf }}"
 sap_bip_is_cms: true

--- a/ansible/group_vars/server_type_onr_web.yml
+++ b/ansible/group_vars/server_type_onr_web.yml
@@ -98,6 +98,8 @@ disks_mount:
     dir: swap
     fstype: swap
 
+timezone: "Europe/London"
+
 sap_bip_responsefile: response.web.ini
 sap_web_server_type: web
 sap_web_disable_infoview: "false"

--- a/ansible/roles/time/tasks/main.yml
+++ b/ansible/roles/time/tasks/main.yml
@@ -3,3 +3,11 @@
     - amibuild
     - ec2provision
     - ec2patch
+    - chrony
+
+- import_tasks: timezone.yml
+  tags:
+    - amibuild
+    - ec2provision
+    - ec2patch
+    - timezone


### PR DESCRIPTION
Correct timezone configuration for BIP reporting:
- added missing import_tasks
- put timezone in server_type rather than environment. As DBs don't currently have it whereas BIP servers do.