### PR TITLE
Dba 889 oem 13.5 ru 25 patching

### DIFF
--- a/ansible/roles/oracle-oem-agent-setup/tasks/agent_gold_image.yml
+++ b/ansible/roles/oracle-oem-agent-setup/tasks/agent_gold_image.yml
@@ -170,7 +170,7 @@
             emcli get_agent_update_status -op_name="{{ update_agents_op_name }}" -status="Inprogress"
           register: update_agents_status_result
           changed_when: false
-          until: update_agents_status_result.stdout.find('No Agent Update Results Found') != -1
+          until: update_agents_status_result.stdout is regex("No Agent Update Results Found")
           retries: 100
           delay: 20
 

--- a/ansible/roles/oracle-oem-agent-setup/tasks/agent_gold_image.yml
+++ b/ansible/roles/oracle-oem-agent-setup/tasks/agent_gold_image.yml
@@ -32,6 +32,9 @@
       register: create_gold_image_result
       when: existing_gold_image_result.stdout == "0"
 
+    - name: Ensure oem agent is up and running
+      import_tasks: start_agent.yml
+
     # Can't use env var for the fqdn
     - name: Create Gold Image
       ansible.builtin.shell: |
@@ -49,7 +52,7 @@
       register: gold_image_status_result
       changed_when: false
       until: gold_image_status_result.stdout is search("PASSED")
-      retries: 15
+      retries: 100
       delay: 20
 
     - name: Parse Gold Image Creation Status
@@ -101,7 +104,7 @@
       register: stage_gold_image_status_result
       changed_when: false
       until: stage_gold_image_status_result.stdout is search("PASSED")
-      retries: 20
+      retries: 100
       delay: 20
 
     - name: Parse Gold Image Staging Status
@@ -163,7 +166,7 @@
           register: update_agents_status_result
           changed_when: false
           until: update_agents_status_result.stdout.find('No Agent Update Results Found') != -1
-          retries: 60
+          retries: 100
           delay: 20
 
         - name: Check NotExecuted Agents

--- a/ansible/roles/oracle-oem-agent-setup/tasks/agent_gold_image.yml
+++ b/ansible/roles/oracle-oem-agent-setup/tasks/agent_gold_image.yml
@@ -7,6 +7,11 @@
     EMCLI_HOME: "{{ app_dir }}/emcli"
     PATH: "{{ app_dir }}/emcli:{{ agent_home }}/oracle_common/jdk/jre/bin:{{ ansible_env.PATH }}"
   block:
+    # First, set a variable that will use the passed parameter if defined, otherwise fall back to the default
+    - name: Set Gold Image Name Variable
+      ansible.builtin.set_fact:
+        active_gold_image_name: "{{ goldimagename | default(agent_image_version_name) }}"
+
     - name: emcli Login
       ansible.builtin.shell: |
         emcli login -username=sysman -password="{{ oem_sysman_password }}" -force
@@ -15,18 +20,18 @@
 
     - name: Check for existing Gold Image version name with Current status
       ansible.builtin.shell: |
-        emcli get_gold_agent_image_details -version_name="{{ agent_image_version_name }}" | grep -c "Status         :Current" | cat
+        emcli get_gold_agent_image_details -version_name="{{ active_gold_image_name }}" | grep -c "Status         :Current" | cat
       register: existing_gold_image_result
       changed_when: false
 
     - name: Fail if Gold Image version name already exists and is in Current status
       ansible.builtin.fail:
-        msg: "Gold Image version name {{ agent_image_version_name }} already exists and is in Current status. Update the Gold Image version name to a different value and try again."
+        msg: "Gold Image version name {{ active_gold_image_name }} already exists and is in Current status. Update the Gold Image version name to a different value and try again."
       when: existing_gold_image_result.stdout == "1"
 
     - name: Delete existing Gold Image version if it's not in Current status
       ansible.builtin.shell: |
-        emcli delete_gold_agent_image -version_name="{{ agent_image_version_name }}"
+        emcli delete_gold_agent_image -version_name="{{ active_gold_image_name }}"
       changed_when: false
       ignore_errors: yes
       register: create_gold_image_result
@@ -38,7 +43,7 @@
     # Can't use env var for the fqdn
     - name: Create Gold Image
       ansible.builtin.shell: |
-        emcli create_gold_agent_image -image_name="{{ agent_image_name }}" -version_name="{{ agent_image_version_name }}" -source_agent="{{ ansible_fqdn }}:3872"
+        emcli create_gold_agent_image -image_name="{{ agent_image_name }}" -version_name="{{ active_gold_image_name }}" -source_agent="{{ ansible_fqdn }}:3872"
       register: create_gold_image_result
 
     - name: Extract Operation Name
