### PR TITLE
RCU Prefix Fixes

### DIFF
--- a/ansible/group_vars/server_type_nomis_web12.yml
+++ b/ansible/group_vars/server_type_nomis_web12.yml
@@ -100,6 +100,11 @@ weblogic_configs:
     weblogic_db_repo_username: "sys"
     weblogic_db_repo_prefix: "{{ ec2.tags['server-type'] | replace('-', '') | upper }}AK"
 
+  qa:
+    weblogic_db_repo_hostname: "dev-nomis-db19c-1-b"
+    weblogic_db_repo_sid: "qa19c"
+    weblogic_db_repo_username: "sys"
+
 weblogic_config: "{{ weblogic_configs[nomis_environment] }}"
 
 weblogic_db_repo_hostname: "{{ weblogic_config.weblogic_db_repo_hostname }}"

--- a/ansible/roles/nomis-weblogic-12/tasks/create-db-repo.yml
+++ b/ansible/roles/nomis-weblogic-12/tasks/create-db-repo.yml
@@ -82,6 +82,8 @@
     /u01/app/oracle/Middleware/oracle_common/bin/rcu -silent -responseFile /u01/software/weblogic/droprcu.rsp < /u01/software/weblogic/passwordfile.txt
   register: drop_db_repo
   when: weblogic_rcu_repository_exists
+  #ignore failures from the drop command, as it may fail if the schemas are already dropped or partially dropped
+  ignore_errors: true
 
 - name: Create repository database using rcu
   become_user: oracle

--- a/ansible/roles/nomis-weblogic-12/tasks/create-db-repo.yml
+++ b/ansible/roles/nomis-weblogic-12/tasks/create-db-repo.yml
@@ -40,9 +40,15 @@
     sqlplus -s /nolog <<'SQL'
     connect sys/{{ weblogic_db_repo_password }}@{{ weblogic_db_repo_hostname }}:1521/{{ weblogic_db_repo_sid }} as sysdba
     set heading off feedback off verify off echo off pagesize 0
-    select count(*)
-    from dba_users
-    where username = upper('{{ weblogic_db_repo_prefix }}_STB');
+    select count(*) from (
+      select 1
+      from schema_version_registry
+      where mrc_name = upper('{{ weblogic_db_repo_prefix }}')
+      union
+      select 1
+      from dba_users
+      where username = upper('{{ weblogic_db_repo_prefix }}_STB')
+    );
     exit
     SQL
   args:

--- a/ansible/roles/nomis-weblogic-12/tasks/main.yml
+++ b/ansible/roles/nomis-weblogic-12/tasks/main.yml
@@ -50,6 +50,7 @@
         - ec2provision
         - weblogic_create_db_repo
         - weblogic_install_domain
+        - prefix_check
 
     - import_tasks: create-db-repo.yml
       tags:

--- a/ansible/roles/nomis-weblogic-12/tasks/set-rcu-prefix.yml
+++ b/ansible/roles/nomis-weblogic-12/tasks/set-rcu-prefix.yml
@@ -79,7 +79,7 @@
           union
           select 1
           from dba_users
-          where username = upper('{{ item }}')
+          where username = upper('{{ item }}_STB')
         );
 
         exit

--- a/ansible/roles/nomis-weblogic-12/tasks/set-rcu-prefix.yml
+++ b/ansible/roles/nomis-weblogic-12/tasks/set-rcu-prefix.yml
@@ -17,92 +17,114 @@
   register: rcu_prefix_marker_contents
   when: rcu_prefix_marker.stat.exists
 
+# display the contents of the marker file for debugging purposes
+- name: Debug existing local RCU prefix marker contents
+  ansible.builtin.debug:
+    msg: "Existing local RCU prefix marker contents: {{ rcu_prefix_marker_contents.content | b64decode | trim }}"
+  when: rcu_prefix_marker.stat.exists
+
 - name: Reuse existing local RCU prefix if present
   ansible.builtin.set_fact:
     weblogic_db_repo_prefix: "{{ rcu_prefix_marker_contents.content | b64decode | trim }}"
   when: rcu_prefix_marker.stat.exists
 
-- name: Derive base RCU prefix from EC2 Name tag
-  ansible.builtin.set_fact:
-    rcu_prefix_base: >-
-      {{
-        (
-          (ec2.tags.Name | lower).split('-')[0] ~
-          'W' ~
-          (ec2.tags.Name | lower).split('-')[-1]
-        )
-        | upper
-        | regex_replace('[^A-Z0-9]', '')
-      }}
+- name: Derive base RCU prefix if not already set
   when: not rcu_prefix_marker.stat.exists
