### PR TITLE
DBA-944

### DIFF
--- a/ansible/roles/oracle-oem-agent-setup/tasks/main.yml
+++ b/ansible/roles/oracle-oem-agent-setup/tasks/main.yml
@@ -48,6 +48,13 @@
   # This task shoudn't be run when run from oracle-oms-setup role
   when: "'amibuild' in ansible_run_tags or 'ec2provision' in ansible_run_tags or 'oem_agent_target_promote' in ansible_run_tags or 'oem_agent_install' in ansible_run_tags"
 
+- import_tasks: update_target_properties.yml
+  tags:
+    - update_target_properties
+  # Added when clause as tags were ignored when this role is called from oracle-oms-setup role
+  # This task shoudn't be run when run from oracle-oms-setup role
+  when: "'update_target_properties' in ansible_run_tags"
+
 # Run prior to gold image so all agents have the fix
 - import_tasks: agent_startup_delay.yml
   tags:

--- a/ansible/roles/oracle-oem-agent-setup/tasks/update_target_properties.yml
+++ b/ansible/roles/oracle-oem-agent-setup/tasks/update_target_properties.yml
@@ -1,0 +1,87 @@
+---
+- name: OEM 13.5 Target Properties Update
+  environment:
+    EMCLI_HOME: "{{ app_dir }}/emcli"
+    PATH: "{{ app_dir }}/emcli:{{ agent_home }}/oracle_common/jdk/jre/bin:{{ ansible_env.PATH }}"
+  block:
+    # EMCLI Setup script contains a password so ensure it is not readable by other users
+    - name: Copy add targets shell script template
+      template:
+        src: "{{ item }}.j2"
+        dest: "{{ stage }}/{{ item }}"
+        mode: "0700"
+      loop:
+        - update_oem_target_properties.sh
+
+    # Do this in one step as emcli needs to have a session open
+    - name: Discover and promote targets
+      ansible.builtin.shell: |
+        . ~/.bash_profile
+        export JAVA_HOME={{ agent_home }}/oracle_common/jdk/jre
+        emcli login -username=sysman -password="{{ oem_sysman_password }}" -force
+        emcli sync
+        echo "running update_oem_target_properties.sh"
+        nohup {{ stage }}/update_oem_target_properties.sh > /tmp/update_oem_target_properties.log 2>&1 &
+        echo $! > /tmp/update_oem_target_properties.pid
+      args:
+        executable: /bin/bash
+
+    - name: Wait for add_targets.sh script to complete
+      ansible.builtin.shell: |
+        logfile="/tmp/update_oem_target_properties.log"
+        pidfile="/tmp/update_oem_target_properties.pid"
+
+        # Wait until the logfile is created
+        while [ ! -f "$logfile" ]; do
+          echo "Waiting for log file..."
+          sleep 5
+        done
+
+        # Wait until the PID file is created
+        while [ ! -f "$pidfile" ]; do
+          echo "Waiting for pid file..."
+          sleep 2
+        done
+
+        pid=$(cat "$pidfile")
+
+        echo "Monitoring PID $pid..."
+
+        # Wait for the process to finish
+        while kill -0 "$pid" 2>/dev/null; do
+          sleep 10
+        done
+
+        # Clean up the PID file
+        rm -f "$pidfile"
+
+        echo "Final log output:"
+        cat "$logfile"
+      args:
+        executable: /bin/bash
+      async: 3600
+      poll: 0
+      register: discovery_async
+
+    - name: Wait for background task to finish
+      ansible.builtin.async_status:
+        jid: "{{ discovery_async.ansible_job_id }}"
+      register: discovery_result
+      until: discovery_result.finished
+      retries: 120 # Retry up to 120 times
+      delay: 10 # Wait 10 seconds between retries
+
+  always:
+    - name: Remove setup scripts from staging area
+      ansible.builtin.file:
+        path: "{{ stage }}/{{ item }}"
+        state: absent
+      loop:
+        - update_oem_target_properties.sh
+      tags: clean_up
+
+    # Leave the logfile in /tmp for analysis and debugging
+
+  # block
+  become: true
+  become_user: oracle