@@ -76,7 +81,7 @@
     # Promote image before it can be staged
     - name: Promote Gold Agent Image
       ansible.builtin.shell: |
-        emcli promote_gold_agent_image -version_name="{{ agent_image_version_name }}" -maturity="Current"
+        emcli promote_gold_agent_image -version_name="{{ active_gold_image_name }}" -maturity="Current"
       register: promote_gold_image_result
       when: gold_image_status == "PASSED"
 
@@ -88,7 +93,7 @@
       # The directories will be created if they don't exist.
     - name: Stage Gold Agent Image
       ansible.builtin.shell: |
-        emcli stage_gold_agent_image -version_name="{{ agent_image_version_name }}" -host_name="{{ OMS_SERVER.split('.')[0] }}" -stage_location="{{ agent_gold_image_stage }}"
+        emcli stage_gold_agent_image -version_name="{{ active_gold_image_name }}" -host_name="{{ OMS_SERVER.split('.')[0] }}" -stage_location="{{ agent_gold_image_stage }}"
       register: stage_gold_image_result
       when: gold_image_status == "PASSED"
 
@@ -152,7 +157,7 @@
 
         - name: Parse Update Agents Operation Name
           ansible.builtin.shell: |
-            emcli get_agent_update_status -version_name="{{ agent_image_version_name }}" | awk '/--------/{getline; print}'
+            emcli get_agent_update_status -version_name="{{ active_gold_image_name }}" | awk '/--------/{getline; print}'
           register: update_agents_op_name_result
           changed_when: false
 
@@ -184,7 +189,7 @@
         - name: Fail if Any Agents Not Executed or Failed
           ansible.builtin.fail:
             msg: "Some agents did not update successfully. NotExecuted: {{ not_executed_agents_result.stdout }}, Failed: {{ failed_agents_result.stdout }}"
-          when: not_executed_agents_result.stdout != "No Agent Update Results Found" or failed_agents_result.stdout != "No Agent Update Results Found"
+          when: not not_executed_agents_result.stdout is regex(".*No Agent Update Results Found.*") or not failed_agents_result.stdout is regex(".*No Agent Update Results Found.*")
 
         - name: Debug Final Update Agents Status
           debug:

--- a/ansible/roles/oracle-oem-agent-setup/tasks/agent_startup_delay.yml
+++ b/ansible/roles/oracle-oem-agent-setup/tasks/agent_startup_delay.yml
@@ -1,26 +1,50 @@
----
-- name: Ensure a 2-minute delay is added after 'start)' in agentstup script
+- name: Ensure a 2-minute delay is added to agentstup file and its templates
   vars:
     agentstup_file: "{{ agent_home }}/install/unix/scripts/agentstup"
+    agentstup_template1: "{{ agent_home }}/inventory/Templates/install/unix/scripts/agentstup.template"
+    agentstup_template2: "{{ agent_home }}/install/unix/scripts/agentstup.template"
   block:
-    - name: Check if the agentstup file exists
+    - name: Check if files exist
       stat:
-        path: "{{ agentstup_file }}"
-      register: agentstup_stat
+        path: "{{ item }}"
+      register: file_stats
+      loop:
+        - "{{ agentstup_file }}"
+        - "{{ agentstup_template1 }}"
+        - "{{ agentstup_template2 }}"
 
-    - name: Check if 'sleep' is already in the file
-      command: grep -q 'sleep' "{{ agentstup_file }}"
-      register: sleep_check
+    - name: Create dict of file existence status
+      set_fact:
+        file_exists: "{{ file_exists|default({}) | combine({item.item: item.stat.exists}) }}"
+      loop: "{{ file_stats.results }}"
+
+    - name: Check if 'sleep' is already in the files
+      command: grep -q 'sleep' "{{ item }}"
+      register: sleep_checks
       changed_when: false
       failed_when: false
-      when: agentstup_stat.stat.exists
+      when: file_exists[item]
+      loop:
+        - "{{ agentstup_file }}"
+        - "{{ agentstup_template1 }}"
+        - "{{ agentstup_template2 }}"
+
+    - name: Create dict of sleep check results
+      set_fact:
+        sleep_exists: "{{ sleep_exists|default({}) | combine({item.item: (item.rc == 0)}) }}"
+      loop: "{{ sleep_checks.results }}"
+      when: item.skipped is not defined
 
     - name: Add sleep 120 after 'start)' if not already present
       lineinfile:
