### PR TITLE
Allow PRDMIS Queries to Run to 3 hours before alerting rather than 2 hours

### DIFF
--- a/ansible/group_vars/environment_name_delius_mis_production_prod_mis_primarydb.yml
+++ b/ansible/group_vars/environment_name_delius_mis_production_prod_mis_primarydb.yml
@@ -123,3 +123,10 @@ all_oem_metrics:
         critical_threshold , 102
         occurrences , 1
         END_RECORD 10
+        START_RECORD 11
+        metric , ME$LONG_RUNNING_SQL
+        column , LONGEST_CURRENTLY_ACTIVE_SQL
+        key_columns , ;
+        warning_threshold , 10800
+        critical_threshold , 11800
+        END_RECORD 11


### PR DESCRIPTION
This pull request adds a new metric configuration to the `all_oem_metrics` section in the `ansible/group_vars/environment_name_delius_mis_production_prod_mis_primarydb.yml` file. The new metric tracks long-running SQL statements by monitoring the longest currently active SQL query.

Monitoring improvements:

* Added a new metric (`ME$LONG_RUNNING_SQL`) to monitor the duration of the longest currently active SQL query, with warning and critical thresholds set to 10,800 and 11,800 seconds, respectively.