### PR TITLE
Dba 1200 run oracle license audit

### DIFF
--- a/ansible/site.yml
+++ b/ansible/site.yml
@@ -43,7 +43,7 @@
         - ansible_version.full >= "2.13.0"
         - ansible_distribution in ['RedHat', 'OracleLinux']
         - ansible_distribution_major_version in ['6']
-      tags: always
+      tags: never
 
     - name: Set roles_defined fact
       ansible.builtin.set_fact:

--- a/ansible/site.yml
+++ b/ansible/site.yml
@@ -33,6 +33,9 @@
 #
 #   # Run all tasks with ec2provision tag
 #   ansible-playbook site.yml --tags ec2provision
+#
+#   # Skip the RHEL6 version check
+#   ansible-playbook site.yml --skip-tags ansible_version_check
 
 - hosts: "{{ target | default('all') }}"
   tasks:
@@ -43,7 +46,9 @@
         - ansible_version.full >= "2.13.0"
         - ansible_distribution in ['RedHat', 'OracleLinux']
         - ansible_distribution_major_version in ['6']
-      tags: never
+      tags:
+        - always
+        - ansible_version_check
 
     - name: Set roles_defined fact
       ansible.builtin.set_fact:


### PR DESCRIPTION
This pull request updates the `ansible/site.yml` playbook to improve tag usage and documentation for version checks. The changes make it easier to skip the RHEL6 Ansible version check and clarify tag usage in the playbook.

**Improvements to Ansible tag usage and documentation:**

- Added documentation on how to skip the RHEL6 version check using the `--skip-tags ansible_version_check` flag in the playbook comments.
- Changed the Ansible version check task to use a specific `ansible_version_check` tag (in addition to `always`), allowing users to selectively skip this task.