### PR TITLE
Update PPCNOM_post_steps.sh.j2

### DIFF
--- a/ansible/roles/oracle-db-refresh/templates/PPCNOM_post_steps.sh.j2
+++ b/ansible/roles/oracle-db-refresh/templates/PPCNOM_post_steps.sh.j2
@@ -239,8 +239,8 @@ user_creation
 # Database Name change
 db_name_change
 
-# Streams setup
-streams_setup
-
 # create_metadata_table
 create_metadata_table
+
+# Streams setup
+streams_setup


### PR DESCRIPTION
Move create_metadata_table before streams_setup — the metadata table records when the refresh happened and doesn't depend on streams. It's logically tied to the database being open and refreshed, not to streams replication being configured.