-        path: "{{ agentstup_file }}"
+        path: "{{ item }}"
         line: "    sleep 120"
         insertafter: "^\\s*start\\)"
         state: present
-      when:
-        - agentstup_stat.stat.exists
-        - sleep_check.rc != 0
+      when: 
+        - file_exists[item] | default(false)
+        - not (sleep_exists[item] | default(false))
+      loop:
+        - "{{ agentstup_file }}"
+        - "{{ agentstup_template1 }}"
+        - "{{ agentstup_template2 }}"

--- a/ansible/roles/oracle-oem-agent-setup/tasks/agent_startup_delay.yml
+++ b/ansible/roles/oracle-oem-agent-setup/tasks/agent_startup_delay.yml
@@ -41,7 +41,7 @@
         line: "    sleep 120"
         insertafter: "^\\s*start\\)"
         state: present
-      when: 
+      when:
         - file_exists[item] | default(false)
         - not (sleep_exists[item] | default(false))
       loop:

--- a/ansible/roles/oracle-oem-agent-setup/tasks/main.yml
+++ b/ansible/roles/oracle-oem-agent-setup/tasks/main.yml
@@ -43,9 +43,10 @@
     - amibuild
     - ec2provision
     - oem_agent_target_promote
+    - oem_agent_install
   # Added when clause as tags were ignored when this role is called from oracle-oms-setup role
   # This task shoudn't be run when run from oracle-oms-setup role
-  when: "'amibuild' in ansible_run_tags or 'ec2provision' in ansible_run_tags or 'oem_agent_target_promote' in ansible_run_tags"
+  when: "'amibuild' in ansible_run_tags or 'ec2provision' in ansible_run_tags or 'oem_agent_target_promote' in ansible_run_tags or 'oem_agent_install' in ansible_run_tags"
 
 # Run prior to gold image so all agents have the fix
 - import_tasks: agent_startup_delay.yml

--- a/ansible/roles/oracle-oem-agent-setup/tasks/main.yml
+++ b/ansible/roles/oracle-oem-agent-setup/tasks/main.yml
@@ -47,6 +47,15 @@
   # This task shoudn't be run when run from oracle-oms-setup role
   when: "'amibuild' in ansible_run_tags or 'ec2provision' in ansible_run_tags or 'oem_agent_target_promote' in ansible_run_tags"
 
+# Run prior to gold image so all agents have the fix
+- import_tasks: agent_startup_delay.yml
+  tags:
+    - amibuild
+    - ec2provision
+    - oem_agent_startup_delay
+    - oem_agent_install
+    - agent_ru_upgrade
+
 - import_tasks: agent_gold_image.yml
   tags:
     - amibuild
@@ -55,14 +64,6 @@
   # Added when clause as tags were ignored when this role is called from oracle-oms-setup role
   # This task shoudn't be run when run from oracle-oms-setup role
   when: "'amibuild' in ansible_run_tags or 'ec2provision' in ansible_run_tags or 'oem_agent_gold_image' in ansible_run_tags"
-
-- import_tasks: agent_startup_delay.yml
-  tags:
-    - amibuild
-    - ec2provision
-    - oem_agent_startup_delay
-    - oem_agent_install
-    - agent_ru_upgrade
 
 - import_tasks: cleanup.yml
   tags:

--- a/ansible/roles/oracle-oem-agent-setup/tasks/oem_agent_ru_upgrade.yml
+++ b/ansible/roles/oracle-oem-agent-setup/tasks/oem_agent_ru_upgrade.yml
@@ -71,3 +71,17 @@
   become: true
   become_user: "{{ oracle_install_user }}"
   environment: "{{ agent_env }}"
+
+- name: Post-update OEM 13.5 agent Root Actions
+  block:
+    - name: Execute root.sh
+      ansible.builtin.shell: |
+        set -eo pipefail
+        main() {
+          {{ agent_home }}/root.sh
+        }
+        main 2>&1 | logger -p local3.info -t ansible-oracle-oem-root-script
+      when: patch_status.stdout == "0"
+  # block
+  become: true
+  become_user: root


### PR DESCRIPTION
Fixes following Test env patching
- ensure agent is up before creating gold image as it may be down after patching
- increase the amount of time it checks
- Run agent delay fix before creating gold image so that the gold image contains the fix
- Use goldimagename parameter if passed in instead of default value in the code
- Add promote target task when agent being installed as it was being skipped
- Add running of root.sh after RU patching