### PR TITLE
Dba-1213 add rcvcat to nomis development so that dbs are registered in the rman catalog

### DIFF
--- a/ansible/group_vars/environment_name_nomis_development.yml
+++ b/ansible/group_vars/environment_name_nomis_development.yml
@@ -60,6 +60,24 @@ OMS_SERVER: dev-oem-a.hmpps-oem.hmpps-development.modernisation-platform.interna
 OEM_AGENT_VERSION: 13.5.0.0.0
 oracle_ru_patch: OCT2024
 
+# rman details
+rman_backup_script: rman_backup.sh
+recovery_catalog: 1
+recovery_catalog_server: "{{ OMS_SERVER }}"
+rman_backup_cron:
+  backup_level_0:
+    - name: rman_backup_weekly
+      weekday: "0"
+      minute: "30"
+      hour: "04"
+      # job: command generated in rman-backup-setup
+  backup_level_1:
+    - name: rman_backup_daily
+      weekday: "1-6"
+      minute: "30"
+      hour: "04"
+      # job: command generated in rman-backup-setup
+      
 # xsiam-agent: Nomis cortex XDR agent has a nomis tag baked in
 xsiam_agent_artefacts_s3_bucket_path: hmpps/XSIAM/Agents/nomis
 xsiam_agent_version: 8.8.0.133595

--- a/ansible/group_vars/environment_name_nomis_development.yml
+++ b/ansible/group_vars/environment_name_nomis_development.yml
@@ -52,7 +52,9 @@ db_configs:
     db_name: qa19c
   qa11r:
     db_name: qa11r
-
+  RCVCAT:
+    rcvcat_db_name: DEVRCVCAT
+    
 # OEM server
 OMS_SERVER: dev-oem-a.hmpps-oem.hmpps-development.modernisation-platform.internal
 OEM_AGENT_VERSION: 13.5.0.0.0

--- a/ansible/roles/oracle-db-backup/templates/db_archivelog_cleanup.sh.j2
+++ b/ansible/roles/oracle-db-backup/templates/db_archivelog_cleanup.sh.j2
@@ -1,7 +1,16 @@
 #!/bin/bash
+
+# This script deletes archivelogs for databases not being backed up. It is intended to be run as a cron job on each database server.
+# It identifies candidate databases by parsing /etc/db_backup_exclude_sids. For each candidate database, it attempts to connect using OS authentication and, if successful, runs an RMAN command to delete archivelogs older than 3 days.
+# It overrides the rman backup policy for keeping the logs e.g. until they've been backed up at least once. That policy can be checked in the database with the following query:
+# select name, value from v$rman_configuration where name like '%ARCHIVELOG DELETION POLICY%';
+
 export THISSCRIPT=$(basename $0)
 export PATH=/usr/local/bin:$PATH
 export SCRIPT_DIR=/home/oracle/admin/rman_scripts
