### PR TITLE
TM-1499: enable listener logs to cloudwatch for csr oem

### DIFF
--- a/ansible/group_vars/server_type_csr_db.yml
+++ b/ansible/group_vars/server_type_csr_db.yml
@@ -69,6 +69,8 @@ server_type_roles_list:
 # the below vars are defined in multiple groups.  Keep the values the same to avoid unexpected behaviour
 roles_list: "{{ (ami_roles_list | default([]) | difference(server_type_roles_list | default([]))) + (server_type_roles_list | default([])) }}"
 
+amazon_cloudwatch_agent_config_name: oracle-db.json.j2
+
 # Oracle common variables
 oracle_install_user: oracle
 oracle_install_group: oinstall

--- a/ansible/group_vars/server_type_hmpps_oem.yml
+++ b/ansible/group_vars/server_type_hmpps_oem.yml
@@ -55,6 +55,7 @@ server_type_roles_list:
   - set-ec2-hostname
   - domain-search
   - ansible-script
+  - selinux-config
   - epel
   - oracle-19c
   - oracle-secure-backup
@@ -62,11 +63,14 @@ server_type_roles_list:
   - oracle-db-backup
   - oracle-db-housekeeping
   - oracle-oms-setup
+  - amazon-cloudwatch-agent
   - collectd-service-metrics
   - collectd-oracle-db-connected
   - collectd-textfile-monitoring
   - collectd-endpoint-monitoring
   - oracle-db-refresh
+
+amazon_cloudwatch_agent_config_name: oracle-db.json.j2
 
 collectd_monitored_services_servertype:
   - metric_name: service_status_os

--- a/ansible/group_vars/server_type_nomis_db.yml
+++ b/ansible/group_vars/server_type_nomis_db.yml
@@ -27,6 +27,7 @@ server_type_roles_list:
 # the below vars are defined in multiple groups.  Keep the values the same to avoid unexpected behaviour
 roles_list: "{{ (ami_roles_list | default([]) | difference(server_type_roles_list | default([]))) + (server_type_roles_list | default([])) }}"
 
+amazon_cloudwatch_agent_config_name: oracle-db.json.j2
 xsiam_agent_state: "{{ xsiam_agent_db_state }}" # set in environment group_vars
 
 # Oracle common variables


### PR DESCRIPTION
Use updated cloudwatch config for all oracle DBs including CSR and hmpps-oem. Already enabled in nomis and oasys