### PR TITLE
TM-2098: ncr: fix provisioning

### DIFF
--- a/ansible/group_vars/server_type_ncr_bip_app.yml
+++ b/ansible/group_vars/server_type_ncr_bip_app.yml
@@ -26,6 +26,8 @@ users_and_groups_system:
       - sapprogram
   - name: sapprogram
     group: sapprogram
+    groups:
+      - binstall
     password: "{{ secretsmanager_passwords_dict['users'].passwords['sapprogram'] | password_hash('sha512', secretsmanager_passwords_dict['users'].passwords['salt']) }}"
 
 set_ec2_hostname_mode: "short" # don't rename to tags.Name

--- a/ansible/group_vars/server_type_ncr_bip_cms.yml
+++ b/ansible/group_vars/server_type_ncr_bip_cms.yml
@@ -26,6 +26,8 @@ users_and_groups_system:
       - sapprogram
   - name: sapprogram
     group: sapprogram
+    groups:
+      - binstall
     password: "{{ secretsmanager_passwords_dict['users'].passwords['sapprogram'] | password_hash('sha512', secretsmanager_passwords_dict['users'].passwords['salt']) }}"
 
 set_ec2_hostname_mode: "short" # don't rename to tags.Name

--- a/ansible/roles/ncr-bip/tasks/setup_provisioning.yml
+++ b/ansible/roles/ncr-bip/tasks/setup_provisioning.yml
@@ -27,11 +27,11 @@
     - name: Allow bobj to su to without password
       ansible.builtin.blockinfile:
         path: /etc/pam.d/su
-        insertafter: "auth.*sufficient.*pam_rootok.so"
         marker: "# {mark} blockinfile ansible managed modernisation-platform-configuration-management ncr-bip"
+        insertafter: "auth.*sufficient.*pam_rootok.so"
         block: |
-          auth [success=ignore default=1] pam_succeed_if.so user = bobj
-          auth [success=done default=1] pam_succeed_if.so use_uid user = sapprogram
+          auth [success=1 default=ignore] pam_succeed_if.so user = sapprogram
+          auth sufficient pam_succeed_if.so use_uid user = bobj
 
     - name: Create provisioning directories
       ansible.builtin.file:

--- a/ansible/roles/ncr-bip/tasks/setup_provisioning.yml
+++ b/ansible/roles/ncr-bip/tasks/setup_provisioning.yml
@@ -27,7 +27,7 @@
     - name: Allow bobj to su to without password
       ansible.builtin.blockinfile:
         path: /etc/pam.d/su
-        insertbefore: BOF  # Ensures it's at the very beginning of the file
+        insertafter: "auth.*sufficient.*pam_rootok.so"
         marker: "# {mark} blockinfile ansible managed modernisation-platform-configuration-management ncr-bip"
         block: |
           auth [success=ignore default=1] pam_succeed_if.so user = bobj

--- a/ansible/roles/ncr-bip/tasks/setup_provisioning.yml
+++ b/ansible/roles/ncr-bip/tasks/setup_provisioning.yml
@@ -15,6 +15,15 @@
       loop:
         - sapprogram
 
+    - name: Allow bobj to sudo without password
+      community.general.sudoers:
+        name: bobj-sapprogram
+        user: bobj
+        state: present
+        runas: sapprogram
+        nopassword: true
+        commands: ALL
+
     - name: Create provisioning directories
       ansible.builtin.file:
         path: "{{ item }}"

--- a/ansible/roles/ncr-bip/tasks/setup_provisioning.yml
+++ b/ansible/roles/ncr-bip/tasks/setup_provisioning.yml
@@ -15,6 +15,15 @@
       loop:
         - sapprogram
 
+    - name: Copy bobj bash profile
+      ansible.builtin.template:
+        src: "{{ item }}"
+        dest: "/{{ item }}"
+        owner: sapprogram
+        group: sapprogram
+      loop:
+        - home/sapprogram/.bash_profile
+
     - name: Allow bobj to sudo without password
       community.general.sudoers:
         name: bobj-sapprogram

--- a/ansible/roles/ncr-bip/tasks/setup_provisioning.yml
+++ b/ansible/roles/ncr-bip/tasks/setup_provisioning.yml
@@ -30,7 +30,7 @@
         marker: "# {mark} blockinfile ansible managed modernisation-platform-configuration-management ncr-bip"
         insertafter: "auth.*sufficient.*pam_rootok.so"
         block: |
-          auth [success=1 default=ignore] pam_succeed_if.so user = sapprogram
+          auth [default=1 success=ignore] pam_succeed_if.so user = sapprogram
           auth sufficient pam_succeed_if.so use_uid user = bobj
 
     - name: Create provisioning directories

--- a/ansible/roles/ncr-bip/tasks/setup_provisioning.yml
+++ b/ansible/roles/ncr-bip/tasks/setup_provisioning.yml
@@ -24,6 +24,15 @@
         nopassword: true
         commands: ALL
 
+    - name: Allow bobj to su to without password
+      ansible.builtin.blockinfile:
+        path: /etc/pam.d/su
+        insertbefore: BOF  # Ensures it's at the very beginning of the file
+        marker: "# {mark} blockinfile ansible managed modernisation-platform-configuration-management ncr-bip"
+        block: |
+          auth [success=ignore default=1] pam_succeed_if.so user = bobj
+          auth [success=done default=1] pam_succeed_if.so use_uid user = sapprogram
+
     - name: Create provisioning directories
       ansible.builtin.file:
         path: "{{ item }}"

--- a/ansible/roles/ncr-bip/templates/home/sapprogram/.bash_profile
+++ b/ansible/roles/ncr-bip/templates/home/sapprogram/.bash_profile
@@ -1,0 +1,16 @@
+# .bash_profile managed by modernisation-platform-configuration-management/ansible/roles/ncr-bip
+export JAVA_HOME={{ sap_bip_installation_directory }}/sap_bobj/enterprise_xi40/linux_x64/sapjvm
+export PATH="$JAVA_HOME/bin:$PATH"
+# Get the aliases and functions
+if [ -f ~/.bashrc ]; then
+        . ~/.bashrc
+fi
+
+# User specific environment and startup programs
+export EDITOR=vi
+export PS1="[\u@\h {{ ec2.tags['Name'] }} \W]\$ "
+
+# Set locale
+export LANG=en_GB.utf8
+export LC_ALL=en_GB.utf8
+export TZ=Europe/London

--- a/ansible/roles/ncr-bip/templates/home/sapprogram/.bash_profile
+++ b/ansible/roles/ncr-bip/templates/home/sapprogram/.bash_profile
@@ -1,5 +1,5 @@
 # .bash_profile managed by modernisation-platform-configuration-management/ansible/roles/ncr-bip
-export JAVA_HOME={{ sap_bip_installation_directory }}/sap_bobj/enterprise_xi40/linux_x64/sapjvm
+export JAVA_HOME={{ ncr_bip_installation_directory }}/sap_bobj/enterprise_xi40/linux_x64/sapjvm
 export PATH="$JAVA_HOME/bin:$PATH"
 # Get the aliases and functions
 if [ -f ~/.bashrc ]; then


### PR DESCRIPTION
Changes are:
- add sapprogram to bipinstall group. This ensures sapprogram can access files in SAP install directory that only had user+group permissions
- allow bobj user to su to sapprogram without password
- also allow bobj user to sudo to sapprogram without password, although I don't think this was strictly needed
- add default bash_profile for sapprogram with java path