### PR TITLE
Ignore Idle SQL Developer sessions

### DIFF
--- a/ansible/roles/oracle-oms-setup/files/metric_extensions/common/long_running_sql/collection/ME#24#LONG_RUNNING_SQL.xml
+++ b/ansible/roles/oracle-oms-setup/files/metric_extensions/common/long_running_sql/collection/ME#24#LONG_RUNNING_SQL.xml
@@ -1,4 +1,4 @@
-<TargetCollectionExt EXT_NAME="ME$LONG_RUNNING_SQL" EXT_VERSION="3" TARGET_TYPE="host"><CollectionItem NAME="ME$LONG_RUNNING_SQL" UPLOAD="YES">
+<TargetCollectionExt EXT_NAME="ME$LONG_RUNNING_SQL" EXT_VERSION="4" TARGET_TYPE="host"><CollectionItem NAME="ME$LONG_RUNNING_SQL" UPLOAD="YES">
 	<Schedule>
 		<IntervalSchedule INTERVAL="15" TIME_UNIT="Min"/>
 	</Schedule>

--- a/ansible/roles/oracle-oms-setup/files/metric_extensions/common/long_running_sql/mea.xml
+++ b/ansible/roles/oracle-oms-setup/files/metric_extensions/common/long_running_sql/mea.xml
@@ -1,5 +1,5 @@
 <MetricExtensionArchive name="MEAME$LONG_RUNNING_SQL">
-<MetricExtension name="ME$LONG_RUNNING_SQL" type="host" version="3" is_repos="FALSE" display_name="Long Running SQL" description="Detect longest running SQL still active in the database" version_comment=" " metadata_digest="27f69ab21fe8e9ac6338aab65b68529d" coll_digest="a6dcb44278628c0cb1378f3b63ccbdba" attach_digest="3bbc7d52f73682925914ebb180daa7ac">
+<MetricExtension name="ME$LONG_RUNNING_SQL" type="host" version="4" is_repos="FALSE" display_name="Long Running SQL" description="Detect longest running SQL still active in the database" version_comment=" " metadata_digest="27f69ab21fe8e9ac6338aab65b68529d" coll_digest="a6dcb44278628c0cb1378f3b63ccbdba" attach_digest="0ea5797e52fd487a1255499b59c092d4">
 <scripts name="long_running_sql.sh">
 </scripts>
 </MetricExtension>

--- a/ansible/roles/oracle-oms-setup/files/metric_extensions/common/long_running_sql/metadata/ME#24#LONG_RUNNING_SQL.xml
+++ b/ansible/roles/oracle-oms-setup/files/metric_extensions/common/long_running_sql/metadata/ME#24#LONG_RUNNING_SQL.xml
@@ -1,4 +1,4 @@
-<TargetMetadataExt EXT_NAME="ME$LONG_RUNNING_SQL" EXT_VERSION="3" TARGET_TYPE="host"><Metric NAME="ME$LONG_RUNNING_SQL" TYPE="TABLE">
+<TargetMetadataExt EXT_NAME="ME$LONG_RUNNING_SQL" EXT_VERSION="4" TARGET_TYPE="host"><Metric NAME="ME$LONG_RUNNING_SQL" TYPE="TABLE">
 <Display>
 <Label NLSID="NLS_METRIC_hostME$LONG_RUNNING_SQL">Long Running SQL</Label>
 <Description NLSID="NLS_DESCRIPTION_hostME$LONG_RUNNING_SQL">Detect longest running SQL still active in the database</Description>

--- a/ansible/roles/oracle-oms-setup/files/metric_extensions/common/long_running_sql/scripts/long_running_sql.sh
+++ b/ansible/roles/oracle-oms-setup/files/metric_extensions/common/long_running_sql/scripts/long_running_sql.sh
@@ -66,6 +66,7 @@ and status='ACTIVE'
 and (action != 'PRF_COLL_JOB' OR action IS NULL)
 and (NOT program LIKE '%rman@%' OR program IS NULL)
 and (NOT program LIKE '%(PR__)' OR program IS NULL)
+and NOT (module = 'SQL Developer' AND wait_class = 'Idle')
 ;
 EXIT
 EOF


### PR DESCRIPTION
This pull request updates the "Long Running SQL" metric extension for Oracle OMS to version 4, with changes to both the extension's metadata and collection definitions, and a refinement to the SQL script that collects long-running SQL sessions.

**Metric Extension Version Update:**

* Incremented the metric extension version from 3 to 4 in `ME#24#LONG_RUNNING_SQL.xml`, `mea.xml`, and `metadata/ME#24#LONG_RUNNING_SQL.xml` to reflect changes and ensure consistency across all related files. [[1]](diffhunk://#diff-f1ecef5f5ec47ba06619e0e4276ec5d6ae66319697c7f411e1e89971e60305a2L1-R1) [[2]](diffhunk://#diff-80a21f7ebda31f38aff7cabb5be15df058ad89f912a9c06a5afc96a923bf299cL2-R2) [[3]](diffhunk://#diff-3e4c8ffc4f1e469f262c59d4ce06ce2729bfdb96120c09af939611b07229d43eL1-R1)

**Script Refinement:**

* Updated `long_running_sql.sh` to exclude sessions where the `module` is `'SQL Developer'` and the `wait_class` is `'Idle'`, preventing idle SQL Developer sessions from being reported as long-running.

**Digest Update:**

* Updated the `attach_digest` in `mea.xml` to ensure integrity and track the new version of the metric extension.