### PR TITLE
TM: update sudoers even if ssm-user already exists

### DIFF
--- a/ansible/roles/users-and-groups/tasks/add-ssm-user.yml
+++ b/ansible/roles/users-and-groups/tasks/add-ssm-user.yml
@@ -27,7 +27,7 @@
     system: yes
   when: getent_passwd["ssm-user"] is not defined
 
-- name: Configure ssm-user sudoers if user doesn't already exist
+- name: Configure ssm-user sudoers
   community.general.sudoers:
     name: ssm-agent-users
     state: present
@@ -35,4 +35,3 @@
     nopassword: yes
     runas: ALL
     commands: ALL
-  when: getent_passwd["ssm-user"] is not defined


### PR DESCRIPTION
Fixes issue reported by DBAs on pd-onr-db-1-a where they couldn't sudo without password. Always updates sudoers file for ssm-user even if user already exists.