### PR TITLE
Detect if FSFO Active Target on 1st Standby

### DIFF
--- a/ansible/roles/oracle-oms-setup/files/metric_extensions/delius/dataguard_active_target/collection/ME#24#DATA_GUARD_ACTIVE_TARGET.xml
+++ b/ansible/roles/oracle-oms-setup/files/metric_extensions/delius/dataguard_active_target/collection/ME#24#DATA_GUARD_ACTIVE_TARGET.xml
@@ -1,9 +1,9 @@
-<TargetCollectionExt EXT_NAME="ME$DATA_GUARD_ACTIVE_TARGET" EXT_VERSION="2" TARGET_TYPE="host"><CollectionItem NAME="ME$DATA_GUARD_ACTIVE_TARGET" UPLOAD="YES">
+<TargetCollectionExt EXT_NAME="ME$DATA_GUARD_ACTIVE_TARGET" EXT_VERSION="3" TARGET_TYPE="host"><CollectionItem NAME="ME$DATA_GUARD_ACTIVE_TARGET" UPLOAD="YES">
 	<Schedule>
 		<IntervalSchedule INTERVAL="15" TIME_UNIT="Min"/>
 	</Schedule>
 	<MetricColl NAME="ME$DATA_GUARD_ACTIVE_TARGET">
-		<Condition COLUMN_NAME="Active_Target_1st_Standby" CRITICAL="YES" WARNING="YES" OPERATOR="NE" OCCURRENCES="1" MESSAGE="The Data Guard Active Target is not the 1st Standby Database" CLEAR_MESSAGE="The Data Guard Active Target is the 1st Standby Database"/>
+		<Condition COLUMN_NAME="Active_Target_1st_Standby" CRITICAL="OK" WARNING="OK" OPERATOR="NE" OCCURRENCES="1" MESSAGE="The Data Guard Active Target is not the 1st Standby Database" CLEAR_MESSAGE="The Data Guard Active Target is the 1st Standby Database"/>
 	</MetricColl>
 </CollectionItem>
 </TargetCollectionExt>

--- a/ansible/roles/oracle-oms-setup/files/metric_extensions/delius/dataguard_active_target/mea.xml
+++ b/ansible/roles/oracle-oms-setup/files/metric_extensions/delius/dataguard_active_target/mea.xml
@@ -1,5 +1,5 @@
 <MetricExtensionArchive name="MEAME$DATA_GUARD_ACTIVE_TARGET">
-<MetricExtension name="ME$DATA_GUARD_ACTIVE_TARGET" type="host" version="2" is_repos="FALSE" display_name="Data Guard Active Target" description="Check that the Data Guard Active Target is the First Standby" version_comment=" " metadata_digest="7897bb64572d2a03334b940efda91027" coll_digest="92247f2f5b596b6221c1458fee0521c6" attach_digest="e597c89598d89d4480195a49aebfe9e0">
+<MetricExtension name="ME$DATA_GUARD_ACTIVE_TARGET" type="host" version="3" is_repos="FALSE" display_name="Data Guard Active Target" description="Check that the Data Guard Active Target is the First Standby" version_comment=" " metadata_digest="7897bb64572d2a03334b940efda91027" coll_digest="4a6a34cdc34f6208ea3329bec07d65b1" attach_digest="89584d1a48f39fe96d9209b51a74aaed">
 <scripts name="active_target.sh">
 </scripts>
 </MetricExtension>

--- a/ansible/roles/oracle-oms-setup/files/metric_extensions/delius/dataguard_active_target/metadata/ME#24#DATA_GUARD_ACTIVE_TARGET.xml
+++ b/ansible/roles/oracle-oms-setup/files/metric_extensions/delius/dataguard_active_target/metadata/ME#24#DATA_GUARD_ACTIVE_TARGET.xml
@@ -1,4 +1,4 @@
-<TargetMetadataExt EXT_NAME="ME$DATA_GUARD_ACTIVE_TARGET" EXT_VERSION="2" TARGET_TYPE="host"><Metric NAME="ME$DATA_GUARD_ACTIVE_TARGET" TYPE="TABLE">
+<TargetMetadataExt EXT_NAME="ME$DATA_GUARD_ACTIVE_TARGET" EXT_VERSION="3" TARGET_TYPE="host"><Metric NAME="ME$DATA_GUARD_ACTIVE_TARGET" TYPE="TABLE">
 <Display>
 <Label NLSID="NLS_METRIC_hostME$DATA_GUARD_ACTIVE_TARGET">Data Guard Active Target</Label>
 <Description NLSID="NLS_DESCRIPTION_hostME$DATA_GUARD_ACTIVE_TARGET">Check that the Data Guard Active Target is the First Standby</Description>

--- a/ansible/roles/oracle-oms-setup/files/metric_extensions/delius/dataguard_active_target/scripts/active_target.sh
+++ b/ansible/roles/oracle-oms-setup/files/metric_extensions/delius/dataguard_active_target/scripts/active_target.sh
@@ -1,16 +1,23 @@
 #!/bin/bash
 
-# Check Active Target is the 1st Standby Database
+# Check Active Target is the 1st Standby Database is FSFO is enabled
 
 . ~/.bash_profile
 
+FSFO_ENABLED=$( echo "show configuration;" | dgmgrl / | grep -c "Fast-Start Failover: Enabled in Zero Data Loss Mode" )
 ACTIVE_TARGET=$( echo "show configuration;" | dgmgrl / | grep "(*) Physical standby database" | awk '{print substr($1,length($1)-1)}')
-# Check if target is not being Observed
-NO_OBSERVER=$( echo "show configuration;" | dgmgrl / | grep -c "ORA-16820" )
 
-if [[ "${ACTIVE_TARGET}" == "s1" && ${NO_OBSERVER} -eq 0 ]];
+if [[ "${ACTIVE_TARGET}" == "s1" && ${FSFO_ENABLED} -eq 1 ]];
 then
-   echo "YES"
+   # OK is the Active Target database is the 1st Standby and FSFO is Enabled
+   echo "OK"
 else
-   echo "NO"
+   if [[ ${FSFO_ENABLED} -eq 0 ]];
+   then
+          # Also OK if FSFO is not enabled at all
+	   echo "OK"
+   else
+           # Otherwise raise an error
+   	   echo "NO"
+   fi
 fi


### PR DESCRIPTION
1st Standby is the preferred target for FSFO as the 2nd standby is used for Active Data Guard. This Metric used to perform the check if the Observer was running, but in MP we need instead to check if FSFO is enabled and do not raise an error if it is disabled.