### PR TITLE
Nomis: weblogic release file fix

### DIFF
--- a/ansible/roles/nomis-weblogic/tasks/install-nomis-releases.yml
+++ b/ansible/roles/nomis-weblogic/tasks/install-nomis-releases.yml
@@ -132,6 +132,17 @@
   loop: "{{ patches_files_found.results|default([]) }}"
   when: item.matched > 0
 
+- name: Update /home/oracle/tag_release_detail to record DB only releases
+  become_user: oracle
+  ansible.builtin.lineinfile:
+    path: /home/oracle/tag_release_detail
+    line: "{{ item.item }}"
+    create: yes
+  loop_control:
+    label: "{{ item.item }}"
+  loop: "{{ patches_files_found.results|default([]) }}"
+  when: item.matched == 0
+
 - block:
     - name: Deploy tag release
       become_user: oracle

--- a/ansible/roles/nomis-weblogic/tasks/install-nomis-releases.yml
+++ b/ansible/roles/nomis-weblogic/tasks/install-nomis-releases.yml
@@ -45,7 +45,7 @@
     path: /home/oracle/tag_release_detail
     line: "{{ item }}"
     create: yes
-  check_mode: false
+  check_mode: true
   register: tag_release_detail
   loop: "{{ nomis_releases | unique }}"
 

--- a/ansible/roles/nomis-weblogic/tasks/install-nomis-releases.yml
+++ b/ansible/roles/nomis-weblogic/tasks/install-nomis-releases.yml
@@ -124,7 +124,7 @@
   register: patches_files_found
   loop: "{{ download_release|default([]) }}"
 
-- name: Set apply fact to releases containing FormFormsSources, Static, Reports files
+- name: Set apply fact to releases containing FormsSources, Static, Reports files
   set_fact:
     apply_release: "{{ apply_release|default([]) + [item.item] }}"
   loop_control:


### PR DESCRIPTION
Fix to nomis weblogic release process - the tag_release_detail file wasn't being populated correctly