### PR TITLE
TM-1398: fix Set-LoginText powershell

### DIFF
--- a/powershell/Scripts/Common/Set-LoginText.ps1
+++ b/powershell/Scripts/Common/Set-LoginText.ps1
@@ -1,24 +1,25 @@
-function Set-LoginText {
-    param (
-        [Parameter(Mandatory)]
-        [hashtable]$Config
-    )
-    # Apply to all environments that aren't on the domain
-    $ErrorActionPreference = "Stop"
-    Write-Output "Add Legal Notice"
+$ErrorActionPreference = "Stop"
+$RegistryPath = "HKLM:\Software\Microsoft\Windows NT\CurrentVersion\winlogon"
+$LegalNoticeCaption = "IMPORTANT"
+$LegalNoticeText = "This system is restricted to authorized users only. Individuals who attempt unauthorized access will be prosecuted. If you are unauthorized terminate access now. Click OK to indicate your acceptance of this information"
 
-    $RegistryPath = "HKLM:\Software\Microsoft\Windows NT\CurrentVersion\winlogon"
-    $LegalNoticeCaption = "IMPORTANT"
-    $LegalNoticeText = "This system is restricted to authorized users only. Individuals who attempt unauthorized access will be prosecuted. If you are unauthorized terminate access now. Click OK to indicate your acceptance of this information"
+if (-NOT (Test-Path $RegistryPath)) {
+    Write-Output "Creating Login registry item: $RegistryPath"
+    New-Item -Path $RegistryPath -Force | Out-Null
+}
 
-    if (-NOT (Test-Path $RegistryPath)) {
-        Write-Output " - Registry path does not exist, creating"
-        New-Item -Path $RegistryPath -Force | Out-Null
-    }
+$ItemProperty = Get-ItemProperty -Path $RegistryPath -Name LegalNoticeCaption -ErrorAction SilentlyContinue
+if ($null -eq $ItemProperty -or $ItemProperty.LegalNoticeCaption -ne $LegalNoticeCaption) {
+    Write-Output "Setting Login Legal Notice Caption"
+    New-ItemProperty -Path $RegistryPath -Name LegalNoticeCaption -Value $LegalNoticeCaption -PropertyType String -Force | Out-Null
+} else {
+    Write-Verbose "Login Legal Notice Caption already set"
+}
 
-    Write-Output " - Set Legal Notice Caption"
-    New-ItemProperty -Path $RegistryPath -Name LegalNoticeCaption -Value $LegalNoticeCaption -PropertyType String -Force
-
-    Write-Output " - Set Legal Notice Text"
-    New-ItemProperty -Path $RegistryPath -Name LegalNoticeText -Value $LegalNoticeText -PropertyType String -Force
+$ItemProperty = Get-ItemProperty -Path $RegistryPath -Name LegalNoticeText -ErrorAction SilentlyContinue
+if ($null -eq $ItemProperty -or $ItemProperty.LegalNoticeText -ne $LegalNoticeText) {
+    Write-Output "Setting Loging Legal Notice Text"
+    New-ItemProperty -Path $RegistryPath -Name LegalNoticeText -Value $LegalNoticeText -PropertyType String -Force | Out-Null
+} else {
+    Write-Verbose "Login Legal Notice Text already set"
 }


### PR DESCRIPTION
Refactor - was just a function but wasn't actually called. 
Updated so output is only used when a change is made. Use verbose to indicate no changes made.