### PR TITLE
DBA-1218 NCR flash usage alert

### DIFF
--- a/ansible/group_vars/environment_name_nomis_combined_reporting_production.yml
+++ b/ansible/group_vars/environment_name_nomis_combined_reporting_production.yml
@@ -22,6 +22,8 @@ OEM_AGENT_VERSION: 13.5.0.0.0
 rman_backup_script: rman_backup.sh
 recovery_catalog: 1
 recovery_catalog_server: "{{ OMS_SERVER }}"
+# Exclude the standby dbs as the backup script won't run backups on them and this config is needed so that their old archivelogs are deleted.
+exclude_db_backup: "DRBIAUD|DRBIPSYS|DRBIPAUD|DRBISYS"
 rman_backup_cron:
   backup_level_0:
     - name: rman_backup_weekly
@@ -48,6 +50,8 @@ housekeeping_cron:
       # job: command generated in
 
 db_configs:
+  RCVCAT:
+    rcvcat_db_name: PRCVCAT
   PDBIPSYS:
     db_name: BIPSYSP
     db_unique_name: PDBIPSYS

--- a/ansible/group_vars/environment_name_oasys_national_reporting_production.yml
+++ b/ansible/group_vars/environment_name_oasys_national_reporting_production.yml
@@ -41,34 +41,8 @@ sap_web_filesystems_mount:
     state: absent
     autofs_mount: true
 
-db_configs:
-  RCVCAT:
-    rcvcat_db_name: PDRCVCAT
-  PDBOSYS:
-    db_name: PDBOSYS
-    db_unique_name: PDBOSYS
-    instance_name: PDBOSYS
-    host_name: pd-oasys-db-1-a
-    port: 1521
-    tns_name: PDBOSYS
-    asm_disk_groups: DATA
-    service:
-      - { name: BISYS_TAF, role: PRIMARY }
-  PDBOAUD:
-    db_name: PDBOAUD
-    db_unique_name: PDBOAUD
-    instance_name: PDBOAUD
-    host_name: pd-oasys-db-1-a
-    port: 1521
-    tns_name: PDBOAUD
-    asm_disk_groups: DATA,FLASH
-    service:
-      - { name: BIAUD_TAF, role: PRIMARY }
-
-audit_db_sid: PDBOAUD
-system_db_sid: PDBOSYS
-audit_service_name: BIAUD_TAF
-system_service_name: BISYS_TAF
+# For some reason pd-onr-db-1-a was added to the oasys-production environment instead of this environment.
+# See environment_name_oasys_production.yml for the db_config for the databases.
 
 oracle_client_tnsnames_ora_source_filename: "tnsnames.ora.onr-bip.{{ onr_environment }}"
 oracle_client_sqlnet_ora_source_filename: sqlnet.ora

--- a/ansible/group_vars/environment_name_oasys_national_reporting_test.yml
+++ b/ansible/group_vars/environment_name_oasys_national_reporting_test.yml
@@ -13,35 +13,6 @@ bip_filesystems_mount:
     metric_dimension: t2_onr_sap_share
     maintenance_window:
 
-db_configs:
-  RCVCAT:
-    rcvcat_db_name: T2RCVCAT
-  T2BOSYS:
-    db_name: T2BOSYS
-    db_unique_name: T2BOSYS
-    instance_name: T2BOSYS
-    host_name: t2-oasys-db-a
-    port: 1521
-    tns_name: T2BOSYS
-    asm_disk_groups: DATA
-    service:
-      - { name: BISYS_TAF, role: PRIMARY }
-  T2BOAUD:
-    db_name: T2BOAUD
-    db_unique_name: T2BOAUD
-    instance_name: T2BOAUD
-    host_name: t2-oasys-db-a
-    port: 1521
-    tns_name: T2BOAUD
-    asm_disk_groups: DATA,FLASH
-    service:
-      - { name: BIAUD_TAF, role: PRIMARY }
-
-audit_db_sid: T2BOAUD
-system_db_sid: T2BOSYS
-audit_service_name: BIAUD_TAF
-system_service_name: BISYS_TAF
-
 oracle_client_tnsnames_ora_source_filename: "tnsnames.ora.onr-bip.{{ onr_environment }}"
 oracle_client_sqlnet_ora_source_filename: sqlnet.ora
 

--- a/ansible/group_vars/environment_name_oasys_production.yml
+++ b/ansible/group_vars/environment_name_oasys_production.yml
@@ -33,6 +33,8 @@ OEM_AGENT_VERSION: 13.5.0.0.0
 rman_backup_script: rman_backup.sh
 recovery_catalog: 1
 recovery_catalog_server: "{{ OMS_SERVER }}"
+# Exclude the standby dbs as the backup script won't run backups on them and this config is needed so that their old archivelogs are deleted.
+exclude_db_backup: "DROASYS"
 rman_backup_cron:
   backup_level_0:
     - name: rman_backup_weekly
@@ -50,6 +52,16 @@ rman_backup_cron:
 db_configs:
   RCVCAT:
     rcvcat_db_name: PRCVCAT
