### PR TITLE
Update get_alert_log_locations.yml

### DIFF
--- a/ansible/roles/oracle-db-housekeeping/tasks/get_alert_log_locations.yml
+++ b/ansible/roles/oracle-db-housekeeping/tasks/get_alert_log_locations.yml
@@ -39,6 +39,7 @@
   become: true
   become_user: oracle
   changed_when: false
+  ignore_errors: yes
   loop_control:
     loop_var: sid_item
 
@@ -46,6 +47,7 @@
   set_fact:
     list_of_alert_log_locations: "{{ list_of_alert_log_locations + [item.stdout] }}"
   with_items: "{{ alert_log_location.results }}"
+  when: not item.failed
 
 - name: Display List of Alert Log Locations
   debug: var=list_of_alert_log_locations


### PR DESCRIPTION
Do not fail when there is a failure e.g. due to the database being down. Omit the entry of any failed databases from the config. See https://dsdmoj.atlassian.net/browse/DBA-1047 for further details of issue