### PR TITLE
DBA-1262 weblogic cluster audit fix

### DIFF
--- a/ansible/Dockerfile.ansible-2.11.12
+++ b/ansible/Dockerfile.ansible-2.11.12
@@ -27,6 +27,7 @@ RUN dnf install -y \
     expat-devel \
     xz \
     make \
+    jq \
     && dnf clean all
 
 # Build Python 3.6.3 from source

--- a/ansible/Dockerfile.ansible-2.13.13
+++ b/ansible/Dockerfile.ansible-2.13.13
@@ -24,6 +24,7 @@ RUN echo "tsflags=nodocs" >> /etc/dnf/dnf.conf \
     xz-devel \
     expat-devel \
     make \
+    jq \
     && dnf clean all \
     && rm -rf /var/cache/dnf /usr/share/doc /usr/share/man
 

--- a/ansible/roles/oracle-licence-audit/tasks/audit-weblogic-cluster.yml
+++ b/ansible/roles/oracle-licence-audit/tasks/audit-weblogic-cluster.yml
@@ -138,7 +138,8 @@
                 weblogic_instance_types: >-
                   {{
                     weblogic_ec2_types
-                    | map('regex_replace', '^.+:(.+)$', '\\1')
+                    | map('split', ':')
+                    | map('last')
                     | list
                   }}
               when: weblogic_task_arns | length > 0

--- a/ansible/roles/oracle-licence-audit/tasks/main.yml
+++ b/ansible/roles/oracle-licence-audit/tasks/main.yml
@@ -34,6 +34,7 @@
       tags:
         - collection
         - weblogic
+        - weblogic-cluster
       run_once: yes
 
     # Generate summary and zip up results - run once per environment


### PR DESCRIPTION
This pull request introduces several improvements to the Ansible Dockerfiles and the Oracle license audit Ansible role. The main changes include adding the `jq` utility to the Docker build environment, refining logic for extracting WebLogic instance types, and updating task tags for better organization.

**Dockerfile enhancements:**
* Added `jq` to the list of installed packages in both `ansible/Dockerfile.ansible-2.11.12` and `ansible/Dockerfile.ansible-2.13.13` to support JSON processing in the build environment. [[1]](diffhunk://#diff-2a069185caed587497334f609795729fdbe23373dfb9316884b975c5c7eddbe6R30) [[2]](diffhunk://#diff-8a9ad54556f0086fc5120f39bcb48c41430f7695abd68d7133e83237ed48f20fR27)

**Oracle license audit role improvements:**
* Improved the extraction of instance types in `audit-weblogic-cluster.yml` by splitting on `:` and taking the last element, which is more robust than the previous regex approach.
* Added the `weblogic-cluster` tag to the relevant task in `main.yml` for better task categorization and filtering.