### PR TITLE
add Jumpserver to collections

### DIFF
--- a/powershell/Scripts/UserDataScripts/RDServices.ps1
+++ b/powershell/Scripts/UserDataScripts/RDServices.ps1
@@ -138,36 +138,6 @@ function Get-Config {
   Return $GlobalConfig[$NameTag]
 }
 
-function Get-SecretValue {
-  param (
-    [Parameter(Mandatory)]
-    [string]$SecretId,
-    [Parameter(Mandatory)]
-    [string]$SecretKey
-  )
-
-  try {
-    $secretJson = aws secretsmanager get-secret-value --secret-id $SecretId --query SecretString --output text
-
-    if ($null -eq $secretJson -or $secretJson -eq '') {
-      Write-Host "The SecretId '$SecretId' does not exist or returned no value."
-      return $null
-    }
-
-    $secretObject = $secretJson | ConvertFrom-Json
-
-    if (-not $secretObject.PSObject.Properties.Name -contains $SecretKey) {
-      Write-Host "The SecretKey '$SecretKey' does not exist in the secret."
-      return $null
-    }
-
-    return $secretObject.$SecretKey
-  }
-  catch {
-    Write-Host "An error occurred while retrieving the secret: $_"
-    return $null
-  }
-}
 
 function Add-PermanentPSModulePath {
   param(

--- a/powershell/Scripts/UserDataScripts/RDServices.ps1
+++ b/powershell/Scripts/UserDataScripts/RDServices.ps1
@@ -281,6 +281,11 @@ if ($RunManually) {
   }
 }
 else {
+  if ($null -eq $Config.svcRdsSecretsVault) {
+    Write-Host "No svcRdsSecretsVault found in config. Exiting." -ForegroundColor Red
+    exit 1
+  }
+
   $svc_rds_password = Get-SecretValue -SecretId $($Config.svcRdsSecretsVault) -SecretKey "svc_rds" -ErrorAction SilentlyContinue
 
   $username = "$($Config.domain)\svc_rds"

--- a/powershell/Scripts/UserDataScripts/RDServices.ps1
+++ b/powershell/Scripts/UserDataScripts/RDServices.ps1
@@ -35,7 +35,6 @@ $GlobalConfig = @{
     "GatewayExternalFqdn" = "rdgateway1.test.hmpps-domain.service.justice.gov.uk"
     "SessionHostServers"  = @("T1-JUMP2022-1.AZURE.NOMS.ROOT")
     "WebAccessServer"     = "$env:computername.AZURE.NOMS.ROOT"
-    "rdsOU"               = "OU=RDServices,OU=MODERNISATION_PLATFORM_SERVERS,DC=AZURE,DC=NOMS,DC=ROOT"
     "svcRdsSecretsVault"  = "/microsoft/AD/azure.noms.root/shared-passwords"
     "domain"              = "AZURE"
     "Collections"         = @{
@@ -55,7 +54,6 @@ $GlobalConfig = @{
     "GatewayExternalFqdn" = "rdgateway1.preproduction.hmpps-domain.service.justice.gov.uk"
     "SessionHostServers"  = @("PP-CAFM-A-11-A.AZURE.HMPP.ROOT", "PP-JUMP2022-1.AZURE.HMPP.ROOT")
     "WebAccessServer"     = "$env:computername.AZURE.HMPP.ROOT"
-    "rdsOU"               = "OU=RDServices,OU=MODERNISATION_PLATFORM_SERVERS,DC=AZURE,DC=HMPP,DC=ROOT"
     "svcRdsSecretsVault"  = "/microsoft/AD/azure.hmpp.root/shared-passwords"
     "domain"              = "HMPP"
     "Collections"         = @{
@@ -94,7 +92,6 @@ $GlobalConfig = @{
     "GatewayExternalFqdn" = "rdgateway1.hmpps-domain.service.justice.gov.uk"
     "SessionHostServers"  = @("PD-CAFM-A-11-A.AZURE.HMPP.ROOT", "PD-CAFM-A-12-B.AZURE.HMPP.ROOT", "PD-CAFM-A-13-A.AZURE.HMPP.ROOT", "PD-JUMP2022-1.AZURE.HMPP.ROOT")
     "WebAccessServer"     = "$env:computername.AZURE.HMPP.ROOT"
-    "rdsOU"               = "OU=RDServices,OU=MODERNISATION_PLATFORM_SERVERS,DC=AZURE,DC=HMPP,DC=ROOT"
     "svcRdsSecretsVault"  = "/microsoft/AD/azure.hmpp.root/shared-passwords"
     "domain"              = "HMPP"
     "Collections"         = @{
@@ -251,11 +248,9 @@ if ($LASTEXITCODE -ne 0) {
   Exit $LASTEXITCODE
 }
 
+# move the RDS server to the RDServices OU
 Import-Module ModPlatformAD -Force
-# $ADConfig = Get-ModPlatformADConfig
-# $ADAdminCredential = Get-ModPlatformADAdminCredential -ModPlatformADConfig $ADConfig
-# Move the computer to the correct OU
-. ../ModPlatformAD/Move-ModPlatformADComputer.ps1 #-ModPlatformADCredential $ADAdminCredential -NewOU $($Config.rdsOU)
+. ../ModPlatformAD/Move-ModPlatformADComputer.ps1
 
 # Path to the deployment scripts
 $deploymentScriptPath = Join-Path $PSScriptRoot "RDSDeployment.ps1"

--- a/powershell/Scripts/UserDataScripts/RDServices.ps1
+++ b/powershell/Scripts/UserDataScripts/RDServices.ps1
@@ -35,7 +35,7 @@ $GlobalConfig = @{
     "GatewayExternalFqdn" = "rdgateway1.test.hmpps-domain.service.justice.gov.uk"
     "SessionHostServers"  = @("T1-JUMP2022-1.AZURE.NOMS.ROOT")
     "WebAccessServer"     = "$env:computername.AZURE.NOMS.ROOT"
-    "rdsOU"               = "OU=RDS,OU=MODERNISATION_PLATFORM_SERVERS,DC=AZURE,DC=NOMS,DC=ROOT"
+    "rdsOU"               = "OU=RDServices,OU=MODERNISATION_PLATFORM_SERVERS,DC=AZURE,DC=NOMS,DC=ROOT"
     "svcRdsSecretsVault"  = "/microsoft/AD/azure.noms.root/shared-passwords"
     "domain"              = "AZURE"
     "Collections"         = @{
@@ -55,7 +55,7 @@ $GlobalConfig = @{
     "GatewayExternalFqdn" = "rdgateway1.preproduction.hmpps-domain.service.justice.gov.uk"
     "SessionHostServers"  = @("PP-CAFM-A-11-A.AZURE.HMPP.ROOT", "PP-JUMP2022-1.AZURE.HMPP.ROOT")
     "WebAccessServer"     = "$env:computername.AZURE.HMPP.ROOT"
-    "rdsOU"               = "OU=RDS,OU=MODERNISATION_PLATFORM_SERVERS,DC=AZURE,DC=HMPP,DC=ROOT"
+    "rdsOU"               = "OU=RDServices,OU=MODERNISATION_PLATFORM_SERVERS,DC=AZURE,DC=HMPP,DC=ROOT"
     "svcRdsSecretsVault"  = "/microsoft/AD/azure.hmpp.root/shared-passwords"
     "domain"              = "HMPP"
     "Collections"         = @{
@@ -94,7 +94,7 @@ $GlobalConfig = @{
     "GatewayExternalFqdn" = "rdgateway1.hmpps-domain.service.justice.gov.uk"
     "SessionHostServers"  = @("PD-CAFM-A-11-A.AZURE.HMPP.ROOT", "PD-CAFM-A-12-B.AZURE.HMPP.ROOT", "PD-CAFM-A-13-A.AZURE.HMPP.ROOT", "PD-JUMP2022-1.AZURE.HMPP.ROOT")
     "WebAccessServer"     = "$env:computername.AZURE.HMPP.ROOT"
-    "rdsOU"               = "OU=RDS,OU=MODERNISATION_PLATFORM_SERVERS,DC=AZURE,DC=HMPP,DC=ROOT"
+    "rdsOU"               = "OU=RDServices,OU=MODERNISATION_PLATFORM_SERVERS,DC=AZURE,DC=HMPP,DC=ROOT"
     "svcRdsSecretsVault"  = "/microsoft/AD/azure.hmpp.root/shared-passwords"
     "domain"              = "HMPP"
     "Collections"         = @{

--- a/powershell/Scripts/UserDataScripts/RDServices.ps1
+++ b/powershell/Scripts/UserDataScripts/RDServices.ps1
@@ -33,17 +33,17 @@ $GlobalConfig = @{
     "LicensingServer"     = "AD-AZURE-RDLIC.AZURE.NOMS.ROOT"
     "GatewayServer"       = "$env:computername.AZURE.NOMS.ROOT"
     "GatewayExternalFqdn" = "rdgateway1.test.hmpps-domain.service.justice.gov.uk"
-    "SessionHostServers"  = @("T2-JUMP2022-2.AZURE.NOMS.ROOT")
+    "SessionHostServers"  = @("T1-JUMP2022-1.AZURE.NOMS.ROOT")
     "WebAccessServer"     = "$env:computername.AZURE.NOMS.ROOT"
     "rdsOU"               = "OU=RDS,OU=MODERNISATION_PLATFORM_SERVERS,DC=AZURE,DC=NOMS,DC=ROOT"
     "svcRdsSecretsVault"  = "/microsoft/AD/azure.noms.root/shared-passwords"
     "domain"              = "AZURE"
     "Collections"         = @{
       "Jumpserver" = @{
-        "SessionHosts"  = @("T2-JUMP2022-2.AZURE.NOMS.ROOT")
+        "SessionHosts"  = @("T1-JUMP2022-1.AZURE.NOMS.ROOT")
         "Configuration" = @{
-          "CollectionDescription" = "Connect to Jumpserver T2-JUMP2022-2"
-          "UserGroup"             = @("Azure\Domain Users")
+          "CollectionDescription" = "Connect to Jumpserver T1-JUMP2022-1"
+          "UserGroup"             = @("Azure\HmppsJump2022")
         }
       }
     }
@@ -53,7 +53,7 @@ $GlobalConfig = @{
     "LicensingServer"     = "AD-HMPP-RDLIC.AZURE.HMPP.ROOT"
     "GatewayServer"       = "$env:computername.AZURE.HMPP.ROOT"
     "GatewayExternalFqdn" = "rdgateway1.preproduction.hmpps-domain.service.justice.gov.uk"
-    "SessionHostServers"  = @("PP-CAFM-A-11-A.AZURE.HMPP.ROOT")
+    "SessionHostServers"  = @("PP-CAFM-A-11-A.AZURE.HMPP.ROOT", "PP-JUMP2022-1.AZURE.HMPP.ROOT")
     "WebAccessServer"     = "$env:computername.AZURE.HMPP.ROOT"
     "rdsOU"               = "OU=RDS,OU=MODERNISATION_PLATFORM_SERVERS,DC=AZURE,DC=HMPP,DC=ROOT"
     "svcRdsSecretsVault"  = "/microsoft/AD/azure.hmpp.root/shared-passwords"
@@ -64,6 +64,13 @@ $GlobalConfig = @{
         "Configuration" = @{
           "CollectionDescription" = "CAFM-RDP PreProd Modernisation Platform"
           "UserGroup"             = @("HMPP\PROD_CAFM_admins")
+        }
+      }
+      "Jumpserver" = @{
+        "SessionHosts"  = @("PP-JUMP2022-1.AZURE.HMPP.ROOT")
+        "Configuration" = @{
+          "CollectionDescription" = "Connect to Jumpserver PP-JUMP2022-1"
+          "UserGroup"             = @("HMPP\HmppsJump2022")
         }
       }
     }
@@ -85,7 +92,7 @@ $GlobalConfig = @{
     "LicensingServer"     = "AD-HMPP-RDLIC.AZURE.HMPP.ROOT"
     "GatewayServer"       = "$env:computername.AZURE.HMPP.ROOT"
     "GatewayExternalFqdn" = "rdgateway1.hmpps-domain.service.justice.gov.uk"
-    "SessionHostServers"  = @("PD-CAFM-A-11-A.AZURE.HMPP.ROOT", "PD-CAFM-A-12-B.AZURE.HMPP.ROOT", "PD-CAFM-A-13-A.AZURE.HMPP.ROOT")
+    "SessionHostServers"  = @("PD-CAFM-A-11-A.AZURE.HMPP.ROOT", "PD-CAFM-A-12-B.AZURE.HMPP.ROOT", "PD-CAFM-A-13-A.AZURE.HMPP.ROOT", "PD-JUMP2022-1.AZURE.HMPP.ROOT")
     "WebAccessServer"     = "$env:computername.AZURE.HMPP.ROOT"
     "rdsOU"               = "OU=RDS,OU=MODERNISATION_PLATFORM_SERVERS,DC=AZURE,DC=HMPP,DC=ROOT"
     "svcRdsSecretsVault"  = "/microsoft/AD/azure.hmpp.root/shared-passwords"
@@ -96,6 +103,13 @@ $GlobalConfig = @{
         "Configuration" = @{
           "CollectionDescription" = "PlanetFM RemoteDesktop App Collection"
           "UserGroup"             = @("HMPP\PROD_CAFM_admins")
+        }
+      }
+      "Jumpserver" = @{
+        "SessionHosts" = @("PD-JUMP2022-1.AZURE.HMPP.ROOT")
+        "Configuration" = @{
+          "CollectionDescription" = "Connect to Jumpserver PD-JUMP2022-1"
+          "UserGroup"             = @("HMPP\HmppsJump2022")
         }
       }
     }
@@ -267,10 +281,10 @@ if ($RunManually) {
   }
 }
 else {
-  $svc_nart_password = Get-SecretValue -SecretId $($Config.svcRdsSecretsVault) -SecretKey "svc_rds" -ErrorAction SilentlyContinue
+  $svc_rds_password = Get-SecretValue -SecretId $($Config.svcRdsSecretsVault) -SecretKey "svc_rds" -ErrorAction SilentlyContinue
 
   $username = "$($Config.domain)\svc_rds"
-  $secure_password = $svc_nart_password | ConvertTo-SecureString -AsPlainText -Force
+  $secure_password = $svc_rds_password | ConvertTo-SecureString -AsPlainText -Force
 
   $credentials = New-Object System.Management.Automation.PSCredential($username, $secure_password)
 

--- a/powershell/Scripts/UserDataScripts/RDServices.ps1
+++ b/powershell/Scripts/UserDataScripts/RDServices.ps1
@@ -281,6 +281,7 @@ if ($RunManually) {
   }
 }
 else {
+  $Config = Get-Config
   if ($null -eq $Config.svcRdsSecretsVault) {
     Write-Host "No svcRdsSecretsVault found in config. Exiting." -ForegroundColor Red
     exit 1

--- a/powershell/Scripts/UserDataScripts/RDServices.ps1
+++ b/powershell/Scripts/UserDataScripts/RDServices.ps1
@@ -252,10 +252,10 @@ if ($LASTEXITCODE -ne 0) {
 }
 
 Import-Module ModPlatformAD -Force
-$ADConfig = Get-ModPlatformADConfig
-$ADAdminCredential = Get-ModPlatformADAdminCredential -ModPlatformADConfig $ADConfig
+# $ADConfig = Get-ModPlatformADConfig
+# $ADAdminCredential = Get-ModPlatformADAdminCredential -ModPlatformADConfig $ADConfig
 # Move the computer to the correct OU
-Move-ModPlatformADComputer -ModPlatformADCredential $ADAdminCredential -NewOU $($Config.rdsOU)
+. ../ModPlatformAD/Move-ModPlatformADComputer.ps1 #-ModPlatformADCredential $ADAdminCredential -NewOU $($Config.rdsOU)
 
 # Path to the deployment scripts
 $deploymentScriptPath = Join-Path $PSScriptRoot "RDSDeployment.ps1"

--- a/powershell/Scripts/UserDataScripts/RDServices.ps1
+++ b/powershell/Scripts/UserDataScripts/RDServices.ps1
@@ -38,7 +38,7 @@ $GlobalConfig = @{
     "svcRdsSecretsVault"  = "/microsoft/AD/azure.noms.root/shared-passwords"
     "domain"              = "AZURE"
     "Collections"         = @{
-      "Jumpserver" = @{
+      "t1-jump2022-1" = @{
         "SessionHosts"  = @("T1-JUMP2022-1.AZURE.NOMS.ROOT")
         "Configuration" = @{
           "CollectionDescription" = "Connect to Jumpserver T1-JUMP2022-1"
@@ -64,7 +64,7 @@ $GlobalConfig = @{
           "UserGroup"             = @("HMPP\PROD_CAFM_admins")
         }
       }
-      "Jumpserver" = @{
+      "pp-jump2022-1" = @{
         "SessionHosts"  = @("PP-JUMP2022-1.AZURE.HMPP.ROOT")
         "Configuration" = @{
           "CollectionDescription" = "Connect to Jumpserver PP-JUMP2022-1"
@@ -102,7 +102,7 @@ $GlobalConfig = @{
           "UserGroup"             = @("HMPP\PROD_CAFM_admins")
         }
       }
-      "Jumpserver" = @{
+      "pd-jump2022-1" = @{
         "SessionHosts" = @("PD-JUMP2022-1.AZURE.HMPP.ROOT")
         "Configuration" = @{
           "CollectionDescription" = "Connect to Jumpserver PD-JUMP2022-1"

--- a/powershell/Scripts/UserDataScripts/RDServices.ps1
+++ b/powershell/Scripts/UserDataScripts/RDServices.ps1
@@ -61,7 +61,7 @@ $GlobalConfig = @{
         "SessionHosts"  = @("PP-CAFM-A-11-A.AZURE.HMPP.ROOT")
         "Configuration" = @{
           "CollectionDescription" = "CAFM-RDP PreProd Modernisation Platform"
-          "UserGroup"             = @("HMPP\PROD_CAFM_admins")
+          "UserGroup"             = @("HMPP\PROD_CAFM_admins", "HMPP\PROD_CAFM_SQL_USERS")
         }
       }
       "pp-jump2022-1" = @{
@@ -99,7 +99,7 @@ $GlobalConfig = @{
         "SessionHosts"  = @("PD-CAFM-A-11-A.AZURE.HMPP.ROOT", "PD-CAFM-A-12-B.AZURE.HMPP.ROOT", "PD-CAFM-A-13-A.AZURE.HMPP.ROOT")
         "Configuration" = @{
           "CollectionDescription" = "PlanetFM RemoteDesktop App Collection"
-          "UserGroup"             = @("HMPP\PROD_CAFM_admins")
+          "UserGroup"             = @("HMPP\PROD_CAFM_admins") # , "HMPP\PROD_CAFM_SQL_USERS") <= possibly add later
         }
       }
       "pd-jump2022-1" = @{


### PR DESCRIPTION
- edit jumpserver collection config for test environment
- add jumpserver collection config to preprod and prod
- change variable name for passwords to make it consistent
- improved pwsh code to deploy RDServices.ps1 using other functions 
- used server names for jumpserver labelling
- added PROD_CAFM_SQL_USERS to cafm-rdp preprod collection

Has not been applied to pd-rds-1-a so ticket TM-1249 has been created to deploy this

We can come back and refactor this to follow the example from HmppsJump2022.ps1 later