### PR TITLE
TM-1499: set selinux to permissive on oracle DBs

### DIFF
--- a/ansible/group_vars/server_type_csr_db.yml
+++ b/ansible/group_vars/server_type_csr_db.yml
@@ -53,6 +53,7 @@ server_type_roles_list:
   - set-ec2-hostname
   - domain-search
   - ansible-script
+  - selinux-config
   - epel
   - tcp-keepalive
   - oracle-19c

--- a/ansible/group_vars/server_type_nomis_db.yml
+++ b/ansible/group_vars/server_type_nomis_db.yml
@@ -6,6 +6,7 @@ server_type_roles_list:
   - set-ec2-hostname
   - domain-search
   - ansible-script
+  - selinux-config
   - epel
   - sshd-config
   - oracle-11g

--- a/ansible/group_vars/server_type_nomis_db19c.yml
+++ b/ansible/group_vars/server_type_nomis_db19c.yml
@@ -4,6 +4,7 @@ server_type_roles_list:
   - set-ec2-hostname
   - domain-search
   - ansible-script
+  - selinux-config
   - epel
   - oracle-19c
   - oracle-secure-backup

--- a/ansible/group_vars/server_type_oasys_db.yml
+++ b/ansible/group_vars/server_type_oasys_db.yml
@@ -24,6 +24,7 @@ roles_list:
   - amazon-ssm-agent
   - amazon-cli
   - ansible-script
+  - selinux-config
   - epel
   # - hugepages has issues
   - disks

--- a/ansible/group_vars/server_type_onr_db.yml
+++ b/ansible/group_vars/server_type_onr_db.yml
@@ -24,6 +24,7 @@ roles_list:
   - amazon-ssm-agent
   - amazon-cli
   - ansible-script
+  - selinux-config
   - epel
   - disks
   - azure-cli


### PR DESCRIPTION
Selinux permissive mode is set inconsistently across Oracle DBs. In enforcing mode, some DBA housekeeping tasks fail such as log rotation. Setting to permissive.