### PR TITLE
Increase threshold for TOTAL_ERRORS in ME$AWSDMS_APPLY_EXCEPTIONS

### DIFF
--- a/ansible/group_vars/environment_name_delius_core_development_dev_all.yml
+++ b/ansible/group_vars/environment_name_delius_core_development_dev_all.yml
@@ -153,3 +153,9 @@ all_oem_metrics:
         warning_threshold , 2000
         critical_threshold , 5000
         END_RECORD 3
+        START_RECORD 4
+        metric , ME$AWSDMS_APPLY_EXCEPTIONS
+        column , TOTAL_ERRORS
+        warning_threshold , 100000
+        critical_threshold , 500000
+        END_RECORD 4


### PR DESCRIPTION
We can ignore errors in dev --> test replication since these databases are not in sync and multiple apply errors can be expected due to data differences.