### PR TITLE
Allow cursors to be open for 7 days in pre-prod

### DIFF
--- a/ansible/group_vars/environment_name_delius_mis_preproduction_preprod_mis_primarydb.yml
+++ b/ansible/group_vars/environment_name_delius_mis_preproduction_preprod_mis_primarydb.yml
@@ -132,6 +132,6 @@ all_oem_metrics:
         metric , ME$LONG_RUNNING_SQL
         column , LONGEST_CURRENTLY_ACTIVE_SQL
         key_columns , ;
-        warning_threshold , 15000
-        critical_threshold , 20000
+        warning_threshold , 604800
+        critical_threshold , 700000
         END_RECORD 12


### PR DESCRIPTION
This pull request updates the alert thresholds for the `LONGEST_CURRENTLY_ACTIVE_SQL` metric in the `environment_name_delius_mis_preproduction_preprod_mis_primarydb.yml` configuration. The warning and critical thresholds have been significantly increased to better reflect expected values and reduce unnecessary alerts.

Configuration changes:

* Increased the `warning_threshold` for the `LONGEST_CURRENTLY_ACTIVE_SQL` metric from `15000` to `604800` and the `critical_threshold` from `20000` to `700000` in `ansible/group_vars/environment_name_delius_mis_preproduction_preprod_mis_primarydb.yml`.