+  PDOASYS:
+    db_name: PDOASYS
+    db_unique_name: PDOASYS
+    instance_name: PDOASYS
+    host_name: pd-oasys-db-a
+    port: 1521
+    tns_name: PDOASYS
+    asm_disk_groups: DATA,FLASH
+    service:
+      - { name: OASYS_TAF, role: PRIMARY }
   PDBOSYS:
     db_name: PDBOSYS
     db_unique_name: PDBOSYS
@@ -70,27 +82,14 @@ db_configs:
     asm_disk_groups: DATA,FLASH
     service:
       - { name: BOAUD_TAF, role: PRIMARY }
-  DRBOSYS:
-    db_name: DRBOSYS
-    db_unique_name: DRBOSYS
-    instance_name: DRBOSYS
-    host_name: pd-oasys-db-b
-    port: 1521
-    tns_name: DRBOSYS
-    asm_disk_groups: DATA,FLASH
-    service:
-      - { name: BOSYS_TAF, role: PRIMARY }
-  DRBOAUD:
-    db_name: DRBOAUD
-    db_unique_name: DRBOAUD
-    instance_name: DRBOAUD
-    host_name: pd-oasys-db-b
-    port: 1521
-    tns_name: DRBOAUD
-    asm_disk_groups: DATA,FLASH
-    service:
-      - { name: BOAUD_TAF, role: PRIMARY }
   PDBIPINF:
+    db_name: PDBIPINF
+    db_unique_name: PDBIPINF
+    instance_name: PDBIPINF
+    host_name: pd-oasys-db-a
+    port: 1521
+    tns_name: PDBIPINF
+    asm_disk_groups: DATA,FLASH
     parameters:
       - { name: "_allow_insert_with_update_check", value: TRUE, db_restart_required: 0, scope: both }
       - { name: session_cached_cursors, value: 300, db_restart_required: 0, scope: spfile }
@@ -108,6 +107,16 @@ db_configs:
         }
     service:
       - { name: BIPINF_TAF, role: PRIMARY }
+  DROASYS:
+    db_name: DROASYS
+    db_unique_name: DROASYS
+    instance_name: DROASYS
+    host_name: pd-oasys-db-b
+    port: 1521
+    tns_name: DROASYS
+    asm_disk_groups: DATA,FLASH
+    service:
+      - { name: OASHA_TAF, role: PRIMARY }
   PROASYS:
     db_name: OASYSPTC
     db_unique_name: PROASYS
@@ -131,6 +140,14 @@ db_configs:
     service:
       - { name: TRAINING_OASYS_TAF, role: PRIMARY }
   TRBIPINF:
+    db_name: OASYSTRN
+    db_unique_name: TRBIPINF
+    instance_name: TRBIPINF
+    host_name: ptctrn-oasys-db-a.oasys.hmpps-preproduction.modernisation-platform.internal
+    port: 1521
+    tns_name: TRBIPINF
+    s3_bucket: oasys-production20230403093924372800000001
+    asm_disk_groups: DATA,FLASH
     parameters:
       - { name: "_allow_insert_with_update_check", value: TRUE, db_restart_required: 0, scope: both }
       - { name: session_cached_cursors, value: 300, db_restart_required: 0, scope: spfile }
@@ -148,6 +165,57 @@ db_configs:
         }
     service:
       - { name: BIPINF_TAF, role: PRIMARY }
+  # From some reason pd-onr-db-a was added to the oasys-production environment instead of the onr environment, so these dbs are in this environment's config file.
+  PDONRSYS:
+    db_name: PDONRSYS
+    db_unique_name: PDONRSYS
+    instance_name: PDONRSYS
+    host_name: pd-onr-db-a
+    port: 1521
+    tns_name: PDONRSYS
+    asm_disk_groups: DATA,FLASH
+    service:
+      - { name: ONRSYS_TAF, role: PRIMARY }
+  PDONRAUD:
+    db_name: PDONRAUD
+    db_unique_name: PDONRAUD
+    instance_name: PDONRAUD
+    host_name: pd-onr-db-a
+    port: 1521
+    tns_name: PDONRAUD
+    asm_disk_groups: DATA,FLASH
+    service:
+      - { name: ONRAUD_TAF, role: PRIMARY }
+  PDONRBDS:
+    db_name: ONRBODS
+    db_unique_name: PDONRBDS
+    instance_name: PDONRBDS
+    host_name: pd-onr-db-a
+    port: 1521
+    tns_name: PDONRBDS
+    asm_disk_groups: DATA,FLASH
+    service:
+      - { name: ONRBODS_TAF, role: PRIMARY }
+  PDOASREP:
+    db_name: PDOASREP
+    db_unique_name: PDOASREP
+    instance_name: PDOASREP
+    host_name: pd-onr-db-a
+    port: 1521
+    tns_name: PDOASREP
+    asm_disk_groups: DATA,FLASH
+    service:
+      - { name: OASYSREP_TAF, role: PRIMARY }
+  PDMISTRN:
+    db_name: PDMISTRN
+    db_unique_name: PDMISTRN
+    instance_name: PDMISTRN
+    host_name: pd-onr-db-a
+    port: 1521
+    tns_name: PDMISTRN
+    asm_disk_groups: DATA,FLASH
+    service:
+      - { name: MISTRANS_TAF, role: PRIMARY }
 
 nart_business_objects_db_confs:
   pd-oasys-db-a:

