### PR TITLE
Add Custom Thresholds for Longest Currently Active SQL

### DIFF
--- a/ansible/group_vars/environment_name_delius_mis_preproduction_preprod_mis_primarydb.yml
+++ b/ansible/group_vars/environment_name_delius_mis_preproduction_preprod_mis_primarydb.yml
@@ -128,3 +128,10 @@ all_oem_metrics:
         warning_threshold , 5
         critical_threshold , 7
         END_RECORD 11
+        START_RECORD 12
+        metric , ME$LONG_RUNNING_SQL
+        column , LONGEST_CURRENTLY_ACTIVE_SQL
+        key_columns , ;
+        warning_threshold , 15000
+        critical_threshold , 20000
+        END_RECORD 12


### PR DESCRIPTION
This pull request adds a new OEM metric configuration to monitor long-running SQL queries in the `delius_mis_preproduction_preprod_mis_primarydb` environment. The main change is the introduction of a new metric with specific warning and critical thresholds.

**New OEM metric configuration:**

* Added a new record to `all_oem_metrics` for the `ME$LONG_RUNNING_SQL` metric, monitoring the `LONGEST_CURRENTLY_ACTIVE_SQL` column with warning and critical thresholds set to 15,000 and 20,000 respectively. (`ansible/group_vars/environment_name_delius_mis_preproduction_preprod_mis_primarydb.yml`)