### PR TITLE
Dba 993 monitoring check packs

### DIFF
--- a/ansible/roles/oracle-oms-setup/templates/create_slack_notification_package.sql.j2
+++ b/ansible/roles/oracle-oms-setup/templates/create_slack_notification_package.sql.j2
@@ -67,6 +67,23 @@ create or replace PACKAGE BODY sysman.slack_notification AS
           l_target_type := l_src_info_array(i).target.target_type;
           l_target_timezone := l_src_info_array(i).target.target_timezone;
           l_hostname := l_src_info_array(i).target.host_name;
+          -- Check if host has any DBs with Diagnostics Pack enabled, which allows notifications.
+          DECLARE
+            l_diag_enabled NUMBER;
+          BEGIN
+            SELECT COUNT(*) INTO l_diag_enabled
+            FROM sysman.mgmt$target db
+            JOIN sysman.mgmt$target os ON db.host_name = os.target_name
+            JOIN sysman.mgmt_license_view lic ON db.target_name = lic.target_name
+            WHERE db.target_type = 'oracle_database'
+              AND lic.pack_name = 'db_diag'
+              AND os.target_type = 'host'
+              AND os.target_name = l_hostname;
+            -- no pack found, so no notification
+            IF l_diag_enabled = 0 THEN
+              RETURN;
+            END IF;
+          END;
         END IF;
       END LOOP;
     END IF;
@@ -215,6 +232,25 @@ create or replace PACKAGE BODY sysman.slack_notification AS
         l_categories_new := (l_categories_new|| c || ' - ' || l_categories(c)||',');
       END LOOP;
     END IF;
+
+    l_hostname := event_msg.event_payload.target.host_name;
+    -- Check if host has any DBs with Diagnostics Pack enabled, which allows notifications.
+    DECLARE
+      l_diag_enabled NUMBER;
+    BEGIN
+      SELECT COUNT(*) INTO l_diag_enabled
+      FROM sysman.mgmt$target db
+      JOIN sysman.mgmt$target os ON db.host_name = os.target_name
+      JOIN sysman.mgmt_license_view lic ON db.target_name = lic.target_name
+      WHERE db.target_type = 'oracle_database'
+        AND lic.pack_name = 'db_diag'
+        AND os.target_type = 'host'
+        AND os.target_name = l_hostname;
+      -- no pack found, so no notification
+      IF l_diag_enabled = 0 THEN
+        RETURN;
+      END IF;
+    END;
 
     -- Build message with event notification attributes
 

--- a/ansible/roles/oracle-oms-setup/templates/rule_set.xml.j2
+++ b/ansible/roles/oracle-oms-setup/templates/rule_set.xml.j2
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <RuleSet xmlns="http://www.oracle.com/EnterpriseManager/Incident/Rules" isEnabled="true" isGlobalCompressionEnabled="false" isOOB="false" EMVersion="13.5.0.0.0">
    <RulesetName>HMPPS OEM Rule Set</RulesetName>
-   <RulesetDescription>Rule set to create and manage hmpps-oem incidents</RulesetDescription>
+   <RulesetDescription>Rule set to create and manage {{ application }} incidents</RulesetDescription>
    <TargetSelectionType>ALL_TARGETS</TargetSelectionType>
    <SourceSelectionType>TARGET</SourceSelectionType>
    <Rule isEnabled="true" isGlobalCompressionEnabled="true" ruleType="EVENT">
@@ -593,13 +593,6 @@
       <RuleName>Notification rule to slack</RuleName>
       <RuleDescription>Rule to notify slack of incidents</RuleDescription>
       <AttributeForRule>
-         <AttrValue>MissionCritical</AttrValue>
-         <AttrValue>Production</AttrValue>
-         <OperatorCode>IN</OperatorCode>
-         <Type>SYSTEM_ATTRIBUTE</Type>
-         <AttrName>sys_target_lifecycle_status</AttrName>
-      </AttributeForRule>
-      <AttributeForRule>
          <AttrValue>Incident creation rule for high-availability events</AttrValue>
          <AttrValue>Create incident for critical metric alerts</AttrValue>
          <AttrValue>Clear metric alert events older than 7 days</AttrValue>
@@ -641,18 +634,24 @@
       <RuleName>Send Slack Notification for All Data Guard Incidents</RuleName>
       <RuleDescription>Additional Slack Notification step in addition to all other incidents for the Data Guard Status metric. For Data Guard we want a notification for Warnings in addition to Errors, as these are more operationally significant than warnings for other metrics.</RuleDescription>
       <AttributeForRule>
-         <AttrValue>MissionCritical</AttrValue>
-         <AttrValue>Production</AttrValue>
-         <OperatorCode>IN</OperatorCode>
-         <Type>SYSTEM_ATTRIBUTE</Type>
-         <AttrName>sys_target_lifecycle_status</AttrName>
-      </AttributeForRule>
-      <AttributeForRule>
          <AttrValue>Data Guard Status</AttrValue>
          <OperatorCode>IN</OperatorCode>
          <Type>SYSTEM_ATTRIBUTE</Type>
          <AttrName>sys_creation_rule_guid</AttrName>
       </AttributeForRule>
+      <RuleCondAction>
+         <ActionTypes>ADVANCED_NOTIFICATION</ActionTypes>
+         <IsRepeat>0</IsRepeat>
+         <RepeatFreq>0</RepeatFreq>
+         <RepeatCount>0</RepeatCount>
+         <IsDuration>0</IsDuration>
+         <Duration>0</Duration>
+         <DurationUnit>2</DurationUnit>
+         <RuleAdvNotification>
+            <AppliedTo>INCIDENT</AppliedTo>
+            <DeviceName>SLACK_NOTIFICATION:PLSQL</DeviceName>
+         </RuleAdvNotification>
+      </RuleCondAction>
    </Rule>
 </RuleSet>
 


### PR DESCRIPTION
Remove Lifecycle Status check from Rule Set as notification validation is carried out in the package and monitoring script.
Add check to package and monitoring script to see if the host that the target relates to has a database on it with the Diagnostics pack. If the host has a db with the pack then we can use the native OEM Notification function, otherwise we can't.