--- a/ansible/group_vars/environment_name_oasys_test.yml
+++ b/ansible/group_vars/environment_name_oasys_test.yml
@@ -197,7 +197,7 @@ db_configs:
     db_name: ONRAUD
     db_unique_name: T2ONRAUD
     instance_name: T2ONRAUD
-    host_name: 10.26.12.211
+    host_name: t2-oasys-db-a.oasys.hmpps-test.modernisation-platform.internal
     port: 1521
     tns_name: T2ONRAUD
     s3_bucket: oasys-test20230403093247696000000001
@@ -209,7 +209,7 @@ db_configs:
     db_name: MISTRANS
     db_unique_name: T2MISTRN
     instance_name: T2MISTRN
-    host_name: 10.26.12.211
+    host_name: t2-oasys-db-a.oasys.hmpps-test.modernisation-platform.internal
     port: 1521
     tns_name: T2MISTRN
     s3_bucket: oasys-test20230403093247696000000001
@@ -221,7 +221,7 @@ db_configs:
     db_name: OASREP
     db_unique_name: T2OASREP
     instance_name: T2OASREP
-    host_name: 10.26.12.211
+    host_name: t2-oasys-db-a.oasys.hmpps-test.modernisation-platform.internal
     port: 1521
     tns_name: T2OASREP
     s3_bucket: oasys-test20230403093247696000000001


### PR DESCRIPTION
This pull request updates Ansible environment configuration files for several production and test environments, primarily to adjust database backup behavior, update database configuration entries, and clean up or move certain database definitions. The most significant changes involve adding or removing database configurations, introducing backup exclusions for standby databases, and correcting hostnames for test environments.

**Database configuration updates:**

* Added new database entries to the `db_configs` section in `environment_name_oasys_production.yml`, including `PDOASYS`, `DROASYS`, `TRBIPINF`, and several `PDONR*` and `PDOASREP` databases, to reflect the current environment setup. [[1]](diffhunk://#diff-bb072481bf4248ebca3ab081c1a981b1a9cd45d421d6c978001b24236893feb3R55-R64) [[2]](diffhunk://#diff-bb072481bf4248ebca3ab081c1a981b1a9cd45d421d6c978001b24236893feb3R110-R119) [[3]](diffhunk://#diff-bb072481bf4248ebca3ab081c1a981b1a9cd45d421d6c978001b24236893feb3R143-R150) [[4]](diffhunk://#diff-bb072481bf4248ebca3ab081c1a981b1a9cd45d421d6c978001b24236893feb3R168-R218)
* Removed `DRBOSYS` and `DRBOAUD` entries from `db_configs` in `environment_name_oasys_production.yml` and replaced them with `PDBIPINF`, aligning with current environment structure.
* Added a new `RCVCAT` entry to `db_configs` in `environment_name_nomis_combined_reporting_production.yml`.

**Backup and housekeeping configuration improvements:**

* Introduced the `exclude_db_backup` variable in both `environment_name_nomis_combined_reporting_production.yml` and `environment_name_oasys_production.yml` to exclude standby databases from backup scripts and ensure proper archivelog deletion. [[1]](diffhunk://#diff-ffc4542c1cfdb21c753bc7fef4710a7d35b58e898950f08b3d8d09023b7ab4feR25-R26) [[2]](diffhunk://#diff-bb072481bf4248ebca3ab081c1a981b1a9cd45d421d6c978001b24236893feb3R36-R37)

**Test and reporting environment clean-up:**

* Removed local `db_configs` from `environment_name_oasys_national_reporting_test.yml` and `environment_name_oasys_national_reporting_production.yml`, with comments clarifying that relevant database configs have been moved to the appropriate environment files. [[1]](diffhunk://#diff-f39398b4bbc4e9f2013bd77345f52bd98d9d04746d349dcdaf4f35cba57497f1L16-L44) [[2]](diffhunk://#diff-33828972b8a67da81100a103092330a031add520da5bfc7e0dc1420f410b2a43L44-R45)
* Updated hostnames for several databases in `environment_name_oasys_test.yml` from IP addresses to fully qualified domain names, improving clarity and maintainability. [[1]](diffhunk://#diff-d1ae5911b2c377aacdbd218889ba89fae9160f1ecbdf4a0adf41525c50a91741L200-R200) [[2]](diffhunk://#diff-d1ae5911b2c377aacdbd218889ba89fae9160f1ecbdf4a0adf41525c50a91741L212-R212) [[3]](diffhunk://#diff-d1ae5911b2c377aacdbd218889ba89fae9160f1ecbdf4a0adf41525c50a91741L224-R224)