### PR TITLE
TM-1259: nomis: web12c fixes

### DIFF
--- a/ansible/group_vars/server_type_nomis_web12.yml
+++ b/ansible/group_vars/server_type_nomis_web12.yml
@@ -57,7 +57,7 @@ packages_yum_install:
   - redhat-lsb-4.1
   - redhat-lsb-core
   - libnsl
-  - xterm # just for testing X
+  - xterm  # just for testing X
 
 disks_mount:
   - ebs_device_name: /dev/sdb
@@ -83,7 +83,8 @@ weblogic_configs:
     weblogic_db_repo_sid: "qa11g"
     weblogic_db_repo_username: "sys"
     weblogic_db_repo_prefix: "nomis13"
-    weblogic_domain_template_filename: "template1.jar"
+    # weblogic_domain_template_filename: "template1.jar"
+    weblogic_domain_template_filename: "template2.jar"  # template1.jar + ReportsServerComponent
 
 weblogic_config: "{{ weblogic_configs[nomis_environment] }}"
 

--- a/ansible/roles/users-and-groups/tasks/add-regular.yml
+++ b/ansible/roles/users-and-groups/tasks/add-regular.yml
@@ -109,6 +109,8 @@
 - name: Touch regular users .xAuthority
   ansible.builtin.file:
     path: "/home/{{ item.name }}/.Xauthority"
+    owner: "{{ item.name }}"
+    group: "{{ item.group }}"
     state: touch
     mode: u+rw,g-rwx,o-rwx
     modification_time: preserve

--- a/ansible/roles/users-and-groups/tasks/add-system.yml
+++ b/ansible/roles/users-and-groups/tasks/add-system.yml
@@ -41,6 +41,8 @@
 - name: Touch system users .xAuthority
   ansible.builtin.file:
     path: "/home/{{ item.name }}/.Xauthority"
+    owner: "{{ item.name }}"
+    group: "{{ item.group }}"
     state: touch
     mode: u+rw,g-rwx,o-rwx
     modification_time: preserve

--- a/powershell/Scripts/Microsoft/Add-EdgeInternetExplorerIntegration.ps1
+++ b/powershell/Scripts/Microsoft/Add-EdgeInternetExplorerIntegration.ps1
@@ -35,8 +35,6 @@ $Configs = @{
       "c-dev.development.nomis.service.justice.gov.uk/forms/frmservlet?config=tag",
       "c-qa11g.development.nomis.service.justice.gov.uk/forms/frmservlet?config=tag",
       "c-qa11r.development.nomis.service.justice.gov.uk/forms/frmservlet?config=tag",
-      "dev-nomis-web19c-a.development.nomis.service.justice.gov.uk/forms/frmservlet?config=tag",
-      "dev-nomis-web19c-b.development.nomis.service.justice.gov.uk/forms/frmservlet?config=tag",
       "qa11g-nomis-web12-a.development.nomis.service.justice.gov.uk/forms/frmservlet?config=tag"
     )
     "TrustedDomains" = @(
@@ -98,8 +96,6 @@ $Configs = @{
       "c-dev.development.nomis.service.justice.gov.uk/forms/frmservlet?config=tag",
       "c-qa11g.development.nomis.service.justice.gov.uk/forms/frmservlet?config=tag",
       "c-qa11r.development.nomis.service.justice.gov.uk/forms/frmservlet?config=tag",
-      "dev-nomis-web19c-a.development.nomis.service.justice.gov.uk/forms/frmservlet?config=tag",
-      "dev-nomis-web19c-b.development.nomis.service.justice.gov.uk/forms/frmservlet?config=tag",
       "qa11g-nomis-web12-a.development.nomis.service.justice.gov.uk/forms/frmservlet?config=tag"
     )
     "TrustedDomains" = @(

--- a/powershell/Scripts/Microsoft/Add-StartMenuShortcuts.ps1
+++ b/powershell/Scripts/Microsoft/Add-StartMenuShortcuts.ps1
@@ -41,7 +41,6 @@ $Configs = @{
         "Prison-Nomis/DEV"      = "https://c-dev.development.nomis.service.justice.gov.uk/forms/frmservlet?config=tag"
         "Prison-Nomis/QA11G"    = "https://c-qa11g.development.nomis.service.justice.gov.uk/forms/frmservlet?config=tag"
         "Prison-Nomis/QA11R"    = "https://c-qa11r.development.nomis.service.justice.gov.uk/forms/frmservlet?config=tag"
-        "Prison-Nomis/WEB19C-B" = "https://dev-nomis-web19c-b.development.nomis.service.justice.gov.uk/forms/frmservlet?config=tag"
       }
     }
   }
@@ -163,7 +162,6 @@ $Configs = @{
         "Prison-Nomis/DEV"      = "https://c-dev.development.nomis.service.justice.gov.uk/forms/frmservlet?config=tag"
         "Prison-Nomis/QA11G"    = "https://c-qa11g.development.nomis.service.justice.gov.uk/forms/frmservlet?config=tag"
         "Prison-Nomis/QA11R"    = "https://c-qa11r.development.nomis.service.justice.gov.uk/forms/frmservlet?config=tag"
-        "Prison-Nomis/WEB19C-B" = "https://dev-nomis-web19c-b.development.nomis.service.justice.gov.uk/forms/frmservlet?config=tag"
       }
     }
   }

--- a/powershell/Scripts/UserDataScripts/NomisClient.ps1
+++ b/powershell/Scripts/UserDataScripts/NomisClient.ps1
@@ -19,8 +19,6 @@ $GlobalConfig = @{
       "c-dev.development.nomis.service.justice.gov.uk/forms/frmservlet?config=tag",
       "c-qa11g.development.nomis.service.justice.gov.uk/forms/frmservlet?config=tag",
       "c-qa11r.development.nomis.service.justice.gov.uk/forms/frmservlet?config=tag",
-      "dev-nomis-web19c-a.development.nomis.service.justice.gov.uk/forms/frmservlet?config=tag",
-      "dev-nomis-web19c-b.development.nomis.service.justice.gov.uk/forms/frmservlet?config=tag",
       "qa11g-nomis-web12-a.development.nomis.service.justice.gov.uk/forms/frmservlet?config=tag"
     )
     "IETrustedDomains" = @(
@@ -32,7 +30,6 @@ $GlobalConfig = @{
       "Prison-Nomis DEV" = "https://c-dev.development.nomis.service.justice.gov.uk/forms/frmservlet?config=tag"
       "Prison-Nomis QA11G" = "https://c-qa11g.development.nomis.service.justice.gov.uk/forms/frmservlet?config=tag"
       "Prison-Nomis QA11R" = "https://c-qa11r.development.nomis.service.justice.gov.uk/forms/frmservlet?config=tag"
-      "Prison-Nomis WEB19C-B" = "https://dev-nomis-web19c-b.development.nomis.service.justice.gov.uk/forms/frmservlet?config=tag"
     }
   }
   "nomis-test" = @{


### PR DESCRIPTION
A few changes for the nomis web12c project:
- updated the template file (this now includes an additional reporting component)
- fixed permission on Xauthority file
- removed unused nomis URLs from JumpServer StartMenu