### PR TITLE
TM-1239: ncr: improve bip monitoring

### DIFF
--- a/ansible/group_vars/server_type_ncr_bip_cms.yml
+++ b/ansible/group_vars/server_type_ncr_bip_cms.yml
@@ -117,6 +117,7 @@ timezone: "Europe/London"
 filesystems_mount: "{{ bip_filesystems_mount|default([]) }}"
 oracle_client_conf: "{{ sap_bip_oracle_client_conf }}"
 sap_bip_is_cms: true
+sap_bip_copy_bip_control_script: true
 
 collectd_monitored_services_servertype:
   - metric_name: service_status_os

--- a/ansible/group_vars/server_type_ncr_webadmin.yml
+++ b/ansible/group_vars/server_type_ncr_webadmin.yml
@@ -110,10 +110,11 @@ collectd_monitored_services_servertype:
     shell_cmd: "systemctl is-active sapbobj && pgrep java -u bobj"
   - metric_name: service_status_app
     metric_dimension: expected_biprws_serverlist
-    shell_cmd: "/usr/local/bin/bip_control.sh -as diff server-list exp biprws +Running 2>&1 | logger -p local3.info -t collectd_service_metrics_bip"
+    shell_cmd: "/usr/local/bin/bip_control.sh -as diff server-list exp biprws Running 2>&1 | logger -p local3.info -t collectd_service_metrics_bip"
 
 sap_bip_responsefile: response.webadmin.ini
 sap_bip_copy_bip_control_script: true
+sap_web_biprws_localhost_url: http://localhost:7010/biprws
 sap_web_disable_infoview: "false"
 sap_web_disable_cmcapp: "false"
 sap_web_java_opts: "{{ sap_web_conf.sap_web_java_opts }}"

--- a/ansible/group_vars/server_type_ncr_webadmin.yml
+++ b/ansible/group_vars/server_type_ncr_webadmin.yml
@@ -108,8 +108,12 @@ collectd_monitored_services_servertype:
   - metric_name: service_status_app
     metric_dimension: service_sapbobj
     shell_cmd: "systemctl is-active sapbobj && pgrep java -u bobj"
+  - metric_name: service_status_app
+    metric_dimension: expected_biprws_serverlist
+    shell_cmd: "/usr/local/bin/bip_control.sh -as diff server-list exp biprws +Running 2>&1 | logger -p local3.info -t collectd_service_metrics_bip"
 
 sap_bip_responsefile: response.webadmin.ini
+sap_bip_copy_bip_control_script: true
 sap_web_disable_infoview: "false"
 sap_web_disable_cmcapp: "false"
 sap_web_java_opts: "{{ sap_web_conf.sap_web_java_opts }}"

--- a/ansible/group_vars/server_type_onr_web.yml
+++ b/ansible/group_vars/server_type_onr_web.yml
@@ -101,7 +101,6 @@ disks_mount:
 timezone: "Europe/London"
 
 sap_bip_responsefile: response.web.ini
-sap_web_server_type: web
 sap_web_disable_infoview: "false"
 sap_web_disable_cmcapp: "false"
 sap_web_server_7777_maxthreads: 1000

--- a/ansible/roles/sap-bip-4/defaults/main.yml
+++ b/ansible/roles/sap-bip-4/defaults/main.yml
@@ -16,6 +16,7 @@ sap_host_agent_exe: SAPCAR_1115-70006178.EXE
 
 # define environment specific settings in group_vars
 #sap_environment:  # t1, t2 etc
+sap_bip_copy_bip_control_script: false
 sap_bip_is_cms: false
 sap_bip_is_new_install: false # gets set to true if secret set to 'newinstall'
 #sap_bip_auditing_db_server:
@@ -65,7 +66,6 @@ sap_bip_secretsmanager_passwords:
     users:
       - Administrator: auto
 
-sap_web_server_type: web # set to webadmin if dedicated to admin
 sap_web_disable_infoview: "false"
 sap_web_disable_cmcapp: "false"
 sap_web_context_cachemaxsize: 500000

--- a/ansible/roles/sap-bip-4/defaults/main.yml
+++ b/ansible/roles/sap-bip-4/defaults/main.yml
@@ -82,6 +82,7 @@ sap_web_apps:
   - dswsbobje
   - webi-websetup
 # sap_bip_rws_url:  # set in group vars, e.g. https://admin.preproduction.reporting.nomis.service.justice.gov.uk/biprws to enable biprws helper script
