### PR TITLE
TM-2113: Get oms_owner from /passwords

### DIFF
--- a/ansible/roles/nomis-release-deployment/defaults/main.yml
+++ b/ansible/roles/nomis-release-deployment/defaults/main.yml
@@ -9,7 +9,7 @@ db_config: "{{ db_configs[app_db_name] }}"
 
 app_secretsmanager_passwords:
   db:
-    secret: "/oracle/database/{{ db_config.db_name }}/weblogic-passwords"
+    secret: "/oracle/database/{{ db_config.db_name }}/passwords"
     users:
       - oms_owner:
 

--- a/ansible/roles/nomis-weblogic-12/defaults/main.yml
+++ b/ansible/roles/nomis-weblogic-12/defaults/main.yml
@@ -73,11 +73,11 @@ weblogic_domain_hostname: "{{ ansible_facts.hostname }}"
 # weblogic_db_repo_hostname:
 # weblogic_db_repo_sid:
 # weblogic_db_repo_prefix:
-weblogic_db_repo_username: "sys"
+#weblogic_db_repo_username: "sys"
 
-weblogic_db_repo_password_secret:
-  - key: "{{ weblogic_db_repo_username }}"
-    value:
+#weblogic_db_repo_password_secret:
+#  - key: "{{ weblogic_db_repo_username }}"
+#    value:
 
 weblogic_admin_password_secret:
   - key: "{{ weblogic_admin_username }}"
@@ -97,11 +97,11 @@ weblogic_secretsmanager_passwords:
     users:
       - tagsar:
       - oms_owner:
-      - wls_schemas: auto
   db_repo:
-    secret: "/oracle/database/{{ weblogic_db_repo_sid }}/passwords"
+    secret: "/oracle/database/{{ weblogic_db_repo_sid }}/weblogic-passwords"
     users:
-      - "{{ weblogic_db_repo_password_secret | items2dict }}"
+#      - "{{ weblogic_db_repo_password_secret | items2dict }}"
+      - wls_schemas: auto
   weblogic:
     secret: "/oracle/weblogic/{{ nomis_environment }}/passwords"
     users:

--- a/ansible/roles/nomis-weblogic-12/tasks/get-facts.yml
+++ b/ansible/roles/nomis-weblogic-12/tasks/get-facts.yml
@@ -10,8 +10,8 @@
     weblogic_admin_password: "{{ secretsmanager_passwords_dict['weblogic'].passwords[weblogic_admin_username] }}"
     weblogic_db_password: "{{ secretsmanager_passwords_dict['db'].passwords[weblogic_db_username] }}"
     weblogic_db_tagsar_password: "{{ secretsmanager_passwords_dict['db'].passwords[weblogic_db_tagsar_username] }}"
-    weblogic_db_repo_password: "{{ secretsmanager_passwords_dict['db_repo'].passwords[weblogic_db_repo_username] }}"
-    weblogic_db_repo_schema_password: "{{ secretsmanager_passwords_dict['db'].passwords['wls_schemas'] }}"
+#    weblogic_db_repo_password: "{{ secretsmanager_passwords_dict['db_repo'].passwords[weblogic_db_repo_username] }}"
+    weblogic_db_repo_schema_password: "{{ secretsmanager_passwords_dict['db_repo'].passwords['wls_schemas'] }}"
 
 #- name: Check all SSM parameters and tags are set
 #  set_fact:

--- a/ansible/roles/nomis-weblogic-12/templates/12/u01/software/weblogic/rcu.rsp
+++ b/ansible/roles/nomis-weblogic-12/templates/12/u01/software/weblogic/rcu.rsp
@@ -8,7 +8,7 @@ connectString={{ weblogic_db_repo_hostname }}:1521:{{ weblogic_db_repo_sid }}
 databaseType=ORACLE
 
 #Database User
-dbUser={{ weblogic_db_repo_username }}
+#dbUser={{ weblogic_db_repo_username }}
 
 #Database Role - sysdba or Normal
 dbRole=SYSDBA


### PR DESCRIPTION
DBAs have requested that oms_owner be retrieved from /passwords rather than /weblogic-passwords, this PR factors in the change for the release-deployment role