+  block:
+    - name: Derive base RCU prefix from EC2 Name tag
+      ansible.builtin.set_fact:
+        rcu_prefix_base: >-
+          {{
+            (
+              (ec2.tags.Name | lower).split('-')[0] ~
+              'W' ~
+              (ec2.tags.Name | lower).split('-')[-1]
+            )
+            | upper
+            | regex_replace('[^A-Z0-9]', '')
+          }}
 
-- name: Validate base RCU prefix
-  ansible.builtin.assert:
-    that:
-      - rcu_prefix_base is match('^[A-Z][A-Z0-9]{0,11}$')
-    fail_msg: >-
-      Derived RCU prefix base '{{ rcu_prefix_base }}' is invalid.
-      It must start with a letter, contain only A-Z and 0-9, and be 1-12 characters long.
-      Expected EC2 Name tag format like qa11g-nomis-web12-a.
-  when: not rcu_prefix_marker.stat.exists
+    - name: Validate base RCU prefix
+      ansible.builtin.assert:
+        that:
+          - rcu_prefix_base is match('^[A-Z][A-Z0-9]{0,11}$')
+        fail_msg: >-
+          Derived RCU prefix base '{{ rcu_prefix_base }}' is invalid.
+          It must start with a letter, contain only A-Z and 0-9, and be 1-12 characters long.
+          Expected EC2 Name tag format like qa11g-nomis-web12-a.
 
-- name: Build candidate RCU prefixes
-  ansible.builtin.set_fact:
-    rcu_prefix_candidates: >-
-      {%- set candidates = [rcu_prefix_base[:12]] -%}
-      {%- for n in range(1, 100) -%}
-      {%-   set _ = candidates.append((rcu_prefix_base[:10] ~ '%02d'|format(n))[:12]) -%}
-      {%- endfor -%}
-      {{ candidates }}
-  when: not rcu_prefix_marker.stat.exists
+    - name: Build candidate RCU prefixes
+      ansible.builtin.set_fact:
+        rcu_prefix_candidates: >-
+          {%- set candidates = [rcu_prefix_base[:12]] -%}
+          {%- for n in range(10, 1) -%}
+          {%-   set _ = candidates.append((rcu_prefix_base[:10] ~ '%02d'|format(n))[:12]) -%}
+          {%- endfor -%}
+          {{ candidates }}
 
-- name: Check candidate RCU prefixes in database
-  become_user: oracle
-  ansible.builtin.shell: |
-    set -eo pipefail
-    source ~oracle/.bash_profile
+    - name: Check candidate RCU prefixes in database
+      become_user: oracle
+      ansible.builtin.shell: |
+        set -eo pipefail
+        source ~oracle/.bash_profile
 
-    sqlplus -s /nolog <<'SQL'
-    connect sys/{{ weblogic_db_repo_password }}@{{ weblogic_db_repo_hostname }}:1521/{{ weblogic_db_repo_sid }} as sysdba
-    set heading off feedback off verify off echo off pagesize 0 trimspool on
+        sqlplus -s /nolog <<'SQL'
+        connect sys/{{ weblogic_db_repo_password }}@{{ weblogic_db_repo_hostname }}:1521/{{ weblogic_db_repo_sid }} as sysdba
+        set heading off feedback off verify off echo off pagesize 0 trimspool on
 
-    select count(*)
-    from schema_version_registry
-    where mrc_name = upper('{{ item }}');
+        select count(*) from (
+          select 1
+          from schema_version_registry
+          where mrc_name = upper('{{ item }}')
+          union
+          select 1
+          from dba_users
+          where username = upper('{{ item }}')
+        );
 
-    exit
-    SQL
-  args:
-    executable: /bin/bash
-  loop: "{{ rcu_prefix_candidates }}"
-  register: rcu_prefix_candidate_checks
-  changed_when: false
-  no_log: true
-  when: not rcu_prefix_marker.stat.exists
+        exit
+        SQL
+      args:
+        executable: /bin/bash
+      loop: "{{ rcu_prefix_candidates }}"
+      register: rcu_prefix_candidate_checks
+      changed_when: false
+      no_log: true
 