+# sap_web_biprws_localhost_url:  # for bip_control.sh script, use localhost instead of LB
 sap_web_tomcat_restart_enabled: true
 sap_web_tomcat_restart_cron:
   minute: "0"

--- a/ansible/roles/sap-bip-4/tasks/install_bip_control_script.yml
+++ b/ansible/roles/sap-bip-4/tasks/install_bip_control_script.yml
@@ -1,0 +1,12 @@
+---
+- name: Copy bip control script
+  ansible.builtin.template:
+    src: "home/bobj/bip_control.sh"
+    dest: "/{{ item }}"
+    owner: bobj
+    group: binstall
+    mode: 0755
+  loop:
+    - /home/bobj/bip_control.sh
+    - /usr/local/bin/bip_control.sh
+  when: sap_bip_copy_bip_control_script

--- a/ansible/roles/sap-bip-4/tasks/main.yml
+++ b/ansible/roles/sap-bip-4/tasks/main.yml
@@ -67,6 +67,13 @@
         - ec2provision
         - sap_bip_install_systemd_service
 
+    - import_tasks: install_bip_control_script.yml
+      tags:
+        - amibuild
+        - ec2provision
+        - ec2patch
+        - sap_bip_install_control_script
+
     - import_tasks: update_secrets.yml
       tags:
         - ec2provision

--- a/ansible/roles/sap-bip-4/tasks/setup_bobj.yml
+++ b/ansible/roles/sap-bip-4/tasks/setup_bobj.yml
@@ -19,17 +19,6 @@
     - home/bobj/archive_logs.sh
     - home/bobj/sap_restart.sh
 
-- name: Copy bobj cmc scripts
-  ansible.builtin.template:
-    src: "{{ item }}"
-    dest: "/{{ item }}"
-    owner: bobj
-    group: binstall
-    mode: 0755
-  loop:
-    - home/bobj/bip_control.sh
-  when: sap_bip_is_cms
-
 - name: Copy bobj biprws helper scripts
   ansible.builtin.template:
     src: "{{ item }}"

--- a/ansible/roles/sap-bip-4/templates/home/bobj/bip_control.sh
+++ b/ansible/roles/sap-bip-4/templates/home/bobj/bip_control.sh
@@ -341,6 +341,14 @@ set_env_biprws_logon_token() {
   BIPRWS_LOGON_TOKEN="\"$logon_token\""
 }
 
+biprws_logoff() {
+  if [[ -n $BIPRWS_LOGON_TOKEN ]]; then
+    debug "curl https://$ADMIN_URL/biprws/v1/logoff"
+    curl -Ss -m "$CURL_TIMEOUT_BIPRWS_LOGOFF" -H "Content-Type: application/json" -H "Accept: application/json" -H "X-SAP-LogonToken: $BIPRWS_LOGON_TOKEN" --data "" "https://$ADMIN_URL/biprws/v1/logoff"
+    BIPRWS_LOGON_TOKEN=
+  fi
+}
+
 biprws_get() {
   local uri
 
@@ -763,8 +771,10 @@ do_biprws() {
   if [[ $1 == "server-list" ]]; then
     shift
     if ! pages_json=$(biprws_get_pages "https://$ADMIN_URL/biprws/bionbi/server/list"); then
+      biprws_logoff
       return 1
     fi
+    biprws_logoff
     if [[ $FORMAT == "json" ]]; then
       if (( $# != 0 )); then
         error "Cannot use json format with server-list filter"

--- a/ansible/roles/sap-bip-4/templates/home/bobj/bip_control.sh
+++ b/ansible/roles/sap-bip-4/templates/home/bobj/bip_control.sh
@@ -971,9 +971,9 @@ do_diff() {
       diff <(echo "$a") <(echo "$b")
     else
       # for checking if all expected servers are running, i.e. not a full diff
-      DIFF=$(comm -23 <(echo "$a" | sort) <(echo "$b" | sort))
-      echo "$DIFF"
+      DIFF=$(comm -23 <(echo "$a" | sort) <(echo "$b" | sort) | cut -f1)
       if [[ -n $DIFF ]]; then
+        echo Following BIP servers not Running: $DIFF
         return 1
       fi
     fi


### PR DESCRIPTION
Added monitoring to check all the expected SAP services are running. This is enabled on the webadmin server in preprod and prod only:
- remove unused variable sap_web_server_type
- add option to install bip_control.sh script on webadmin server
- also install it in /usr/local/bin so accessible by collectd scripts
- use localhost for the API rather than the load balancer endpoint