### PR TITLE
Log SSL Certificate Failures when writing DDL changes

### DIFF
--- a/ansible/roles/oracle-db-ddl-notifier/templates/create_slack_notification_package_body.sql.j2
+++ b/ansible/roles/oracle-db-ddl-notifier/templates/create_slack_notification_package_body.sql.j2
@@ -9,6 +9,8 @@ CREATE OR REPLACE PACKAGE BODY {{ notification_schema }}.slack_notifier AS
     l_http_resp  UTL_HTTP.resp;
     l_payload    VARCHAR2(32767);
     l_response   VARCHAR2(32767);
+    e_http_failed EXCEPTION;
+    PRAGMA EXCEPTION_INIT(e_http_failed, -29273);
   BEGIN
     l_payload := '{"channel":"' || gc_channel || '",'||
                   '"username":"'|| gc_application ||' DDL Notifier",' ||
@@ -36,6 +38,13 @@ CREATE OR REPLACE PACKAGE BODY {{ notification_schema }}.slack_notifier AS
         NULL;
     END;
     UTL_HTTP.end_response(l_http_resp);
+    EXCEPTION
+        WHEN e_http_failed THEN
+            SYS.DBMS_SYSTEM.KSDWRT(
+                2,
+                SQLERRM || ' from {{ notification_schema }}.SLACK_NOTIFIER'
+            );
+            RAISE;
   END send_message;
 
 END slack_notifier;

--- a/ansible/roles/oracle-db-ddl-notifier/templates/create_slack_notification_package_spec.sql.j2
+++ b/ansible/roles/oracle-db-ddl-notifier/templates/create_slack_notification_package_spec.sql.j2
@@ -12,3 +12,8 @@ CREATE OR REPLACE PACKAGE {{ notification_schema }}.slack_notifier AS
   gc_account_name          VARCHAR2(1000)  := '{{ account_name }}';
 END slack_notifier;
 /
+
+-- DBMS_SYSTEM is used to allow SSL Certificate failures to
+-- be logged to avoid silent failures where Slack notifications are not sent
+GRANT EXECUTE ON DBMS_SYSTEM TO {{ notification_schema }};
+


### PR DESCRIPTION
This pull request improves error handling and observability for Slack notification failures in the Oracle DDL notifier package. The main enhancement is that SSL certificate errors (and other HTTP failures) during Slack notifications are now explicitly logged, which helps diagnose issues where notifications might silently fail.

Error handling and logging improvements:

* Added a custom exception `e_http_failed` for HTTP failures (specifically Oracle error -29273) in the `slack_notifier` package body.
* Enhanced the `send_message` procedure to catch `e_http_failed`, log the error using `SYS.DBMS_SYSTEM.KSDWRT`, and re-raise the exception to ensure failures are not silent.

Database privileges and documentation:

* Granted `EXECUTE` privilege on `DBMS_SYSTEM` to the notification schema to allow error logging, and added a comment explaining the purpose of this change.