### PR TITLE
TM-1637: ncr: improve fsx monitoring

### DIFF
--- a/ansible/group_vars/environment_name_nomis_combined_reporting_preproduction.yml
+++ b/ansible/group_vars/environment_name_nomis_combined_reporting_preproduction.yml
@@ -173,6 +173,7 @@ bip_filesystems_mount:
     opts: nfsvers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2,noresvport,nofail
     src: "eu-west-2a.fs-05865134b09d24a7e.efs.eu-west-2.amazonaws.com:/"
     metric_dimension: pp_ncr_sap_share
+    maintenance_window:
   - dir: /NART
     uid: bobj
     gid: binstall
@@ -180,6 +181,7 @@ bip_filesystems_mount:
     opts: vers=3.0,_netdev,nofail,uid=1201,gid=1201,dir_mode=0755,file_mode=0755,credentials=/root/.filesystems/azure.hmpp.root.creds
     src: //fslinux.azure.hmpp.root/NART$
     metric_dimension: NART
+    maintenance_window: "04.0400-04.0430"
 
 webadmin_filesystems_mount:
   - dir: /NART
@@ -189,3 +191,4 @@ webadmin_filesystems_mount:
     opts: vers=3.0,_netdev,nofail,uid=1201,gid=1201,dir_mode=0755,file_mode=0755,credentials=/root/.filesystems/azure.hmpp.root.creds
     src: //fslinux.azure.hmpp.root/NART$
     metric_dimension: NART
+    maintenance_window:

--- a/ansible/group_vars/environment_name_nomis_combined_reporting_preproduction.yml
+++ b/ansible/group_vars/environment_name_nomis_combined_reporting_preproduction.yml
@@ -181,7 +181,7 @@ bip_filesystems_mount:
     opts: vers=3.0,_netdev,nofail,uid=1201,gid=1201,dir_mode=0755,file_mode=0755,credentials=/root/.filesystems/azure.hmpp.root.creds
     src: //fslinux.azure.hmpp.root/NART$
     metric_dimension: NART
-    maintenance_window: "04.0400-04.0430"
+    maintenance_window: "4.0400-4.0430" # Thu 4am UTC
 
 webadmin_filesystems_mount:
   - dir: /NART

--- a/ansible/group_vars/environment_name_nomis_combined_reporting_production.yml
+++ b/ansible/group_vars/environment_name_nomis_combined_reporting_production.yml
@@ -195,6 +195,7 @@ bip_filesystems_mount:
     opts: nfsvers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2,noresvport,nofail
     src: "fs-030a75a6d02aa86ef.efs.eu-west-2.amazonaws.com:/"
     metric_dimension: pd_ncr_sap_share
+    maintenance_window:
   - dir: /NART
     uid: bobj
     gid: binstall
@@ -202,6 +203,7 @@ bip_filesystems_mount:
     opts: vers=3.0,_netdev,nofail,uid=1201,gid=1201,dir_mode=0755,file_mode=0755,credentials=/root/.filesystems/azure.hmpp.root.creds
     src: //fslinux.azure.hmpp.root/NART$
     metric_dimension: NART
+    maintenance_window: "04.0400-04.0430"
 
 webadmin_filesystems_mount:
   - dir: /NART
@@ -211,3 +213,4 @@ webadmin_filesystems_mount:
     opts: vers=3.0,_netdev,nofail,uid=1201,gid=1201,dir_mode=0755,file_mode=0755,credentials=/root/.filesystems/azure.hmpp.root.creds
     src: //fslinux.azure.hmpp.root/NART$
     metric_dimension: NART
+    maintenance_window:

--- a/ansible/group_vars/environment_name_nomis_combined_reporting_production.yml
+++ b/ansible/group_vars/environment_name_nomis_combined_reporting_production.yml
@@ -203,7 +203,7 @@ bip_filesystems_mount:
     opts: vers=3.0,_netdev,nofail,uid=1201,gid=1201,dir_mode=0755,file_mode=0755,credentials=/root/.filesystems/azure.hmpp.root.creds
     src: //fslinux.azure.hmpp.root/NART$
     metric_dimension: NART
-    maintenance_window: "04.0400-04.0430"
+    maintenance_window: "4.0400-4.0430" # Thu 4am UTC
 
 webadmin_filesystems_mount:
   - dir: /NART

--- a/ansible/group_vars/environment_name_nomis_combined_reporting_test.yml
+++ b/ansible/group_vars/environment_name_nomis_combined_reporting_test.yml
@@ -163,3 +163,4 @@ bip_filesystems_mount:
     opts: nfsvers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2,noresvport,nofail
     src: "eu-west-2a.fs-0a9a52ec4ffec21cc.efs.eu-west-2.amazonaws.com:/"
     metric_dimension: t1_ncr_sap_share
+    maintenance_window:

--- a/ansible/group_vars/environment_name_oasys_national_reporting_preproduction.yml
+++ b/ansible/group_vars/environment_name_oasys_national_reporting_preproduction.yml
@@ -25,7 +25,7 @@ bip_filesystems_mount:
     opts: vers=3.0,_netdev,nofail,uid=1201,gid=1201,dir_mode=0755,file_mode=0755,credentials=/root/.filesystems/azure.hmpp.root.creds
     src: //fslinux.azure.hmpp.root/NART$
     metric_dimension: NART
