### PR TITLE
TM-2168: nomis: allow ssh to web servers

### DIFF
--- a/ansible/group_vars/environment_name_nomis_development.yml
+++ b/ansible/group_vars/environment_name_nomis_development.yml
@@ -27,9 +27,11 @@ tnsnames_qa11g2_service_name: QA11G2
 zip_file_temp_dir: /tmp
 winrm_domain_name_fqdn: azure.noms.root
 
-users_and_groups_regular:
+users_and_groups_regular_web:
   - group: studio-webops
   - group: syscon-nomis
+
+users_and_groups_regular: "{{ users_and_groups_regular_web }}"
 
 weblogic_additional_form_servers: []
 

--- a/ansible/group_vars/environment_name_nomis_preproduction.yml
+++ b/ansible/group_vars/environment_name_nomis_preproduction.yml
@@ -9,6 +9,9 @@ dns_search_domains:
   - azure.hmpp.root
 winrm_domain_name_fqdn: azure.hmpp.root
 
+users_and_groups_regular:
+  - group: studio-webops
+
 # OEM server
 OMS_SERVER: preprod-oem-a.hmpps-oem.hmpps-preproduction.modernisation-platform.internal
 OEM_AGENT_VERSION: 13.5.0.0.0

--- a/ansible/group_vars/environment_name_nomis_preproduction.yml
+++ b/ansible/group_vars/environment_name_nomis_preproduction.yml
@@ -9,7 +9,8 @@ dns_search_domains:
   - azure.hmpp.root
 winrm_domain_name_fqdn: azure.hmpp.root
 
-users_and_groups_regular:
+# since ssm broken on web, add user accounts in case ec2-user breaks
+users_and_groups_regular_web:
   - group: studio-webops
 
 # OEM server

--- a/ansible/group_vars/environment_name_nomis_production.yml
+++ b/ansible/group_vars/environment_name_nomis_production.yml
@@ -9,7 +9,8 @@ dns_search_domains:
   - azure.hmpp.root
 winrm_domain_name_fqdn: azure.hmpp.root
 
-users_and_groups_regular:
+# since ssm broken on web, add user accounts in case ec2-user breaks
+users_and_groups_regular_web:
   - group: studio-webops
 
 oracle_path: /usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/home/oracle/.local/bin:/home/oracle/bin

--- a/ansible/group_vars/environment_name_nomis_production.yml
+++ b/ansible/group_vars/environment_name_nomis_production.yml
@@ -9,6 +9,9 @@ dns_search_domains:
   - azure.hmpp.root
 winrm_domain_name_fqdn: azure.hmpp.root
 
+users_and_groups_regular:
+  - group: studio-webops
+
 oracle_path: /usr/local/bin:/bin:/usr/bin:/usr/local/sbin:/usr/sbin:/home/oracle/.local/bin:/home/oracle/bin
 db_env:
   ORACLE_HOME: "{{ database_home }}"

--- a/ansible/group_vars/environment_name_nomis_test.yml
+++ b/ansible/group_vars/environment_name_nomis_test.yml
@@ -9,6 +9,9 @@ dns_search_domains:
   - azure.noms.root
 winrm_domain_name_fqdn: azure.noms.root
 
+users_and_groups_regular:
+  - group: studio-webops
+
 # OEM server
 OMS_SERVER: test-oem-a.hmpps-oem.hmpps-test.modernisation-platform.internal
 OEM_AGENT_VERSION: 13.5.0.0.0

--- a/ansible/group_vars/environment_name_nomis_test.yml
+++ b/ansible/group_vars/environment_name_nomis_test.yml
@@ -9,7 +9,8 @@ dns_search_domains:
   - azure.noms.root
 winrm_domain_name_fqdn: azure.noms.root
 
-users_and_groups_regular:
+# since ssm broken on web, add user accounts in case ec2-user breaks
+users_and_groups_regular_web:
   - group: studio-webops
 
 # OEM server

--- a/ansible/group_vars/server_type_nomis_web.yml
+++ b/ansible/group_vars/server_type_nomis_web.yml
@@ -22,6 +22,8 @@ roles_list: "{{ (ami_roles_list | default([]) | difference(server_type_roles_lis
 
 xsiam_agent_state: "{{ xsiam_agent_web_state }}" # set in environment group_vars
 
+users_and_groups_regular: "{{ users_and_groups_regular_web }}"
+
 collectd_monitored_services_servertype:
   - metric_name: service_status_os
     metric_dimension: chronyd

--- a/ansible/roles/sshd-config/defaults/main.yml
+++ b/ansible/roles/sshd-config/defaults/main.yml
@@ -15,10 +15,10 @@ sshd_config_settings:
     PermitRootLogin: "no"
     PasswordAuthentication: "no"
     PubkeyAuthentication: "yes"
-    UsePAM: "no"
+    UsePAM: "yes"
   default:
     X11Forwarding: "no"
     PermitRootLogin: "no"
     PasswordAuthentication: "no"
     PubkeyAuthentication: "yes"
-    UsePAM: "no"
+    UsePAM: "yes"


### PR DESCRIPTION
To allow login access once SSM stops working:
- Add webops ssh keys to web servers as a backup in case ec2-user stops working
- Fix ec2-user ssh issue