### PR TITLE
oasys: disable ec2-user password

### DIFF
--- a/ansible/roles/users-and-groups/tasks/add-ec2-user.yml
+++ b/ansible/roles/users-and-groups/tasks/add-ec2-user.yml
@@ -1,0 +1,15 @@
+---
+# Explicitly disable ec2-user password to avoid account locked issue on some OS
+
+- name: Check if ec2-user exists
+  ansible.builtin.getent:
+    database: passwd
+    key: ec2-user
+  ignore_errors: true
+  failed_when: false
+
+- name: Disable ec2-user password
+  ansible.builtin.user:
+    name: ec2-user
+    password: '*'
+  when: getent_passwd["ec2-user"] is defined

--- a/ansible/roles/users-and-groups/tasks/main.yml
+++ b/ansible/roles/users-and-groups/tasks/main.yml
@@ -12,6 +12,12 @@
     - ec2patch
     - users-and-groups-ssm-user
 
+- import_tasks: add-ec2-user.yml
+  tags:
+    - ec2provision
+    - ec2patch
+    - users-and-groups-ec2-user
+
 - import_tasks: add-regular.yml
   tags:
     - amibuild


### PR DESCRIPTION
Explicitly disable ec2-user password to fix account locked issue on oracle linux