-    maintenance_window: "04.0400-04.0430"
+    maintenance_window: "4.0400-4.0430" # Thu 4am UTC
 
 db_configs:
   RCVCAT:

--- a/ansible/group_vars/environment_name_oasys_national_reporting_preproduction.yml
+++ b/ansible/group_vars/environment_name_oasys_national_reporting_preproduction.yml
@@ -17,6 +17,7 @@ bip_filesystems_mount:
     opts: nfsvers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2,noresvport,nofail
     src: "eu-west-2a.fs-0c31bfebea0befa14.efs.eu-west-2.amazonaws.com:/"
     metric_dimension: pp_onr_sap_share
+    maintenance_window:
   - dir: /NART
     uid: bobj
     gid: binstall
@@ -24,6 +25,7 @@ bip_filesystems_mount:
     opts: vers=3.0,_netdev,nofail,uid=1201,gid=1201,dir_mode=0755,file_mode=0755,credentials=/root/.filesystems/azure.hmpp.root.creds
     src: //fslinux.azure.hmpp.root/NART$
     metric_dimension: NART
+    maintenance_window: "04.0400-04.0430"
 
 db_configs:
   RCVCAT:

--- a/ansible/group_vars/environment_name_oasys_national_reporting_production.yml
+++ b/ansible/group_vars/environment_name_oasys_national_reporting_production.yml
@@ -17,6 +17,7 @@ bip_filesystems_mount:
     opts: nfsvers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2,noresvport,nofail
     src: "fs-082eb379ce8caf385.efs.eu-west-2.amazonaws.com:/"
     metric_dimension: pd_onr_sap_share
+    maintenance_window:
   - dir: /NART
     uid: bobj
     gid: binstall
@@ -24,6 +25,7 @@ bip_filesystems_mount:
     opts: vers=3.0,_netdev,nofail,uid=1201,gid=1201,dir_mode=0755,file_mode=0755,credentials=/root/.filesystems/azure.hmpp.root.creds
     src: //fslinux.azure.hmpp.root/NART$
     metric_dimension: NART
+    maintenance_window: "04.0400-04.0430"
 
 db_configs:
   RCVCAT:

--- a/ansible/group_vars/environment_name_oasys_national_reporting_production.yml
+++ b/ansible/group_vars/environment_name_oasys_national_reporting_production.yml
@@ -25,7 +25,7 @@ bip_filesystems_mount:
     opts: vers=3.0,_netdev,nofail,uid=1201,gid=1201,dir_mode=0755,file_mode=0755,credentials=/root/.filesystems/azure.hmpp.root.creds
     src: //fslinux.azure.hmpp.root/NART$
     metric_dimension: NART
-    maintenance_window: "04.0400-04.0430"
+    maintenance_window: "4.0400-4.0430" # Thu 4am UTC
 
 db_configs:
   RCVCAT:

--- a/ansible/group_vars/environment_name_oasys_national_reporting_test.yml
+++ b/ansible/group_vars/environment_name_oasys_national_reporting_test.yml
@@ -11,6 +11,7 @@ bip_filesystems_mount:
     opts: nfsvers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2,noresvport,nofail
     src: "eu-west-2a.fs-0089d47e90f353ea0.efs.eu-west-2.amazonaws.com:/"
     metric_dimension: t2_onr_sap_share
+    maintenance_window:
 
 db_configs:
   RCVCAT:

--- a/ansible/roles/collectd-endpoint-monitoring/templates/collectd_endpoint_monitoring.sh.j2
+++ b/ansible/roles/collectd-endpoint-monitoring/templates/collectd_endpoint_monitoring.sh.j2
@@ -121,7 +121,7 @@ while true; do
     args=(${ENDPOINTS[$i]})
     timeranges="${args[4]}"
     if [[ -n $timeranges ]]; then
-      now_dayhourminute=$(date +%u%H%M)
+      now_dayhourminute=$(date +%u.%H%M)
       if ! check_within_timeranges "$now_dayhourminute" "$timeranges"; then
         continue
       fi

--- a/ansible/roles/collectd-textfile-monitoring/tasks/configure_collectd.yml
+++ b/ansible/roles/collectd-textfile-monitoring/tasks/configure_collectd.yml
@@ -5,7 +5,6 @@
     owner: root
     group: root
     state: directory
-    recurse: yes
   loop:
     - /opt/textfile_monitoring
 

--- a/ansible/roles/filesystems/tasks/mount.yml
+++ b/ansible/roles/filesystems/tasks/mount.yml
@@ -33,7 +33,7 @@
     name: "filesystem monitoring {{ item.metric_dimension }}"
     user: root
     minute: "*/5"
-    job: "/usr/local/bin/filesystem_keepalive.sh '{{ item.src }}' '{{ item.metric_dimension }}' 2>&1 | logger -p local3.info -t filesystem_keepalive.sh"
+    job: "/usr/local/bin/filesystem_keepalive.sh '{{ item.src }}' '{{ item.metric_dimension }}' '{{ item.maintenance_window }}' 2>&1 | logger -p local3.info -t filesystem_keepalive.sh"
     state: "{{ item.state | default('present') }}"
   when: item.metric_dimension is defined and item.metric_dimension|length > 0
   loop_control:


### PR DESCRIPTION
Add maintenance window for file system monitoring so we don't alarm when AWS takes FSX down for monitoring
Fix bug with textfile monitoring role, don't recurse directory creation as it breaks DB monitoring