+export LOG_DIR=${SCRIPT_DIR}/logs
+
+mkdir -p ${LOG_DIR} 2>/dev/null
 
 info () {
   T=$(date +"%D %T")
@@ -33,22 +42,58 @@ set_ora_env () {
   export NLS_DATE_FORMAT=YYMMDDHH24MI
 }
 
+  can_os_auth_connect () {
+    local sqlplus_cmd
+    sqlplus_cmd=${ORACLE_HOME}/bin/sqlplus
+    if [ ! -x "${sqlplus_cmd}" ]
+    then
+      warning "Skipping ${ORACLE_SID}: sqlplus not found at ${sqlplus_cmd}"
+      return 1
+    fi
+
+    echo "exit" | ${sqlplus_cmd} -L -s "/ as sysdba" > /dev/null 2>&1
+    if [ $? -ne 0 ]
+    then
+      warning "Skipping ${ORACLE_SID}: OS authentication failed for / as sysdba"
+      return 1
+    fi
+
+    return 0
+  }
+
 rman_delete_archivelog () {
     set_ora_env ${1}
+  can_os_auth_connect || return 0
     info "Deleting archivelogs on  ${ORACLE_SID}"
-    echo "delete archivelog until time 'sysdate-3';" > ${SCRIPT_DIR}/rman_delete_archivelogs.cmd
+    echo "delete noprompt force archivelog until time 'sysdate-3';" > ${SCRIPT_DIR}/rman_delete_archivelogs.cmd
     echo "exit" >> ${SCRIPT_DIR}/rman_delete_archivelogs.cmd
-    rman target / cmdfile=${SCRIPT_DIR}/rman_delete_archivelogs.cmd log=${SCRIPT_DIR}/logs/archivelog_deletion_${TARGET_DB}.log
+  ${ORACLE_HOME}/bin/rman target / cmdfile=${SCRIPT_DIR}/rman_delete_archivelogs.cmd log=${LOG_DIR}/archivelog_deletion_${TARGET_DB}.log
 }
 
 # ------------------------------------------------------------------------------
 # Main
 # ------------------------------------------------------------------------------
 
-for TARGET_DB in $(cat /etc/db_backup_exclude_sids | tr "|" "\n")
-do
-    if [ $(grep ${TARGET_DB} /etc/oratab | wc -l) -eq 1 ]
+# If /etc/db_backup_exclude_sids exists, only process SIDs listed in that file as those aren't being backed up, 
+# which will also delete those archivelogs.
+if [ -s /etc/db_backup_exclude_sids ]
+then
+  for TARGET_DB in $(tr "|" "\n" < /etc/db_backup_exclude_sids)
+  do
+    [ -z "${TARGET_DB}" ] && continue
+
+    if [ "${TARGET_DB}" = "+ASM" ]
     then
-        rman_delete_archivelog ${TARGET_DB}
+      info "Skipping ${TARGET_DB}: ASM is excluded"
+      continue
     fi
-done
+
+    if ! grep -Eq "^${TARGET_DB}:" /etc/oratab
+    then
+      warning "Skipping ${TARGET_DB}: not found in /etc/oratab"
+      continue
+    fi
+
+    rman_delete_archivelog ${TARGET_DB}
+  done
+fi

--- a/ansible/roles/oracle-db-backup/templates/db_archivelog_cleanup.sh.j2
+++ b/ansible/roles/oracle-db-backup/templates/db_archivelog_cleanup.sh.j2
@@ -10,7 +10,11 @@ export PATH=/usr/local/bin:$PATH
 export SCRIPT_DIR=/home/oracle/admin/rman_scripts
 export LOG_DIR=${SCRIPT_DIR}/logs
 
-mkdir -p ${LOG_DIR} 2>/dev/null
+mkdir -p ${LOG_DIR}
+if [ $? -ne 0 ]
+then
+  error "Failed to create log directory: ${LOG_DIR}"
+fi
 
 info () {
   T=$(date +"%D %T")
@@ -67,7 +71,7 @@ rman_delete_archivelog () {
     info "Deleting archivelogs on  ${ORACLE_SID}"
     echo "delete noprompt force archivelog until time 'sysdate-3';" > ${SCRIPT_DIR}/rman_delete_archivelogs.cmd
     echo "exit" >> ${SCRIPT_DIR}/rman_delete_archivelogs.cmd
-  ${ORACLE_HOME}/bin/rman target / cmdfile=${SCRIPT_DIR}/rman_delete_archivelogs.cmd log=${LOG_DIR}/archivelog_deletion_${TARGET_DB}.log
+  ${ORACLE_HOME}/bin/rman target / cmdfile=${SCRIPT_DIR}/rman_delete_archivelogs.cmd log=${LOG_DIR}/archivelog_deletion_${ORACLE_SID}.log
 }
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
This pull request introduces enhancements and new configuration for Oracle database backup and archivelog cleanup processes. The changes add support for a recovery catalog, configure RMAN backup scheduling, and improve the robustness and logging of the archivelog cleanup script, ensuring only eligible databases are processed and errors are handled gracefully.

**Backup and Recovery Catalog Configuration:**
- Added configuration for a recovery catalog database (`RCVCAT`) and related RMAN backup scheduling, including weekly and daily jobs, in `environment_name_nomis_development.yml`.

**Archivelog Cleanup Script Improvements:**
- Improved `db_archivelog_cleanup.sh.j2` to:
  - Add detailed documentation and ensure log directories are created.
  - Implement a check (`can_os_auth_connect`) to verify OS authentication before attempting RMAN operations, with clear warnings and early exits on failure.
  - Enhance RMAN archivelog deletion by using `noprompt force` and improved logging, and ensure only databases listed in `/etc/db_backup_exclude_sids` and present in `/etc/oratab` are processed, skipping `+ASM` and invalid entries.