### PR TITLE
Derive UEK before using it

### DIFF
--- a/ansible/roles/oracle-db-hugepages/tasks/main.yml
+++ b/ansible/roles/oracle-db-hugepages/tasks/main.yml
@@ -157,6 +157,9 @@
          else 5 if ansible_kernel is version('4.14', '>=')
          else 4 if ansible_kernel is version('4.1', '>=')
          else 3 }}
+
+- name: Derive expected Transparent HugePages mode from UEK release
+  set_fact:
     thp_expected_mode: "{{ 'madvise' if uek_release | int >= 7 else 'disabled ([never])' }}"
     thp_expected_marker: "{{ '\\[madvise\\]' if uek_release | int >= 7 else '\\[never\\]' }}"
 


### PR DESCRIPTION
This pull request introduces a task to dynamically set the expected Transparent HugePages (THP) mode based on the UEK (Unbreakable Enterprise Kernel) release in the Ansible role for Oracle DB hugepages.

Configuration improvements:

* Added a new Ansible task in `ansible/roles/oracle-db-hugepages/tasks/main.yml` to set the `thp_expected_mode` and `thp_expected_marker` variables according to the value of `uek_release`, ensuring that systems with UEK 7 or higher use `madvise`, while older versions use `disabled ([never])`.