--- a/ansible/roles/oracle-oem-agent-setup/templates/update_oem_target_properties.sh.j2
+++ b/ansible/roles/oracle-oem-agent-setup/templates/update_oem_target_properties.sh.j2
@@ -1,0 +1,88 @@
+#!/bin/bash
+
+# Usage: DEBUG=1 ./update_oem_target_properties.sh
+
+DEBUG=0
+
+DELIUS_PROD_CONTACT="#delius-aws-oracle-prod-alerts"
+DELIUS_DEV_CONTACT="#delius-aws-oracle-dev-alerts"
+
+NOMIS_PROD_CONTACT="#dba_alerts_prod"
+NOMIS_DEV_CONTACT="#dba_alerts_devtest"
+
+# === Debug Logging ===
+run_cmd() {
+  if [[ "$DEBUG" == "1" ]]; then
+    echo "[DEBUG] $1"
+  else
+    echo "[Running] $1"
+    eval "$1"
+  fi
+}
+
+# === Get list of hosts ===
+echo "Getting list of OEM host targets..."
+hosts=$(emcli get_targets -noheader -format="name:script;column_separator:|" | grep '|host|' | awk -F '|' '{print $4}')
+
+for hostname in $hosts; do
+  echo "Processing host: $hostname"
+
+  # Extract environment from hostname pattern
+  if [[ "$hostname" =~ "preproduction" ]]; then
+    DELIUS_CONTACT=$DELIUS_DEV_CONTACT
+    NOMIS_CONTACT=$NOMIS_DEV_CONTACT
+  elif [[ "$hostname" =~ "production" ]]; then
+    DELIUS_CONTACT=$DELIUS_PROD_CONTACT
+    NOMIS_CONTACT=$NOMIS_PROD_CONTACT
+  else
+    DELIUS_CONTACT=$DELIUS_DEV_CONTACT
+    NOMIS_CONTACT=$NOMIS_DEV_CONTACT
+  fi
+
+
+  # Extract application from hostname pattern and set the values to be used for Contact and Line of Business respectively
+  if [[ "$hostname" =~ "delius-mis" ]]; then
+    CONTACT=$DELIUS_CONTACT
+    APPLICATION="delius-mis"
+  elif [[ "$hostname" =~ "delius" ]]; then
+    CONTACT=$DELIUS_CONTACT
+    APPLICATION="delius"
+  elif [[ "$hostname" =~ "oem" ]]; then
+    CONTACT="#hmpps-oem-alerts"
+    APPLICATION="hmpps-oem"
+  elif [[ "$hostname" =~ "ncr" ]]; then
+    CONTACT=$NOMIS_CONTACT
+    APPLICATION="nomis-combined-reporting"
+  elif [[ "$hostname" =~ "csr" ]]; then
+    CONTACT=$NOMIS_CONTACT
+    APPLICATION="corporate-staff-rostering"
+  elif [[ "$hostname" =~ "nomis" ]]; then
+    CONTACT=$NOMIS_CONTACT
+    APPLICATION="nomis"
+  elif [[ "$hostname" =~ "oasys" ]]; then
+    CONTACT=$NOMIS_CONTACT
+    APPLICATION="oasys"
+  else
+    CONTACT="#hmpps-oem-alerts"
+    APPLICATION="hmpps-oem"
+  fi
+  echo "Updating targets for $hostname with Contact as $CONTACT and Line of Business as $CONTACT"
+
+  # Get all targets associated with this hostname
+  targets=$(emcli list -sql="select target_name, target_type, host_name from mgmt\$target" -noheader -format="name:script;column_separator:|"  | grep "$hostname")
+
+  while IFS='|' read -r target_name target_type host; do
+    echo "Target found: name=$target_name, type=$target_type, host=$host"
+
+    # Special case for Oracle Database targets as they are members of the oracle_dbsys target and properties can be set on the parent target
+    # and propagated to the members.
+    if [[ ${target_type} == "oracle_database" ]]; then
+      run_cmd "emcli set_target_property_value -subseparator=property_records=\"@@\" -property_records=\"${target_name}_sys@@oracle_dbsys@@Line of Business@@${APPLICATION}\" -propagate_to_members"
+      run_cmd "emcli set_target_property_value -subseparator=property_records=\"@@\" -property_records=\"${target_name}_sys@@oracle_dbsys@@Contact@@${CONTACT}\" -propagate_to_members"
+    else
+      run_cmd "emcli set_target_property_value -subseparator=property_records=\"@@\" -property_records=\"${target_name}@@${target_type}@@Line of Business@@${APPLICATION}\""
+      run_cmd "emcli set_target_property_value -subseparator=property_records=\"@@\" -property_records=\"${target_name}@@${target_type}@@Contact@@${CONTACT}\""
+    fi
+
+  done <<< "$targets"
+done


### PR DESCRIPTION
Added update_target_properties task.
Runs script update_oem_target_properties.sh which is used to update target properties in OEM. It assigns properties "Contact" and "Line of Business" to targets based on their hostname and application. It should only be run on the OEM host.

Key Features:

Debug Mode: 
The DEBUG variable allows the script to run in debug mode, where commands are printed instead of executed.

Host and Environment Detection:
The script retrieves a list of host targets from OEM using the emcli get_targets command.

It determines the environment (e.g., preproduction, production) based on the hostname pattern.

Application and Contact Assignment:
The script assigns a "Contact" (Slack channel) and "Line of Business" based on the hostname (as opposed to using the  “application” tag on the AWS instances which is how those are set when deploying the agent to a new host).

For example:
Hostnames containing delius are assigned to the delius application with the appropriate contact.
Hostnames containing nomis are assigned to the nomis application.

Target Property Updates:
The script updates target properties in OEM using the emcli set_target_property_value command.

For Oracle Database targets, properties are set on the parent oracle_dbsys target and propagated to its members. 