### PR TITLE
Re-evaluate monitoring connectivity before unsuppressing incidents

### DIFF
--- a/ansible/roles/oracle-oem-blackout/tasks/script_exclusion.yml
+++ b/ansible/roles/oracle-oem-blackout/tasks/script_exclusion.yml
@@ -107,7 +107,7 @@
 - name: Declare Named Database Metrics Lists
   set_fact:
     dataguard_named_database_metrics: ["dataguard_11gR2", "fsfo_observers"]
-    named_database_metrics: []
+    named_database_metrics: ["monitoring_connectivity_issue"]
 
 - name: Show HAC
   debug:


### PR DESCRIPTION
This pull request makes a small update to the `ansible/roles/oracle-oem-blackout/tasks/script_exclusion.yml` file. The change initializes the `named_database_metrics` variable with a default value of `["monitoring_connectivity_issue"]` instead of an empty list.  This forces the Oracle agent to re-evaluate database connectivity before we unsupress any incidents raised during the monitoring blackout.

([ansible/roles/oracle-oem-blackout/tasks/script_exclusion.ymlL110-R110](diffhunk://#diff-8cf950d185e632e2ddf735d479004e8635a40cc4d064ad002928f37c4eed36ceL110-R110))