### PR TITLE
TM-2026: delius-mis: add aws agents

### DIFF
--- a/ansible/group_vars/server_type_mis_db.yml
+++ b/ansible/group_vars/server_type_mis_db.yml
@@ -14,14 +14,16 @@ ami_roles_list:
   - get-ec2-facts # e.g. populate var ec2 metadata, instance and tag info fact called ec2
   - set-ec2-hostname # for ec2provision and ec2patch only, sets hostname within OS, hostfile and ansible.builtin.hostname
   - domain-search # for ec2provision and ec2patch only
+  - ansible-script
   - disable-ipv6 # disable ipv6 in sysctl
   - disable-firewall
   - packages # Perform any updates to existing if there are no new packages to install
-  # - amazon-ssm-agent # for ec2patch only (if version has changed)
   - disks
   - oracle-19c-delius
   - oracle-db-bootstrap
   - oracle-db-housekeeping
+  - amazon-ssm-agent # for ec2patch only (if version has changed)
+  - amazon-cloudwatch-agent
 
 # the below vars are defined in multiple groups.  Keep the values the same to avoid unexpected behaviour
 roles_list: "{{ (ami_roles_list | default([])) + (server_type_roles_list | default([])) }}"
@@ -33,6 +35,9 @@ packages_yum_update_on_build_exclude: ["oraclelinux-release*"]
 # Downloading Oracle packages
 s3_bucket: mod-platform-image-artefact-bucket20230203091453221500000001
 s3_bucket_object: hmpps/oracle-19c-software
+
+# Cloudwatch agent includes configuration for listener logs
+amazon_cloudwatch_agent_config_name: oracle-db.json.j2
 
 # Storage: volumes, partitioning and mounting
 disks_partition:

--- a/ansible/group_vars/server_type_mis_db.yml
+++ b/ansible/group_vars/server_type_mis_db.yml
@@ -22,6 +22,7 @@ ami_roles_list:
   - oracle-19c-delius
   - oracle-db-bootstrap
   - oracle-db-housekeeping
+  - amazon-cli
   - amazon-ssm-agent # for ec2patch only (if version has changed)
   - amazon-cloudwatch-agent
 


### PR DESCRIPTION
Add Cloudwatch Agent to delius-mis DBs including listener log config
Also bumped CLI & SSM Agent to latest, and installed local ansible script for running ansible directly on EC2s.convenience