-- name: Select first unused RCU prefix
-  ansible.builtin.set_fact:
-    weblogic_db_repo_prefix: "{{ item.item }}"
-  loop: "{{ rcu_prefix_candidate_checks.results }}"
-  when:
-    - not rcu_prefix_marker.stat.exists
-    - weblogic_db_repo_prefix is not defined
-    - item.stdout | trim == "0"
+    - name: Select first unused RCU prefix
+      ansible.builtin.set_fact:
+        new_weblogic_db_repo_prefix: "{{ item.item }}"
+      loop: "{{ rcu_prefix_candidate_checks.results }}"
+      when:
+        - item.stdout | trim == "0"
 
-- name: Fail if no unused RCU prefix was found
-  ansible.builtin.fail:
-    msg: >-
-      Could not find an unused RCU prefix from candidates derived from '{{ rcu_prefix_base }}'.
-      Tried: {{ rcu_prefix_candidates | join(', ') }}
-  when:
-    - not rcu_prefix_marker.stat.exists
-    - weblogic_db_repo_prefix is not defined
+    # Display the selected RCU prefix for debugging purposes
+    - name: Debug selected RCU prefix
+      ansible.builtin.debug:
+        msg: "Selected RCU prefix: {{ new_weblogic_db_repo_prefix }}"
+
+    - name: Fail if no unused RCU prefix was found
+      ansible.builtin.fail:
+        msg: >-
+          Could not find an unused RCU prefix from candidates derived from '{{ rcu_prefix_base }}'.
+          Tried: {{ rcu_prefix_candidates | join(', ') }}
+      when:
+        - new_weblogic_db_repo_prefix is not defined
+
+    - name: Set new RCU prefix
+      ansible.builtin.set_fact:
+        weblogic_db_repo_prefix: "{{ new_weblogic_db_repo_prefix }}"
 
 - name: Final validation of selected RCU prefix
   ansible.builtin.assert:
     that:
       - weblogic_db_repo_prefix is match('^[A-Z][A-Z0-9]{0,11}$')
     fail_msg: "Selected RCU prefix '{{ weblogic_db_repo_prefix }}' is invalid."
+
+# Display the final RCU prefix for debugging purposes
+- name: Debug the final RCU prefix
+  ansible.builtin.debug:
+    msg: "Selected RCU prefix: {{ weblogic_db_repo_prefix }}"
 
 - name: Persist local RCU prefix marker
   ansible.builtin.copy:


### PR DESCRIPTION
This pull request introduces several improvements and debugging enhancements to the WebLogic RCU prefix management in the Ansible configuration for the `nomis-weblogic-12` role. The main focus is on making the RCU prefix selection process more robust and transparent, as well as adding support for the `qa` environment. The changes include additional debug output, improved candidate prefix generation, and a minor update to the Ansible task sequence.

**Enhancements to RCU prefix management and debugging:**

* Added multiple debug steps to display the contents of the RCU prefix marker, the selected candidate prefix, and the final RCU prefix to aid troubleshooting and increase transparency during playbook runs. [[1]](diffhunk://#diff-6df3e9d2fbaf0a8d355b4450b4d3f74ac78d136be5cd9d5e2b8d56ff943488fcR20-R33) [[2]](diffhunk://#diff-6df3e9d2fbaf0a8d355b4450b4d3f74ac78d136be5cd9d5e2b8d56ff943488fcL81-R128)
* Refactored the logic for deriving and selecting the RCU prefix: replaced inline `when` conditions with block scoping, improved candidate generation by adjusting the candidate range, and ensured proper assignment of the selected prefix. [[1]](diffhunk://#diff-6df3e9d2fbaf0a8d355b4450b4d3f74ac78d136be5cd9d5e2b8d56ff943488fcL37) [[2]](diffhunk://#diff-6df3e9d2fbaf0a8d355b4450b4d3f74ac78d136be5cd9d5e2b8d56ff943488fcL47-L57) [[3]](diffhunk://#diff-6df3e9d2fbaf0a8d355b4450b4d3f74ac78d136be5cd9d5e2b8d56ff943488fcL81-R128)
* Expanded the database check to ensure candidate prefixes are unused by checking both `schema_version_registry` and `dba_users` tables for greater reliability.

**Configuration and workflow updates:**

* Added a new `qa` environment configuration to `weblogic_configs` in `server_type_nomis_web12.yml`.
* Inserted the `prefix_check` tag into the main task sequence for the `nomis-weblogic-12` role, enabling targeted execution of RCU prefix-related tasks.