### PR TITLE
TM-1518: remove crypto from RHEL6 requirements as it is broken

### DIFF
--- a/ansible/requirements.rhel6.yml
+++ b/ansible/requirements.rhel6.yml
@@ -25,6 +25,7 @@ collections:
   - name: community.windows
     source: https://galaxy.ansible.com
     version: 1.12.0
-  - name: community.crypto
-    source: https://galaxy.ansible.com
-    version: 2.15.0
+  # broken
+  # - name: community.crypto
+  #   source: https://galaxy.ansible.com
+  #   version: 2.15.0


### PR DESCRIPTION
Commenting out crypto requirement as it seems broken on RHEL6. This is only used by OEM and NDH at the moment which are RHEL7+