### PR TITLE
DBA-1243 Mod Platform local container testing

### DIFF
--- a/ansible/Dockerfile.ansible-2.13.13
+++ b/ansible/Dockerfile.ansible-2.13.13
@@ -5,8 +5,9 @@ FROM rockylinux:8
 ARG ANSIBLE_DIR=/opt/ansible
 ENV ANSIBLE_DIR=${ANSIBLE_DIR}
 
-# Install build tools, zip tools, and dependencies
-RUN dnf install -y \
+# Install build tools, zip tools, and dependencies but no docs to save space
+RUN echo "tsflags=nodocs" >> /etc/dnf/dnf.conf \
+    && dnf install -y \
     gcc \
     wget \
     unzip \
@@ -23,7 +24,8 @@ RUN dnf install -y \
     xz-devel \
     expat-devel \
     make \
-    && dnf clean all
+    && dnf clean all \
+    && rm -rf /var/cache/dnf /usr/share/doc /usr/share/man
 
 # Build Python 3.9.6 from source
 WORKDIR /tmp
@@ -31,9 +33,9 @@ RUN wget https://www.python.org/ftp/python/3.9.6/Python-3.9.6.tgz \
     && tar xzf Python-3.9.6.tgz \
     && cd Python-3.9.6 \
     && sed -i 's/^#zlib/zlib/' Modules/Setup \
-    && ./configure --enable-optimizations \
+    && ./configure \
     && make altinstall \
-    && rm -rf /tmp/Python-3.9.6*
+    && rm -rf /tmp/Python-3.9.6* /root/.cache/pip
 
 # Install AWS CLI v2 dynamically based on architecture
 RUN ARCH=$(uname -m) \

--- a/ansible/README.md
+++ b/ansible/README.md
@@ -28,6 +28,7 @@ For example:
 Running via a container is simplest:
 - install PodMan
 - paste in credentials or use aws-vault
+- disconnect from the VPN
 - use ./container.sh wrapper script to run ansible
 
 #### Install Podman
@@ -37,9 +38,18 @@ Skip this if you are using Docker. For M1, M2, M3 chipsets, install podman as fo
 ```
 brew install vfkit
 brew install podman
-sudo /opt/homebrew/Cellar/podman/5.8.0/bin/podman-mac-helper install
+sudo /opt/homebrew/Cellar/podman/$(podman --version | awk '{print $3}')/bin/podman-mac-helper install
 export CONTAINERS_MACHINE_PROVIDER=applehv
-podman machine init
+podman machine init  --disk-size 80
+podman machine start
+```
+
+If podman has already been installed, stop the default machine and extend the disk to avoid disk space issues:
+
+```
+podman machine stop
+podman machine rm
+podman machine init --disk-size 80
 podman machine start
 ```
 
@@ -56,6 +66,9 @@ podman machine ssh "sudo touch /etc/containers/enable-rosetta"
 podman machine stop
 podman machine start
 ```
+
+#### VPN
+Being connected to the Prisma VPN results in tls certificate errors when attempting to download the inital rockylinux image. Therefore it is best to disconnect from the VPN while creating the local container.
 
 #### Credentials Environment Variables
 
@@ -215,4 +228,12 @@ Use requirements.rhel6.yml instead.  Example error:
 # [WARNING]: Skipping Galaxy server https://galaxy.ansible.com/api/. Got an unexpected error when getting available versions of collection amazon.aws:
 # '/api/v3/plugin/ansible/content/published/collections/index/amazon/aws/versions/'
 # ERROR! Unexpected Exception, this is probably a bug: '/api/v3/plugin/ansible/content/published/collections/index/amazon/aws/versions/'
+```
+
+### Removing the local container
+If using podman you can remove the image (depending on which you built) so it builds again next time the container.sh script is run:
+
+```
+podman image rm localhost/ansible-2.11.12
+podman image rm localhost/ansible-2.13.13
 ```

--- a/ansible/container.sh
+++ b/ansible/container.sh
@@ -33,6 +33,14 @@ else
   exit 1
 fi
 
+if [ "$ENGINE" = "podman" ]; then
+  # Set up a temporary directory for podman to use, since it uses /var/tmp by default which will fill up quickly in a container environment. This is a workaround.
+  export TMPDIR="${TMPDIR:-/tmp/podman}"
+  export TMP="$TMPDIR"
+  export TEMP="$TMPDIR"
+  mkdir -p "$TMPDIR"
+fi
+
 if ! $ENGINE image inspect $IMAGE &> /dev/null; then
   echo "# Building $IMAGE using $ENGINE..."
   $ENGINE build -t $IMAGE -f Dockerfile.$IMAGE .


### PR DESCRIPTION
This pull request focuses on improving the usability and efficiency of the Ansible container setup, particularly for developers using Podman. The changes optimise the Dockerfile for smaller image sizes, update documentation for better onboarding and troubleshooting, and add workarounds for common disk space and environment issues with Podman.

**Dockerfile and Image Optimization:**
* Updated `ansible/Dockerfile.ansible-2.13.13` to reduce image size by disabling documentation during package installation and cleaning up unnecessary files after installing dependencies. Also, removed pip cache after Python build to further save space. [[1]](diffhunk://#diff-8a9ad54556f0086fc5120f39bcb48c41430f7695abd68d7133e83237ed48f20fL8-R10) [[2]](diffhunk://#diff-8a9ad54556f0086fc5120f39bcb48c41430f7695abd68d7133e83237ed48f20fL26-R38)

**Podman Usage Improvements:**
* Enhanced `ansible/README.md` with instructions for initializing Podman machines with larger disk sizes and guidance for extending disk space if Podman is already installed.
* Added a workaround in `ansible/container.sh` to set a custom temporary directory for Podman, preventing disk space issues caused by default `/var/tmp` usage.

**Developer Experience and Troubleshooting:**
* Updated `ansible/README.md` to recommend disconnecting from VPN when pulling the initial Rocky Linux image to avoid TLS certificate errors, and explained the reason in a new VPN section. [[1]](diffhunk://#diff-fac2c4b2da0d1130d0f929abfff14008a96373c769abad4fdd1c8ee2ffca5226R31) [[2]](diffhunk://#diff-fac2c4b2da0d1130d0f929abfff14008a96373c769abad4fdd1c8ee2ffca5226R70-R72)
* Added documentation on how to remove local Podman images to force a rebuild, helping with troubleshooting and disk space management.